### PR TITLE
Disable real data checks

### DIFF
--- a/larpandora/LArPandoraAnalysis/PFParticleMonitoring_module.cc
+++ b/larpandora/LArPandoraAnalysis/PFParticleMonitoring_module.cc
@@ -548,23 +548,20 @@ void PFParticleMonitoring::analyze(const art::Event &evt)
     MCParticlesToHits trueParticlesToHits;
     HitsToMCParticles trueHitsToParticles;
 
-    if (!evt.isRealData())
+    LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, trueParticleVector);
+    LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, truthToParticles, particlesToTruth);
+
+    LArPandoraHelper::BuildMCParticleHitMaps(evt, m_geantModuleLabel, hitVector, trueParticlesToHits, trueHitsToParticles,
+        (m_useDaughterMCParticles ? (m_addDaughterMCParticles ? LArPandoraHelper::kAddDaughters : LArPandoraHelper::kUseDaughters) : LArPandoraHelper::kIgnoreDaughters));
+
+    if (trueHitsToParticles.empty())
     {
-        LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, trueParticleVector);
-        LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, truthToParticles, particlesToTruth);
+        if (m_backtrackerLabel.empty())
+            throw cet::exception("LArPandora") << " PFParticleMonitoring::analyze - no sim channels found, backtracker module must be set in FHiCL " << std::endl;
 
-        LArPandoraHelper::BuildMCParticleHitMaps(evt, m_geantModuleLabel, hitVector, trueParticlesToHits, trueHitsToParticles,
+        LArPandoraHelper::BuildMCParticleHitMaps(evt, m_geantModuleLabel, m_hitfinderLabel, m_backtrackerLabel,
+            trueParticlesToHits, trueHitsToParticles,
             (m_useDaughterMCParticles ? (m_addDaughterMCParticles ? LArPandoraHelper::kAddDaughters : LArPandoraHelper::kUseDaughters) : LArPandoraHelper::kIgnoreDaughters));
-
-        if (trueHitsToParticles.empty())
-        {
-            if (m_backtrackerLabel.empty())
-                throw cet::exception("LArPandora") << " PFParticleMonitoring::analyze - no sim channels found, backtracker module must be set in FHiCL " << std::endl;
-
-            LArPandoraHelper::BuildMCParticleHitMaps(evt, m_geantModuleLabel, m_hitfinderLabel, m_backtrackerLabel,
-                trueParticlesToHits, trueHitsToParticles,
-                (m_useDaughterMCParticles ? (m_addDaughterMCParticles ? LArPandoraHelper::kAddDaughters : LArPandoraHelper::kUseDaughters) : LArPandoraHelper::kIgnoreDaughters));
-        }
     }
 
     if (m_printDebug)

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -193,7 +193,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
     LArPandoraHelper::CollectHits(evt, m_hitfinderModuleLabel, artHits);
 
-    if (m_enableMCParticles && !evt.isRealData())
+    if (m_enableMCParticles)
     {
         LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, artMCParticleVector);
 
@@ -223,7 +223,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
     LArPandoraInput::CreatePandoraHits2D(m_inputSettings, m_driftVolumeMap, artHits, idToHitMap);
 
