### PR TITLE
Feature/protodune dual phase volumes

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -277,18 +277,6 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
             UIntSet tpcList;
             tpcList.insert(itpc1);
 
-            if (isDualPhase)
-            {
-                LArDaughterDriftVolumeList tpcVolumeList;
-                tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc1));
-
-                driftVolumeList.emplace_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
-                    wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
-                    0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
-                    (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
-                    (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
-            }
-
             // Now identify the other TPCs associated with this drift volume
             for (unsigned int itpc2 = itpc1+1; itpc2 < theGeometry->NTPC(icstat); ++itpc2)
             {
@@ -338,18 +326,6 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
                 driftMinZ = std::min(driftMinZ, driftMinZ2);
                 driftMaxZ = std::max(driftMaxZ, driftMaxZ2);
 
-                if (isDualPhase)
-                {
-                    LArDaughterDriftVolumeList tpcVolumeList;
-                    tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc2));
-
-                    driftVolumeList.emplace_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
-                        wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
-                        0.5f * (driftMaxX2 + driftMinX2), 0.5f * (driftMaxY2 + driftMinY2), 0.5f * (driftMaxZ2 + driftMinZ2),
-                        (driftMaxX2 - driftMinX2), (driftMaxY2 - driftMinY2), (driftMaxZ2 - driftMinZ2),
-                        (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
-                }
-
             }
 
             // Collate the tpc volumes in this drift volume
@@ -361,12 +337,11 @@ void LArPandoraGeometry::LoadGeometry(LArDriftVolumeList &driftVolumeList)
             }
 
             // Create new daughter drift volume (volume ID = 0 to N-1)
-            if (!isDualPhase)
-                driftVolumeList.emplace_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
-                    wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
-                    0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
-                    (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
-                    (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
+            driftVolumeList.emplace_back(LArDriftVolume(driftVolumeList.size(), isPositiveDrift,
+                wirePitchU, wirePitchV, wirePitchW, wireAngleU, wireAngleV, wireAngleW,
+                0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
+                (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ),
+                (wirePitchU + wirePitchV + wirePitchW + 0.1f), tpcVolumeList));
         }
     }
 

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.h
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.h
@@ -75,7 +75,6 @@ private:
     float   m_x2;
     float   m_y2;
     float   m_z2;
-    //float   m_maxGapSize; // unused - note that GetMaxGapSize returns a hard coded number
 };
 
 typedef std::vector<LArDetectorGap> LArDetectorGapList;


### PR DESCRIPTION
Following last week’s larpandora feature, a change in strategy was decided, and so some elements from last week’s release have been deliberately reverted. Specifically, the decision to divide up the dual phase detector into specific volumes, with a stitching process to connect crossing particles, has been reverted. Instead, the reconstruction proceeds in a single volume. (The stitching procedure would have worked, but not on timescale required for current planned ProtoDUNE-DP production.) Thanks!