### PR TITLE
larpandora branch Feature/larpandoracontent v03 22 04

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -92,16 +92,14 @@ namespace lar_pandora {
         for (LArDaughterDriftVolumeList::const_iterator iterDghtr1 = driftVolume1.GetTpcVolumeList().begin(),
              iterDghtrEnd1 = driftVolume1.GetTpcVolumeList().end();
              iterDghtr1 != iterDghtrEnd1; 
-             ++iterDghtr1)
-        {
-            const LArDaughterDriftVolume &tpcVolume1(*iterDghtr1);
+             ++iterDghtr1) {
+          const LArDaughterDriftVolume &tpcVolume1(*iterDghtr1);
 
           for (LArDaughterDriftVolumeList::const_iterator iterDghtr2 = iterDghtr1,
                iterDghtrEnd2 = driftVolume1.GetTpcVolumeList().end();
                iterDghtr2 != iterDghtrEnd2;
-               ++iterDghtr2)
-          {
-              const LArDaughterDriftVolume &tpcVolume2(*iterDghtr2);
+               ++iterDghtr2) {
+            const LArDaughterDriftVolume &tpcVolume2(*iterDghtr2);
 
             if (tpcVolume1.GetTpc() == tpcVolume2.GetTpc())
               continue;
@@ -197,14 +195,13 @@ namespace lar_pandora {
 
     for (LArDaughterDriftVolumeList::const_iterator iterDghtr = iter->second.GetTpcVolumeList().begin(),
          iterDghtrEnd = iter->second.GetTpcVolumeList().end(); 
-         iterDghtr != iterDghtrEnd; ++iterDghtr)
-    {
-        const LArDaughterDriftVolume &daughterVolume(*iterDghtr);
+         iterDghtr != iterDghtrEnd; ++iterDghtr) {
+      const LArDaughterDriftVolume &daughterVolume(*iterDghtr);
       if (cstat == daughterVolume.GetCryostat() && tpc == daughterVolume.GetTpc())
         return std::distance(iter->second.GetTpcVolumeList().begin(), iterDghtr);
     }
     throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- found a daughter volume that doesn't belong to the drift volume ";
-    }
+  }
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -375,9 +372,13 @@ namespace lar_pandora {
         tpcList.insert(itpc1);
 
         LArDaughterDriftVolumeList tpcVolumeList;
-        tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc1, 
-                                                          0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
-                                                          (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ)));
+        tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc1,
+                                                          0.5f * (driftMaxX + driftMinX),
+                                                          0.5f * (driftMaxY + driftMinY),
+                                                          0.5f * (driftMaxZ + driftMinZ),
+                                                          (driftMaxX - driftMinX),
+                                                          (driftMaxY - driftMinY),
+                                                          (driftMaxZ - driftMinZ)));
 
         // Now identify the other TPCs associated with this drift volume
         for (unsigned int itpc2 = itpc1 + 1; itpc2 < theGeometry->NTPC(icstat); ++itpc2) {
@@ -432,8 +433,12 @@ namespace lar_pandora {
           driftMaxZ = std::max(driftMaxZ, driftMaxZ2);
 
           tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc2, 
-                                                            0.5f * (driftMaxX2 + driftMinX2), 0.5f * (driftMaxY2 + driftMinY2), 0.5f * (driftMaxZ2 + driftMinZ2),
-                                                            (driftMaxX2 - driftMinX2), (driftMaxY2 - driftMinY2), (driftMaxZ2 - driftMinZ2)));
+                                                            0.5f * (driftMaxX2 + driftMinX2),
+                                                            0.5f * (driftMaxY2 + driftMinY2),
+                                                            0.5f * (driftMaxZ2 + driftMinZ2),
+                                                            (driftMaxX2 - driftMinX2),
+                                                            (driftMaxY2 - driftMinY2),
+                                                            (driftMaxZ2 - driftMinZ2)));
         }
 
         // Create new daughter drift volume (volume ID = 0 to N-1)

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -87,6 +87,54 @@ namespace lar_pandora {
         else if (!isDualPhase)
           listOfGaps.emplace_back(LArDetectorGap(X1, Y1, Z1, X2, Y2, Z2));
       }
