### PR TITLE
Protect against exception when looking for non-existent T0 association

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/ShowerElementHolder.hh
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/ShowerElementHolder.hh
@@ -604,7 +604,7 @@ class reco::shower::ShowerElementHolder{
       const art::FindManyP<T1>& GetFindManyP(const art::ValidHandle<std::vector<T2> >& handle,
           const art::Event &evt, const art::InputTag &moduleTag){
 
-        const std::string name("FMP" + moduleTag.label() + getType<T1>() + getType<T2>());
+        const std::string name("FMP_" + moduleTag.label() + "_" + getType<T1>() + "_" + getType<T2>());
 
         if (CheckEventElement(name)){
           return GetEventElement<art::FindManyP<T1> >(name);
@@ -614,7 +614,7 @@ class reco::shower::ShowerElementHolder{
             SetEventElement(findManyP, name);
             return GetEventElement<art::FindManyP<T1> >(name);
           } else {
-            throw cet::exception("ShowerElementHolder") << "FindManyP is not valid" << std::endl;
+            throw cet::exception("ShowerElementHolder") << "FindManyP is not valid: " << name << std::endl;
           }
         }
       }
@@ -623,7 +623,7 @@ class reco::shower::ShowerElementHolder{
       const art::FindOneP<T1>& GetFindOneP(const art::ValidHandle<std::vector<T2> >& handle,
           const art::Event& evt, const art::InputTag& moduleTag){
 
-        const std::string name("FOP" + moduleTag.label() + getType<T1>() + getType<T2>());
+        const std::string name("FOP_" + moduleTag.label() + "_" + getType<T1>() + "_" + getType<T2>());
 
         if (CheckEventElement(name)){
           return GetEventElement<art::FindOneP<T1> >(name);
@@ -633,7 +633,7 @@ class reco::shower::ShowerElementHolder{
             SetEventElement(findOneP, name);
             return GetEventElement<art::FindOneP<T1> >(name);
           } else {
-            throw cet::exception("ShowerElementHolder") << "FindOneP is not valid" << std::endl;
+            throw cet::exception("ShowerElementHolder") << "FindOneP is not valid: " << name << std::endl;
           }
         }
       }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -136,9 +136,6 @@ namespace ShowerRecoTools{
       return 0;
     }
 
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
-    const art::FindManyP<anab::T0>& fmpfpt0 = ShowerEleHolder.GetFindManyP<anab::T0>(
-        pfpHandle, Event, fPFParticleLabel);
 
     // Get the spacepoints
     auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
@@ -158,6 +155,9 @@ namespace ShowerRecoTools{
 
     double pfpT0Time(0); // If no T0 found, assume the particle happened at trigger time (0)
     if (fT0Correct){
+      auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+      const art::FindManyP<anab::T0>& fmpfpt0 = ShowerEleHolder.GetFindManyP<anab::T0>(
+          pfpHandle, Event, fPFParticleLabel);
       std::vector<art::Ptr<anab::T0> > pfpT0Vec = fmpfpt0.at(pfparticle.key());
       if (pfpT0Vec.size()==1) {
         pfpT0Time = pfpT0Vec.front()->Time();


### PR DESCRIPTION
Only looks for PFP -> T0 association if it will actually be used. This avoids exceptions when Pandora is run in certain modes that do not produce this association. No changes are expected to the outputs.

I also took the opportunity to make the exception more descriptive for future debugging.