### PR TITLE
Feature/sce v9

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
@@ -20,6 +20,8 @@
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/ShowerElementHolder.hh"
 #include "lardataalg/DetectorInfo/DetectorClocksData.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
+#include "larevt/SpaceCharge/SpaceCharge.h"
+#include "larevt/SpaceChargeServices/SpaceChargeService.h"
 
 //C++ Includes
 #include <iostream>
@@ -98,6 +100,13 @@ class shower::LArPandoraShowerAlg {
     double SpacePointPerpendicular(art::Ptr<recob::SpacePoint> const& sp, TVector3 const& vertex,
         TVector3 const& direction, double proj) const;
 
+  // The SCE service requires thing in geo::Point/Vector form, so overload and be nice
+    double SCECorrectPitch(double const& pitch, TVector3 const& pos, TVector3 const& dir, unsigned int const& TPC) const;
+    double SCECorrectPitch(double const& pitch, geo::Point_t const& pos, geo::Vector_t const& dir, unsigned int const& TPC) const;
+
+    double SCECorrectEField(double const& EField, TVector3 const& pos) const;
+    double SCECorrectEField(double const& EField, geo::Point_t const& pos) const;
+
     void DebugEVD(art::Ptr<recob::PFParticle> const& pfparticle,
         art::Event const& Event,
         const reco::shower::ShowerElementHolder& ShowerEleHolder,
@@ -105,8 +114,11 @@ class shower::LArPandoraShowerAlg {
 
   private:
 
-    bool fUseCollectionOnly;
-    art::InputTag                           fPFParticleLabel;
+    bool          fUseCollectionOnly;
+    art::InputTag fPFParticleLabel;
+    bool          fSCEXFlip; // If a (legacy) flip is needed in x componant of spatial SCE correction
+
+    spacecharge::SpaceCharge const*         fSCE;
     art::ServiceHandle<geo::Geometry const> fGeom;
     art::ServiceHandle<art::TFileService>   tfs;
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/pandorashoweralgs.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/pandorashoweralgs.fcl
@@ -3,6 +3,7 @@ standard_larpandorashoweralg:
 {
   UseCollectionOnly: false #Only use the collection charge infromation.
   # PFParticleLabel: "pandora"
+  SCEXFlip:          false
   InitialTrackInputLabel: "InitialTrack"
   ShowerStartPositionInputLabel: "ShowerStartPosition"
   ShowerDirectionInputLabel: "ShowerDirection"

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -281,6 +281,10 @@ showertrajpointdedx:{
     dEdxCut:               999.
     CutStartPosition:     false #Remove hits using MinDistCutOff from the vertex as well
     UseMedian:            true  #Use the median dEdx rather the mean.
+    T0Correct:            false
+    SCECorrectPitch:      false
+    SCECorrectEField:     false
+    SCEInputCorrected:    false
     # PFParticleLabel: "pandora"
     ShowerStartPositionInputLabel: "ShowerStartPosition"
     InitialTrackSpacePointsInputLabel: "InitialTrackSpacePoints"


### PR DESCRIPTION
PR to include Space Charge Effect (SCE) corrections into the TrajPoint dEdx tool (although most of the work is done in the alg for extensibility). This requires [larreco pr](https://github.com/LArSoft/larreco/pull/18) (and associated PRs) and the input should already have spatial corrections applied by the SCECorrections module in that PR. 

Specifically the corrections are:
 - Correct for the "squeezing" from SCE in the dx
- Use the local electric field when calculating the recombination in conversion from dQ/dx -> dE/dx

Default behaviour is unchanged and experiments must choose to enable the corrections via fcl if they wish to use them. 