-    if (m_enableMCParticles && !evt.isRealData())
+    if (m_enableMCParticles)
     {
         LArPandoraInput::CreatePandoraMCParticles(m_inputSettings, artMCTruthToMCParticles, artMCParticlesToMCTruth, generatorArtMCParticleVector);
         LArPandoraInput::CreatePandoraMCLinks2D(m_inputSettings, idToHitMap, artHitsToTrackIDEs);

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -63,6 +63,7 @@ LArPandora::LArPandora(fhicl::ParameterSet const &pset) :
     m_enableProduction(pset.get<bool>("EnableProduction", true)),
     m_enableDetectorGaps(pset.get<bool>("EnableLineGaps", true)),
     m_enableMCParticles(pset.get<bool>("EnableMCParticles", false)),
+    m_disableRealDataCheck(pset.get<bool>("DisableRealDataCheck", false)),
     m_lineGapsCreated(false)
 {
     m_inputSettings.m_useHitWidths = pset.get<bool>("UseHitWidths", true);
@@ -193,7 +194,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
     LArPandoraHelper::CollectHits(evt, m_hitfinderModuleLabel, artHits);
 
-    if (m_enableMCParticles)
+    if (m_enableMCParticles && (m_disableRealDataCheck || !evt.IsRealData()))
     {
         LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, artMCParticleVector);
 
@@ -223,7 +224,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
     LArPandoraInput::CreatePandoraHits2D(m_inputSettings, m_driftVolumeMap, artHits, idToHitMap);
 
-    if (m_enableMCParticles)
+    if (m_enableMCParticles && (m_disableRealDataCheck || !evt.IsRealData()))
     {
         LArPandoraInput::CreatePandoraMCParticles(m_inputSettings, artMCTruthToMCParticles, artMCParticlesToMCTruth, generatorArtMCParticleVector);
         LArPandoraInput::CreatePandoraMCLinks2D(m_inputSettings, idToHitMap, artHitsToTrackIDEs);

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -194,7 +194,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
     LArPandoraHelper::CollectHits(evt, m_hitfinderModuleLabel, artHits);
 
-    if (m_enableMCParticles && (m_disableRealDataCheck || !evt.IsRealData()))
+    if (m_enableMCParticles && (m_disableRealDataCheck || !evt.isRealData()))
     {
         LArPandoraHelper::CollectMCParticles(evt, m_geantModuleLabel, artMCParticleVector);
 
@@ -224,7 +224,7 @@ void LArPandora::CreatePandoraInput(art::Event &evt, IdToHitMap &idToHitMap)
 
     LArPandoraInput::CreatePandoraHits2D(m_inputSettings, m_driftVolumeMap, artHits, idToHitMap);
 
-    if (m_enableMCParticles && (m_disableRealDataCheck || !evt.IsRealData()))
+    if (m_enableMCParticles && (m_disableRealDataCheck || !evt.isRealData()))
     {
         LArPandoraInput::CreatePandoraMCParticles(m_inputSettings, artMCTruthToMCParticles, artMCParticlesToMCTruth, generatorArtMCParticleVector);
         LArPandoraInput::CreatePandoraMCLinks2D(m_inputSettings, idToHitMap, artHitsToTrackIDEs);

--- a/larpandora/LArPandoraInterface/LArPandora.h
+++ b/larpandora/LArPandoraInterface/LArPandora.h
@@ -62,6 +62,7 @@ protected:
     bool                            m_enableProduction;             ///< Whether to persist output products
     bool                            m_enableDetectorGaps;           ///< Whether to pass detector gap information to Pandora instances
     bool                            m_enableMCParticles;            ///< Whether to pass mc information to Pandora instances to aid development
+    bool                            m_disableRealDataCheck;         ///< Whether to check if the input file contains real data before accessing MC information
     bool                            m_lineGapsCreated;              ///< Book-keeping: whether line gap creation has been called
 
     LArPandoraInput::Settings       m_inputSettings;                ///< The lar pandora input settings

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -737,9 +737,6 @@ void LArPandoraHelper::CollectT0s(const art::Event &evt, const std::string &labe
 
 void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::string &label, SimChannelVector &simChannelVector, bool &areSimChannelsValid)
 {
-    if (evt.isRealData())
-        throw cet::exception("LArPandora") << " PandoraCollector::CollectSimChannels --- Trying to access MC truth from real data ";
-
     art::Handle< std::vector<sim::SimChannel> > theSimChannels;
     evt.getByLabel(label, theSimChannels);
 
@@ -766,9 +763,6 @@ void LArPandoraHelper::CollectSimChannels(const art::Event &evt, const std::stri
 
 void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::string &label, MCParticleVector &particleVector)
 {
-    if (evt.isRealData())
-        throw cet::exception("LArPandora") << " PandoraCollector::CollectMCParticles --- Trying to access MC truth from real data ";
-
     art::Handle< RawMCParticleVector > theParticles;
     evt.getByLabel(label, theParticles);
 
@@ -793,9 +787,6 @@ void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::stri
 
 void LArPandoraHelper::CollectGeneratorMCParticles(const art::Event &evt, const std::string &label, RawMCParticleVector &particleVector)
 {
-    if (evt.isRealData())
-        throw cet::exception("LArPandora") << " PandoraCollector::CollectGeneratorMCParticles --- Trying to access MC truth from real data ";
-
     art::Handle< std::vector<simb::MCTruth> > mcTruthBlocks;
     evt.getByLabel(label, mcTruthBlocks);
 
@@ -826,9 +817,6 @@ void LArPandoraHelper::CollectGeneratorMCParticles(const art::Event &evt, const 
 void LArPandoraHelper::CollectMCParticles(const art::Event &evt, const std::string &label, MCTruthToMCParticles &truthToParticles,
     MCParticlesToMCTruth &particlesToTruth)
 {
-    if (evt.isRealData())
-        throw cet::exception("LArPandora") << " PandoraCollector::CollectMCParticles --- Trying to access MC truth from real data ";
-
     art::Handle< RawMCParticleVector > theParticles;
     evt.getByLabel(label, theParticles);
 


### PR DESCRIPTION
Redux of previous pull request.

I removed `art::Event::isRealData()` checks from `LArPandoraHelper` and added FHiCL flags to `LArPandora` and `PFParticleMonitoring` which allow the user to optionally disable the checks.