+      if (isDualPhase)
+      {
+        for (LArDaughterDriftVolumeList::const_iterator iterDghtr1 = driftVolume1.GetTpcVolumeList().begin(),
+                 iterDghtrEnd1 = driftVolume1.GetTpcVolumeList().end();
+             iterDghtr1 != iterDghtrEnd1; 
+             ++iterDghtr1)
+        {
+          const LArDaughterDriftVolume &tpcVolume1 = *iterDghtr1;
+
+          for (LArDaughterDriftVolumeList::const_iterator iterDghtr2 = iterDghtr1,
+                   iterDghtrEnd2 = driftVolume1.GetTpcVolumeList().end();
+               iterDghtr2 != iterDghtrEnd2;
+               ++iterDghtr2)
+          {
+            const LArDaughterDriftVolume &tpcVolume2 = *iterDghtr2;
+
+            if (tpcVolume1.GetTpc() == tpcVolume2.GetTpc())
+              continue;
+
+            const float maxDisplacement(LArDetectorGap::GetMaxGapSize());
+
+            const float deltaY(std::fabs(tpcVolume1.GetCenterY() - tpcVolume2.GetCenterY()));
+            const float deltaZ(std::fabs(tpcVolume1.GetCenterZ() - tpcVolume2.GetCenterZ()));
+
+            const float widthY(0.5f * (tpcVolume1.GetWidthY() + tpcVolume2.GetWidthY()));
+            const float widthZ(0.5f * (tpcVolume1.GetWidthZ() + tpcVolume2.GetWidthZ()));
+
+            const float gapY(deltaY - widthY);
+            const float gapZ(deltaZ - widthZ);
+
+            const float X1((tpcVolume1.GetCenterX() < tpcVolume2.GetCenterX()) ? (tpcVolume1.GetCenterX() + 0.5f * tpcVolume1.GetWidthX()) :
+                           (tpcVolume2.GetCenterX() + 0.5f * tpcVolume2.GetWidthX()));
+            const float X2((tpcVolume1.GetCenterX() > tpcVolume2.GetCenterX()) ? (tpcVolume1.GetCenterX() - 0.5f * tpcVolume1.GetWidthX()) :
+                           (tpcVolume2.GetCenterX() - 0.5f * tpcVolume2.GetWidthX()));
+            const float Y1(std::min((tpcVolume1.GetCenterY() - 0.5f * tpcVolume1.GetWidthY()),
+                                    (tpcVolume2.GetCenterY() - 0.5f * tpcVolume2.GetWidthY())));
+            const float Y2(std::max((tpcVolume1.GetCenterY() + 0.5f * tpcVolume1.GetWidthY()),
+                                    (tpcVolume2.GetCenterY() + 0.5f * tpcVolume2.GetWidthY())));
+            const float Z1(std::min((tpcVolume1.GetCenterZ() - 0.5f * tpcVolume1.GetWidthZ()),
+                                    (tpcVolume2.GetCenterZ() - 0.5f * tpcVolume2.GetWidthZ())));
+            const float Z2(std::max((tpcVolume1.GetCenterZ() + 0.5f * tpcVolume1.GetWidthZ()),
+                                    (tpcVolume2.GetCenterZ() + 0.5f * tpcVolume2.GetWidthZ())));
+
+            if (std::fabs(gapY) > maxDisplacement || std::fabs(gapZ) > maxDisplacement)
+              listOfGaps.emplace_back(LArDetectorGap(X1, Y1 + widthY, Z1 + widthZ, X2, Y2 - widthY, Z2 - widthZ));
+          }
+        }
+      }
     }
   }
 
@@ -134,6 +182,32 @@ namespace lar_pandora {
 
     return iter->second.GetVolumeID();
   }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  unsigned int 
+  LArPandoraGeometry::GetDaughterVolumeID(const LArDriftVolumeMap &driftVolumeMap, 
+                                          const unsigned int cstat, 
+                                          const unsigned int tpc)
+  {
+    if (driftVolumeMap.empty())
+      throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- detector geometry map is empty";
+
+    LArDriftVolumeMap::const_iterator iter = driftVolumeMap.find(LArPandoraGeometry::GetTpcID(cstat, tpc));
+
+    if (driftVolumeMap.end() == iter)
+      throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- found a TPC volume that doesn't belong to a drift volume";
+
+    for (LArDaughterDriftVolumeList::const_iterator iterDghtr = iter->second.GetTpcVolumeList().begin(),
+         iterDghtrEnd = iter->second.GetTpcVolumeList().end(); 
+         iterDghtr != iterDghtrEnd; ++iterDghtr)
+    {
+      const LArDaughterDriftVolume &daughterVolume = *iterDghtr;
+      if (cstat == daughterVolume.GetCryostat() && tpc == daughterVolume.GetTpc())
+        return std::distance(iter->second.GetTpcVolumeList().begin(), iterDghtr);
+    }
+    throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- found a daughter volume that doesn't belong to the drift volume ";
+    }
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -306,6 +380,15 @@ namespace lar_pandora {
         UIntSet tpcList;
         tpcList.insert(itpc1);
 
+        LArDaughterDriftVolumeList tpcVolumeList;
+        tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc1,
+                                                          0.5f * (driftMaxX + driftMinX),
+                                                          0.5f * (driftMaxY + driftMinY),
+                                                          0.5f * (driftMaxZ + driftMinZ),
+                                                          (driftMaxX - driftMinX),
+                                                          (driftMaxY - driftMinY),
+                                                          (driftMaxZ - driftMinZ)));
+
         // Now identify the other TPCs associated with this drift volume
         for (unsigned int itpc2 = itpc1 + 1; itpc2 < theGeometry->NTPC(icstat); ++itpc2) {
           if (cstatList.end() != cstatList.find(itpc2)) continue;
@@ -357,13 +440,14 @@ namespace lar_pandora {
           driftMaxY = std::max(driftMaxY, driftMaxY2);
           driftMinZ = std::min(driftMinZ, driftMinZ2);
           driftMaxZ = std::max(driftMaxZ, driftMaxZ2);
-        }
 
-        // Collate the tpc volumes in this drift volume
-        LArDaughterDriftVolumeList tpcVolumeList;
-
-        for (const unsigned int itpc : tpcList) {
-          tpcVolumeList.emplace_back(icstat, itpc);
+          tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc2,
+                                                            0.5f * (driftMaxX2 + driftMinX2),
+                                                            0.5f * (driftMaxY2 + driftMinY2),
+                                                            0.5f * (driftMaxZ2 + driftMinZ2),
+                                                            (driftMaxX2 - driftMinX2),
+                                                            (driftMaxY2 - driftMinY2),
+                                                            (driftMaxZ2 - driftMinZ2)));
         }
 
         // Create new daughter drift volume (volume ID = 0 to N-1)

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -90,18 +90,18 @@ namespace lar_pandora {
       if (isDualPhase)
       {
         for (LArDaughterDriftVolumeList::const_iterator iterDghtr1 = driftVolume1.GetTpcVolumeList().begin(),
-                 iterDghtrEnd1 = driftVolume1.GetTpcVolumeList().end();
+             iterDghtrEnd1 = driftVolume1.GetTpcVolumeList().end();
              iterDghtr1 != iterDghtrEnd1; 
              ++iterDghtr1)
         {
-          const LArDaughterDriftVolume &tpcVolume1 = *iterDghtr1;
+            const LArDaughterDriftVolume &tpcVolume1(*iterDghtr1);
 
           for (LArDaughterDriftVolumeList::const_iterator iterDghtr2 = iterDghtr1,
-                   iterDghtrEnd2 = driftVolume1.GetTpcVolumeList().end();
+               iterDghtrEnd2 = driftVolume1.GetTpcVolumeList().end();
                iterDghtr2 != iterDghtrEnd2;
                ++iterDghtr2)
           {
-            const LArDaughterDriftVolume &tpcVolume2 = *iterDghtr2;
+              const LArDaughterDriftVolume &tpcVolume2(*iterDghtr2);
 
             if (tpcVolume1.GetTpc() == tpcVolume2.GetTpc())
               continue;
@@ -185,10 +185,7 @@ namespace lar_pandora {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  unsigned int 
-  LArPandoraGeometry::GetDaughterVolumeID(const LArDriftVolumeMap &driftVolumeMap, 
-                                          const unsigned int cstat, 
-                                          const unsigned int tpc)
+  unsigned int LArPandoraGeometry::GetDaughterVolumeID(const LArDriftVolumeMap &driftVolumeMap, const unsigned int cstat, const unsigned int tpc)
   {
     if (driftVolumeMap.empty())
       throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- detector geometry map is empty";
@@ -202,7 +199,7 @@ namespace lar_pandora {
          iterDghtrEnd = iter->second.GetTpcVolumeList().end(); 
          iterDghtr != iterDghtrEnd; ++iterDghtr)
     {
-      const LArDaughterDriftVolume &daughterVolume = *iterDghtr;
+        const LArDaughterDriftVolume &daughterVolume(*iterDghtr);
       if (cstat == daughterVolume.GetCryostat() && tpc == daughterVolume.GetTpc())
         return std::distance(iter->second.GetTpcVolumeList().begin(), iterDghtr);
     }
@@ -211,10 +208,7 @@ namespace lar_pandora {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  geo::View_t
-  LArPandoraGeometry::GetGlobalView(const unsigned int cstat,
-                                    const unsigned int tpc,
-                                    const geo::View_t hit_View)
+  geo::View_t LArPandoraGeometry::GetGlobalView(const unsigned int cstat, const unsigned int tpc, const geo::View_t hit_View)
   {
     const bool switchUV(LArPandoraGeometry::ShouldSwitchUV(cstat, tpc));
 
@@ -381,13 +375,9 @@ namespace lar_pandora {
         tpcList.insert(itpc1);
 
         LArDaughterDriftVolumeList tpcVolumeList;
-        tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc1,
-                                                          0.5f * (driftMaxX + driftMinX),
-                                                          0.5f * (driftMaxY + driftMinY),
-                                                          0.5f * (driftMaxZ + driftMinZ),
-                                                          (driftMaxX - driftMinX),
-                                                          (driftMaxY - driftMinY),
-                                                          (driftMaxZ - driftMinZ)));
+        tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc1, 
+                                                          0.5f * (driftMaxX + driftMinX), 0.5f * (driftMaxY + driftMinY), 0.5f * (driftMaxZ + driftMinZ),
+                                                          (driftMaxX - driftMinX), (driftMaxY - driftMinY), (driftMaxZ - driftMinZ)));
 
         // Now identify the other TPCs associated with this drift volume
         for (unsigned int itpc2 = itpc1 + 1; itpc2 < theGeometry->NTPC(icstat); ++itpc2) {
@@ -441,13 +431,9 @@ namespace lar_pandora {
           driftMinZ = std::min(driftMinZ, driftMinZ2);
           driftMaxZ = std::max(driftMaxZ, driftMaxZ2);
 
-          tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc2,
-                                                            0.5f * (driftMaxX2 + driftMinX2),
-                                                            0.5f * (driftMaxY2 + driftMinY2),
-                                                            0.5f * (driftMaxZ2 + driftMinZ2),
-                                                            (driftMaxX2 - driftMinX2),
-                                                            (driftMaxY2 - driftMinY2),
-                                                            (driftMaxZ2 - driftMinZ2)));
+          tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc2, 
+                                                            0.5f * (driftMaxX2 + driftMinX2), 0.5f * (driftMaxY2 + driftMinY2), 0.5f * (driftMaxZ2 + driftMinZ2),
+                                                            (driftMaxX2 - driftMinX2), (driftMaxY2 - driftMinY2), (driftMaxZ2 - driftMinZ2)));
         }
 
         // Create new daughter drift volume (volume ID = 0 to N-1)

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.h
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.h
@@ -352,8 +352,8 @@ private:
      *  @param  tpc the input tpc unique ID
      */
     static unsigned int GetDaughterVolumeID(const LArDriftVolumeMap& driftVolumeMap,
-                                    const unsigned int cstat,
-                                    const unsigned int tpc);
+                                            const unsigned int cstat,
+                                            const unsigned int tpc);
 
     /**
      *  @brief  Convert to global coordinate system

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.h
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.h
@@ -102,7 +102,7 @@ namespace lar_pandora {
      *  @param  widthY           width of tpc volume (Y)
      *  @param  widthZ           width of tpc volume (Z)
      */
-    LArDaughterDriftVolume(const unsigned int cryostat, const unsigned int tpc
+    LArDaughterDriftVolume(const unsigned int cryostat, const unsigned int tpc,
                            const float centerX, const float centerY, const float centerZ,
                            const float widthX, const float widthY, const float widthZ);
 

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.h
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.h
@@ -93,25 +93,69 @@ namespace lar_pandora {
     /**
      *  @brief  Constructor
      *
-     *  @param  cryostat  the cryostat ID
-     *  @param  tpc       the tpc ID
+     *  @param  cryostat         the cryostat ID
+     *  @param  tpc              the tpc ID
+     *  @param  centerX          centre of tpc volume (X)
+     *  @param  centerY          centre of tpc volume (Y)
+     *  @param  centerZ          centre of tpc volume (Z)
+     *  @param  widthX           width of tpc volume (X)
+     *  @param  widthY           width of tpc volume (Y)
+     *  @param  widthZ           width of tpc volume (Z)
      */
-    LArDaughterDriftVolume(const unsigned int cryostat, const unsigned int tpc);
+    LArDaughterDriftVolume(const unsigned int cryostat, const unsigned int tpc
+                           const float centerX, const float centerY, const float centerZ,
+                           const float widthX, const float widthY, const float widthZ);
 
     /**
-     *  @brief  return cryostat ID
+     *  @brief  Return cryostat ID
      */
     unsigned int GetCryostat() const;
 
     /**
-     *  @brief  return tpc ID
+     *  @brief  Return tpc ID
      */
     unsigned int GetTpc() const;
 
-  private:
-    unsigned int m_cryostat;
-    unsigned int m_tpc;
-  };
+    /**
+     *  @brief  Return X position at centre of tpc volume
+     */
+    float GetCenterX() const;
+
+    /**
+     *  @brief  Return Y position at centre of tpc volume
+     */
+    float GetCenterY() const;
+
+    /**
+     *  @brief  Return Z position at centre of tpc volume
+     */
+    float GetCenterZ() const;
+
+    /**
+     *  @brief  Return X span of tpc volume
+     */
+    float GetWidthX() const;
+
+    /**
+     *  @brief  Return Y span of tpc volume
+     */
+    float GetWidthY() const;
+
+    /**
+     *  @brief  Return Z span of tpc volume
+     */
+    float GetWidthZ() const;
+
+private:
+    unsigned int    m_cryostat;
+    unsigned int    m_tpc;
+    float           m_centerX;
+    float           m_centerY;
+    float           m_centerZ;
+    float           m_widthX;
+    float           m_widthY;
+    float           m_widthZ;
+};
 
   typedef std::vector<LArDaughterDriftVolume> LArDaughterDriftVolumeList;
 
@@ -301,6 +345,17 @@ namespace lar_pandora {
                                     const unsigned int tpc);
 
     /**
+     *  @brief  Get daughter volume ID from a specified cryostat/tpc pair
+     *
+     *  @param  driftVolumeMap the output mapping between cryostat/tpc and drift volumes
+     *  @param  cstat the input cryostat unique ID
+     *  @param  tpc the input tpc unique ID
+     */
+    static unsigned int GetDaughterVolumeID(const LArDriftVolumeMap& driftVolumeMap,
+                                    const unsigned int cstat,
+                                    const unsigned int tpc);
+
+    /**
      *  @brief  Convert to global coordinate system
      *
      *  @param  cstat the input cryostat
@@ -425,9 +480,12 @@ namespace lar_pandora {
   //------------------------------------------------------------------------------------------------------------------------------------------
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  inline LArDaughterDriftVolume::LArDaughterDriftVolume(const unsigned int cryostat,
-                                                        const unsigned int tpc)
-    : m_cryostat(cryostat), m_tpc(tpc)
+  inline LArDaughterDriftVolume::LArDaughterDriftVolume(const unsigned int cryostat, const unsigned int tpc,
+                                                        const float centerX, const float centerY, const float centerZ,
+                                                        const float widthX, const float widthY, const float widthZ) :
+      m_cryostat(cryostat), m_tpc(tpc),
+      m_centerX(centerX), m_centerY(centerY), m_centerZ(centerZ),
+      m_widthX(widthX), m_widthY(widthY), m_widthZ(widthZ)      
   {}
 
   //------------------------------------------------------------------------------------------------------------------------------------------
@@ -444,6 +502,54 @@ namespace lar_pandora {
   LArDaughterDriftVolume::GetTpc() const
   {
     return m_tpc;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  inline float
+  LArDaughterDriftVolume::GetCenterX() const
+  {
+    return m_centerX;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  inline float
+  LArDaughterDriftVolume::GetCenterY() const
+  {
+    return m_centerY;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  inline float
+  LArDaughterDriftVolume::GetCenterZ() const
+  {
+    return m_centerZ;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  inline float
+  LArDaughterDriftVolume::GetWidthX() const
+  {
+    return m_widthX;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  inline float
+  LArDaughterDriftVolume::GetWidthY() const
+  {
+      return m_widthY;
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  inline float
+  LArDaughterDriftVolume::GetWidthZ() const
+  {
+    return m_widthZ;
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -122,6 +122,8 @@ namespace lar_pandora {
         caloHitParameters.m_pParentAddress = (void*)((intptr_t)(++hitCounter));
         caloHitParameters.m_larTPCVolumeId =
           LArPandoraGeometry::GetVolumeID(driftVolumeMap, hit_WireID.Cryostat, hit_WireID.TPC);
+        caloHitParameters.m_daughterVolumeId = 
+          LArPandoraGeometry::GetDaughterVolumeID(driftVolumeMap, hit_WireID.Cryostat, hit_WireID.TPC);
 
         const geo::View_t pandora_GlobalView(
           LArPandoraGeometry::GetGlobalView(hit_WireID.Cryostat, hit_WireID.TPC, hit_View));


### PR DESCRIPTION
This PR concerns the creation of daughter volumes for each CRP in the Dual-Phase geometry along with a more complete set of member variables for the LArDaughterVolume class. Also the new LArCaloHit member variable `m_daughterVolumeId` gets filled with the daughter volume ID of the corresponding hit.

This PR is associated to the larpandoracontent PR https://github.com/LArSoft/larpandoracontent/pull/17 in which cluster matching checks for a common daughter volume, where this is relevant (dual phase).