### PR TITLE
feature/larpandoracontent_v03_25_00

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
@@ -2,44 +2,44 @@
 #define LArPandoraShowerAlg_hxx
 
 //Framework Includes
-#include "fhiclcpp/ParameterSet.h"
 #include "art_root_io/TFileService.h"
-#include "messagefacility/MessageLogger/MessageLogger.h"
-#include "cetlib_except/exception.h"
-#include "canvas/Persistency/Common/Ptr.h"
 #include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "cetlib_except/exception.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 
 //LArSoft Includes
 #include "art/Framework/Principal/Event.h"
-#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larcore/Geometry/Geometry.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "lardataalg/DetectorInfo/DetectorClocksData.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/PFParticle.h"
 #include "lardataobj/RecoBase/SpacePoint.h"
 #include "lardataobj/RecoBase/Track.h"
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/ShowerElementHolder.hh"
-#include "lardataalg/DetectorInfo/DetectorClocksData.h"
-#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
 #include "larevt/SpaceCharge/SpaceCharge.h"
 #include "larevt/SpaceChargeServices/SpaceChargeService.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/ShowerElementHolder.hh"
 
 //C++ Includes
-#include <iostream>
-#include <vector>
-#include <map>
 #include <algorithm>
+#include <iostream>
+#include <map>
+#include <vector>
 
 //Root Includes
-#include "TVector3.h"
-#include "TMath.h"
-#include "TVector.h"
-#include "TTree.h"
 #include "TCanvas.h"
-#include "TPolyMarker3D.h"
-#include "TPolyLine3D.h"
-#include "TString.h"
 #include "TH3F.h"
+#include "TMath.h"
+#include "TPolyLine3D.h"
+#include "TPolyMarker3D.h"
+#include "TString.h"
 #include "TStyle.h"
+#include "TTree.h"
+#include "TVector.h"
+#include "TVector3.h"
 
 namespace detinfo {
   class DetectorClocksData;
@@ -51,85 +51,103 @@ namespace shower {
 }
 
 class shower::LArPandoraShowerAlg {
-  public:
-    explicit LArPandoraShowerAlg(const fhicl::ParameterSet& pset);
+public:
+  explicit LArPandoraShowerAlg(const fhicl::ParameterSet& pset);
 
-    void OrderShowerHits(detinfo::DetectorPropertiesData const& detProp,
-        std::vector<art::Ptr<recob::Hit> >& hits,
-        TVector3 const& ShowerDirection,
-        TVector3 const& ShowerPosition
-        ) const;
+  void OrderShowerHits(detinfo::DetectorPropertiesData const& detProp,
+                       std::vector<art::Ptr<recob::Hit>>& hits,
+                       TVector3 const& ShowerDirection,
+                       TVector3 const& ShowerPosition) const;
 
-    void OrderShowerSpacePointsPerpendicular(std::vector<art::Ptr<recob::SpacePoint> >&
-        showersps, TVector3 const& vertex, TVector3 const& direction) const;
+  void OrderShowerSpacePointsPerpendicular(std::vector<art::Ptr<recob::SpacePoint>>& showersps,
+                                           TVector3 const& vertex,
+                                           TVector3 const& direction) const;
 
-    void OrderShowerSpacePoints(std::vector<art::Ptr<recob::SpacePoint> >& showersps,
-        TVector3 const& vertex, TVector3 const& direction) const;
+  void OrderShowerSpacePoints(std::vector<art::Ptr<recob::SpacePoint>>& showersps,
+                              TVector3 const& vertex,
+                              TVector3 const& direction) const;
 
-    void OrderShowerSpacePoints(std::vector<art::Ptr<recob::SpacePoint> >& showersps,
-        TVector3 const& vertex) const;
+  void OrderShowerSpacePoints(std::vector<art::Ptr<recob::SpacePoint>>& showersps,
+                              TVector3 const& vertex) const;
 
-    TVector3 ShowerCentre(std::vector<art::Ptr<recob::SpacePoint> > const& showersps) const;
+  TVector3 ShowerCentre(std::vector<art::Ptr<recob::SpacePoint>> const& showersps) const;
 
-    TVector3 ShowerCentre(detinfo::DetectorClocksData const& clockData,
-        detinfo::DetectorPropertiesData const& detProp,
-        std::vector<art::Ptr<recob::SpacePoint> > const& showersps,
-        art::FindManyP<recob::Hit> const& fmh, float& totalCharge) const;
+  TVector3 ShowerCentre(detinfo::DetectorClocksData const& clockData,
+                        detinfo::DetectorPropertiesData const& detProp,
+                        std::vector<art::Ptr<recob::SpacePoint>> const& showersps,
+                        art::FindManyP<recob::Hit> const& fmh,
+                        float& totalCharge) const;
 
-    TVector3 ShowerCentre(detinfo::DetectorClocksData const& clockData,
-        detinfo::DetectorPropertiesData const& detProp,
-        std::vector<art::Ptr<recob::SpacePoint> > const& showerspcs,
-        art::FindManyP<recob::Hit> const& fmh) const;
+  TVector3 ShowerCentre(detinfo::DetectorClocksData const& clockData,
+                        detinfo::DetectorPropertiesData const& detProp,
+                        std::vector<art::Ptr<recob::SpacePoint>> const& showerspcs,
+                        art::FindManyP<recob::Hit> const& fmh) const;
 
-    TVector3 SpacePointPosition(art::Ptr<recob::SpacePoint> const& sp) const;
+  TVector3 SpacePointPosition(art::Ptr<recob::SpacePoint> const& sp) const;
 
-    double DistanceBetweenSpacePoints(art::Ptr<recob::SpacePoint> const& sp_a, art::Ptr<recob::SpacePoint> const& sp_b) const;
+  double DistanceBetweenSpacePoints(art::Ptr<recob::SpacePoint> const& sp_a,
+                                    art::Ptr<recob::SpacePoint> const& sp_b) const;
 
-    double SpacePointCharge(art::Ptr<recob::SpacePoint> const& sp, art::FindManyP<recob::Hit> const& fmh) const;
+  double SpacePointCharge(art::Ptr<recob::SpacePoint> const& sp,
+                          art::FindManyP<recob::Hit> const& fmh) const;
 
-    double SpacePointTime(art::Ptr<recob::SpacePoint> const& sp, art::FindManyP<recob::Hit> const& fmh) const;
+  double SpacePointTime(art::Ptr<recob::SpacePoint> const& sp,
+                        art::FindManyP<recob::Hit> const& fmh) const;
 
-    TVector2 HitCoordinates(detinfo::DetectorPropertiesData const& detProp, art::Ptr<recob::Hit> const& hit) const;
+  TVector2 HitCoordinates(detinfo::DetectorPropertiesData const& detProp,
+                          art::Ptr<recob::Hit> const& hit) const;
 
-    double SpacePointProjection(art::Ptr<recob::SpacePoint> const& sp, TVector3 const& vertex,
-        TVector3 const& direction) const;
+  double SpacePointProjection(art::Ptr<recob::SpacePoint> const& sp,
+                              TVector3 const& vertex,
+                              TVector3 const& direction) const;
 
-    double SpacePointPerpendicular(art::Ptr<recob::SpacePoint> const &sp,
-        TVector3 const& vertex, TVector3 const& direction) const;
+  double SpacePointPerpendicular(art::Ptr<recob::SpacePoint> const& sp,
+                                 TVector3 const& vertex,
+                                 TVector3 const& direction) const;
 
-    double SpacePointPerpendicular(art::Ptr<recob::SpacePoint> const& sp, TVector3 const& vertex,
-        TVector3 const& direction, double proj) const;
+  double SpacePointPerpendicular(art::Ptr<recob::SpacePoint> const& sp,
+                                 TVector3 const& vertex,
+                                 TVector3 const& direction,
+                                 double proj) const;
 
-    double RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint> >& sps, const TVector3& ShowerCentre, const TVector3& Direction, const unsigned int nSegments) const;
+  double RMSShowerGradient(std::vector<art::Ptr<recob::SpacePoint>>& sps,
+                           const TVector3& ShowerCentre,
+                           const TVector3& Direction,
+                           const unsigned int nSegments) const;
 
-    double CalculateRMS(const std::vector<float>& perps) const;
+  double CalculateRMS(const std::vector<float>& perps) const;
 
   // The SCE service requires thing in geo::Point/Vector form, so overload and be nice
-    double SCECorrectPitch(double const& pitch, TVector3 const& pos, TVector3 const& dir, unsigned int const& TPC) const;
-    double SCECorrectPitch(double const& pitch, geo::Point_t const& pos, geo::Vector_t const& dir, unsigned int const& TPC) const;
+  double SCECorrectPitch(double const& pitch,
+                         TVector3 const& pos,
+                         TVector3 const& dir,
+                         unsigned int const& TPC) const;
+  double SCECorrectPitch(double const& pitch,
+                         geo::Point_t const& pos,
+                         geo::Vector_t const& dir,
+                         unsigned int const& TPC) const;
 
-    double SCECorrectEField(double const& EField, TVector3 const& pos) const;
-    double SCECorrectEField(double const& EField, geo::Point_t const& pos) const;
+  double SCECorrectEField(double const& EField, TVector3 const& pos) const;
+  double SCECorrectEField(double const& EField, geo::Point_t const& pos) const;
 
-    void DebugEVD(art::Ptr<recob::PFParticle> const& pfparticle,
-        art::Event const& Event,
-        const reco::shower::ShowerElementHolder& ShowerEleHolder,
-        std::string const& evd_disp_name_append="") const;
+  void DebugEVD(art::Ptr<recob::PFParticle> const& pfparticle,
+                art::Event const& Event,
+                const reco::shower::ShowerElementHolder& ShowerEleHolder,
+                std::string const& evd_disp_name_append = "") const;
 
-  private:
+private:
+  bool fUseCollectionOnly;
+  art::InputTag fPFParticleLabel;
+  bool fSCEXFlip; // If a (legacy) flip is needed in x componant of spatial SCE correction
 
-    bool          fUseCollectionOnly;
-    art::InputTag fPFParticleLabel;
-    bool          fSCEXFlip; // If a (legacy) flip is needed in x componant of spatial SCE correction
+  spacecharge::SpaceCharge const* fSCE;
+  art::ServiceHandle<geo::Geometry const> fGeom;
+  art::ServiceHandle<art::TFileService> tfs;
 
-    spacecharge::SpaceCharge const*         fSCE;
-    art::ServiceHandle<geo::Geometry const> fGeom;
-    art::ServiceHandle<art::TFileService>   tfs;
-
-    const std::string fInitialTrackInputLabel;
-    const std::string fShowerStartPositionInputLabel;
-    const std::string fShowerDirectionInputLabel;
-    const std::string fInitialTrackSpacePointsInputLabel;
+  const std::string fInitialTrackInputLabel;
+  const std::string fShowerStartPositionInputLabel;
+  const std::string fShowerDirectionInputLabel;
+  const std::string fInitialTrackSpacePointsInputLabel;
 };
 
 #endif

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.cxx
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.cxx
@@ -1,51 +1,54 @@
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h"
 
-shower::LArPandoraShowerCheatingAlg::LArPandoraShowerCheatingAlg(const fhicl::ParameterSet& pset):
-  fLArPandoraShowerAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerAlg")),
-  fHitModuleLabel(pset.get<art::InputTag> ("HitModuleLabel")),
-  fPFParticleLabel(pset.get<art::InputTag> ("PFParticleLabel")),
-  fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-  fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel")),
-  fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel"))
-{
-}
+shower::LArPandoraShowerCheatingAlg::LArPandoraShowerCheatingAlg(const fhicl::ParameterSet& pset)
+  : fLArPandoraShowerAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerAlg"))
+  , fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel"))
+  , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+  , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+  , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+  , fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel"))
+{}
 
-std::map<int,const simb::MCParticle*>  shower::LArPandoraShowerCheatingAlg::GetTrueParticleMap() const {
+std::map<int, const simb::MCParticle*>
+shower::LArPandoraShowerCheatingAlg::GetTrueParticleMap() const
+{
 
   const sim::ParticleList& particles = particleInventory->ParticleList();
 
-  std::map<int,const simb::MCParticle*> trueParticles;
+  std::map<int, const simb::MCParticle*> trueParticles;
   // Make a map of track id to particle
   for (sim::ParticleList::const_iterator particleIt = particles.begin();
-      particleIt != particles.end(); ++particleIt){
-    const simb::MCParticle *particle = particleIt->second;
+       particleIt != particles.end();
+       ++particleIt) {
+    const simb::MCParticle* particle = particleIt->second;
     trueParticles[particle->TrackId()] = particle;
     //std::cout<<"Particle ID: "<<particle->TrackId()<<" and PDG: "<<particle->PdgCode()<<std::endl;
   }
   return trueParticles;
 }
 
-
-std::map<int,std::vector<int> > shower::LArPandoraShowerCheatingAlg::GetTrueChain(
-    std::map<int,const simb::MCParticle*>& trueParticles) const {
+std::map<int, std::vector<int>>
+shower::LArPandoraShowerCheatingAlg::GetTrueChain(
+  std::map<int, const simb::MCParticle*>& trueParticles) const
+{
 
   // Roll up showers if not already done:
-  std::map<int,std::vector<int> > showerMothers;
+  std::map<int, std::vector<int>> showerMothers;
 
   // Loop over daughters and find th`e mothers
-  for (const auto &particleIt : trueParticles ){
-    const simb::MCParticle *particle = particleIt.second;
-    const simb::MCParticle *mother   = particle;
+  for (const auto& particleIt : trueParticles) {
+    const simb::MCParticle* particle = particleIt.second;
+    const simb::MCParticle* mother = particle;
 
-    if(std::abs(particle->PdgCode()) != 11 && std::abs(particle->PdgCode()) != 22){continue;}
+    if (std::abs(particle->PdgCode()) != 11 && std::abs(particle->PdgCode()) != 22) { continue; }
 
     // While the grand mother exists and is an electron or photon
     // Note the true mother will skip this loop and fill itself into the map
-    while (mother->Mother()!=0 && trueParticles.find(mother->Mother())!= trueParticles.end()){
+    while (mother->Mother() != 0 && trueParticles.find(mother->Mother()) != trueParticles.end()) {
 
       int motherId = mother->Mother();
-      if (std::abs(trueParticles[motherId]->PdgCode())!=11 &&
-          std::abs(trueParticles[motherId]->PdgCode())!=22){
+      if (std::abs(trueParticles[motherId]->PdgCode()) != 11 &&
+          std::abs(trueParticles[motherId]->PdgCode()) != 22) {
         break;
       }
       mother = trueParticles[motherId];
@@ -55,22 +58,27 @@ std::map<int,std::vector<int> > shower::LArPandoraShowerCheatingAlg::GetTrueChai
   return showerMothers;
 }
 
-void shower::LArPandoraShowerCheatingAlg::CheatDebugEVD(detinfo::DetectorClocksData const& clockData,
-    const simb::MCParticle* trueParticle, art::Event const& Event, reco::shower::ShowerElementHolder& ShowerEleHolder,
-    const art::Ptr<recob::PFParticle>& pfparticle) const {
+void
+shower::LArPandoraShowerCheatingAlg::CheatDebugEVD(
+  detinfo::DetectorClocksData const& clockData,
+  const simb::MCParticle* trueParticle,
+  art::Event const& Event,
+  reco::shower::ShowerElementHolder& ShowerEleHolder,
+  const art::Ptr<recob::PFParticle>& pfparticle) const
+{
 
-  std::cout<<"Making Debug Event Display"<<std::endl;
+  std::cout << "Making Debug Event Display" << std::endl;
 
   //Function for drawing reco showers to check direction and initial track selection
 
   // Get run info to make unique canvas names
-  int run    = Event.run();
+  int run = Event.run();
   int subRun = Event.subRun();
-  int event  = Event.event();
-  int PFPID  = pfparticle->Self();
+  int event = Event.event();
+  int PFPID = pfparticle->Self();
 
   // Create the canvas
-  TString canvasName = Form("canvas_%i_%i_%i_%i",run,subRun,event,PFPID);
+  TString canvasName = Form("canvas_%i_%i_%i_%i", run, subRun, event, PFPID);
   TCanvas* canvas = tfs->make<TCanvas>(canvasName, canvasName);
 
   // Initialise variables
@@ -78,114 +86,115 @@ void shower::LArPandoraShowerCheatingAlg::CheatDebugEVD(detinfo::DetectorClocksD
   double y = 0;
   double z = 0;
 
-  std::vector<art::Ptr<recob::SpacePoint> > showerSpacePoints;
-  std::vector<art::Ptr<recob::SpacePoint> > otherSpacePoints;
+  std::vector<art::Ptr<recob::SpacePoint>> showerSpacePoints;
+  std::vector<art::Ptr<recob::SpacePoint>> otherSpacePoints;
 
-  auto const hitHandle = Event.getValidHandle<std::vector<recob::Hit> >(fHitModuleLabel);
-  std::vector<art::Ptr<recob::Hit> > hits;
+  auto const hitHandle = Event.getValidHandle<std::vector<recob::Hit>>(fHitModuleLabel);
+  std::vector<art::Ptr<recob::Hit>> hits;
   art::fill_ptr_vector(hits, hitHandle);
 
   // Get the hits associated with the space points
   const art::FindManyP<recob::SpacePoint> fmsph(hitHandle, Event, fPFParticleLabel);
-  if(!fmsph.isValid()){
-    throw cet::exception("LArPandoraShowerCheatingAlg") << "Spacepoint and hit association not valid. Stopping.";
+  if (!fmsph.isValid()) {
+    throw cet::exception("LArPandoraShowerCheatingAlg")
+      << "Spacepoint and hit association not valid. Stopping.";
   }
 
-  std::map< art::Ptr<recob::SpacePoint>, art::Ptr<recob::Hit> > spacePointHitMap;
+  std::map<art::Ptr<recob::SpacePoint>, art::Ptr<recob::Hit>> spacePointHitMap;
   //Get the hits from the true particle
-  for (auto hit : hits){
+  for (auto hit : hits) {
     int trueParticleID = std::abs(TrueParticleID(clockData, hit));
-    std::vector<art::Ptr<recob::SpacePoint> > sps = fmsph.at(hit.key());
-    if (sps.size() == 1){
+    std::vector<art::Ptr<recob::SpacePoint>> sps = fmsph.at(hit.key());
+    if (sps.size() == 1) {
       art::Ptr<recob::SpacePoint> sp = sps.front();
-      if (trueParticleID == trueParticle->TrackId()){
-        showerSpacePoints.push_back(sp);
-      } else {
+      if (trueParticleID == trueParticle->TrackId()) { showerSpacePoints.push_back(sp); }
+      else {
         otherSpacePoints.push_back(sp);
       }
     }
   }
 
-  if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
-    mf::LogError("LArPandoraShowerCheatingAlg") << "Start position not set, returning "<< std::endl;
+  if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
+    mf::LogError("LArPandoraShowerCheatingAlg")
+      << "Start position not set, returning " << std::endl;
     return;
   }
-  if(!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)){
-    mf::LogError("LArPandoraShowerCheatingAlg") << "Direction not set, returning "<< std::endl;
+  if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)) {
+    mf::LogError("LArPandoraShowerCheatingAlg") << "Direction not set, returning " << std::endl;
     return;
   }
-  if(!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)){
-    mf::LogError("LArPandoraShowerCheatingAlg") << "TrackSpacePoints not set, returning "<< std::endl;
+  if (!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)) {
+    mf::LogError("LArPandoraShowerCheatingAlg")
+      << "TrackSpacePoints not set, returning " << std::endl;
     return;
   }
 
   // Get info from shower property holder
-  TVector3 showerStartPosition = {-999,-999,-999};
-  TVector3 showerDirection = {-999,-999,-999};
-  std::vector<art::Ptr<recob::SpacePoint> > trackSpacePoints;
+  TVector3 showerStartPosition = {-999, -999, -999};
+  TVector3 showerDirection = {-999, -999, -999};
+  std::vector<art::Ptr<recob::SpacePoint>> trackSpacePoints;
 
-  ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,showerStartPosition);
+  ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, showerStartPosition);
   ShowerEleHolder.GetElement(fShowerDirectionInputLabel, showerDirection);
-  ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel,trackSpacePoints);
+  ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel, trackSpacePoints);
 
   // Create 3D point at vertex, chosed to be origin for ease of use of display
-  double startXYZ[3] = {0,0,0};
-  auto startPoly = std::make_unique<TPolyMarker3D>(1,startXYZ);
+  double startXYZ[3] = {0, 0, 0};
+  auto startPoly = std::make_unique<TPolyMarker3D>(1, startXYZ);
 
   // Get the min and max projections along the direction to know how long to draw
   // the direction line
   double minProj = std::numeric_limits<double>::max();
   double maxProj = -std::numeric_limits<double>::max();
 
-  double x_min=std::numeric_limits<double>::max(), x_max=-std::numeric_limits<double>::max();
-  double y_min=std::numeric_limits<double>::max(), y_max=-std::numeric_limits<double>::max();
-  double z_min=std::numeric_limits<double>::max(), z_max=-std::numeric_limits<double>::max();
+  double x_min = std::numeric_limits<double>::max(), x_max = -std::numeric_limits<double>::max();
+  double y_min = std::numeric_limits<double>::max(), y_max = -std::numeric_limits<double>::max();
+  double z_min = std::numeric_limits<double>::max(), z_max = -std::numeric_limits<double>::max();
 
   //initialise counter point
   int point = 0;
 
-
   // Make 3D points for each spacepoint in the shower
   auto showerPoly = std::make_unique<TPolyMarker3D>(showerSpacePoints.size());
-  for (auto spacePoint : showerSpacePoints){
+  for (auto spacePoint : showerSpacePoints) {
     TVector3 pos = fLArPandoraShowerAlg.SpacePointPosition(spacePoint) - showerStartPosition;
 
     x = pos.X();
     y = pos.Y();
     z = pos.Z();
-    x_min = std::min(x,x_min);
-    x_max = std::max(x,x_max);
-    y_min = std::min(y,y_min);
-    y_max = std::max(y,y_max);
-    z_min = std::min(z,z_min);
-    z_max = std::max(z,z_max);
+    x_min = std::min(x, x_min);
+    x_max = std::max(x, x_max);
+    y_min = std::min(y, y_min);
+    y_max = std::max(y, y_max);
+    z_min = std::min(z, z_min);
+    z_max = std::max(z, z_max);
 
-    showerPoly->SetPoint(point,x,y,z);
+    showerPoly->SetPoint(point, x, y, z);
     ++point;
 
     // Calculate the projection of (point-startpoint) along the direction
-    double proj = fLArPandoraShowerAlg.SpacePointProjection(spacePoint, showerStartPosition,
-        showerDirection);
+    double proj =
+      fLArPandoraShowerAlg.SpacePointProjection(spacePoint, showerStartPosition, showerDirection);
 
     maxProj = std::max(proj, maxProj);
     minProj = std::min(proj, minProj);
   } // loop over spacepoints
 
   // Create TPolyLine3D arrays
-  double xDirPoints[2] = {minProj*showerDirection.X(), maxProj*showerDirection.X()};
-  double yDirPoints[2] = {minProj*showerDirection.Y(), maxProj*showerDirection.Y()};
-  double zDirPoints[2] = {minProj*showerDirection.Z(), maxProj*showerDirection.Z()};
+  double xDirPoints[2] = {minProj * showerDirection.X(), maxProj * showerDirection.X()};
+  double yDirPoints[2] = {minProj * showerDirection.Y(), maxProj * showerDirection.Y()};
+  double zDirPoints[2] = {minProj * showerDirection.Z(), maxProj * showerDirection.Z()};
 
-  auto dirPoly = std::make_unique<TPolyLine3D>(2,xDirPoints,yDirPoints,zDirPoints);
+  auto dirPoly = std::make_unique<TPolyLine3D>(2, xDirPoints, yDirPoints, zDirPoints);
 
   point = 0; // re-initialise counter
   auto trackPoly = std::make_unique<TPolyMarker3D>(trackSpacePoints.size());
-  for (auto spacePoint : trackSpacePoints){
+  for (auto spacePoint : trackSpacePoints) {
     TVector3 pos = fLArPandoraShowerAlg.SpacePointPosition(spacePoint) - showerStartPosition;
     x = pos.X();
     y = pos.Y();
     z = pos.Z();
-    trackPoly->SetPoint(point,x,y,z);
+    trackPoly->SetPoint(point, x, y, z);
     ++point;
   } // loop over track spacepoints
 
@@ -197,23 +206,23 @@ void shower::LArPandoraShowerCheatingAlg::CheatDebugEVD(detinfo::DetectorClocksD
   // initialise counters
   point = 0; // re-initialise counter
 
-  for(auto const& sp: otherSpacePoints){
+  for (auto const& sp : otherSpacePoints) {
     TVector3 pos = fLArPandoraShowerAlg.SpacePointPosition(sp) - showerStartPosition;
     x = pos.X();
     y = pos.Y();
     z = pos.Z();
-    x_min = std::min(x,x_min);
-    x_max = std::max(x,x_max);
-    y_min = std::min(y,y_min);
-    y_max = std::max(y,y_max);
-    z_min = std::min(z,z_min);
-    z_max = std::max(z,z_max);
-    otherPoly->SetPoint(point,x,y,z);
+    x_min = std::min(x, x_min);
+    x_max = std::max(x, x_max);
+    y_min = std::min(y, y_min);
+    y_max = std::max(y, y_max);
+    z_min = std::min(z, z_min);
+    z_max = std::max(z, z_max);
+    otherPoly->SetPoint(point, x, y, z);
     ++point;
   }
 
   gStyle->SetOptStat(0);
-  TH3F axes("axes","",1,x_min,x_max,1,y_min,y_max,1,z_min,z_max);
+  TH3F axes("axes", "", 1, x_min, x_max, 1, y_min, y_max, 1, z_min, z_max);
   axes.SetDirectory(0);
   axes.GetXaxis()->SetTitle("X");
   axes.GetYaxis()->SetTitle("Y");
@@ -243,8 +252,10 @@ void shower::LArPandoraShowerCheatingAlg::CheatDebugEVD(detinfo::DetectorClocksD
   canvas->Write();
 }
 
-int shower::LArPandoraShowerCheatingAlg::TrueParticleID(detinfo::DetectorClocksData const& clockData,
-    const art::Ptr<recob::Hit>& hit) const {
+int
+shower::LArPandoraShowerCheatingAlg::TrueParticleID(detinfo::DetectorClocksData const& clockData,
+                                                    const art::Ptr<recob::Hit>& hit) const
+{
 
   double particleEnergy = 0;
   int likelyTrackID = 0;
@@ -259,16 +270,22 @@ int shower::LArPandoraShowerCheatingAlg::TrueParticleID(detinfo::DetectorClocksD
   return likelyTrackID;
 }
 
-std::pair<int,double> shower::LArPandoraShowerCheatingAlg::TrueParticleIDFromTrueChain(detinfo::DetectorClocksData const& clockData,
-    std::map<int,std::vector<int>> const& ShowersMothers, std::vector<art::Ptr<recob::Hit> > const& hits, int planeid) const {
+std::pair<int, double>
+shower::LArPandoraShowerCheatingAlg::TrueParticleIDFromTrueChain(
+  detinfo::DetectorClocksData const& clockData,
+  std::map<int, std::vector<int>> const& ShowersMothers,
+  std::vector<art::Ptr<recob::Hit>> const& hits,
+  int planeid) const
+{
 
   art::ServiceHandle<cheat::BackTrackerService> bt_serv;
   art::ServiceHandle<cheat::ParticleInventoryService> particleInventory;
 
   //Find the energy for each track ID.
-  std::map<int,double> trackIDToEDepMap;
-  std::map<int,double> trackIDTo3EDepMap;
-  for (std::vector<art::Ptr<recob::Hit> >::const_iterator hitIt = hits.begin(); hitIt != hits.end(); ++hitIt) {
+  std::map<int, double> trackIDToEDepMap;
+  std::map<int, double> trackIDTo3EDepMap;
+  for (std::vector<art::Ptr<recob::Hit>>::const_iterator hitIt = hits.begin(); hitIt != hits.end();
+       ++hitIt) {
     art::Ptr<recob::Hit> hit = *hitIt;
 
     //Get the plane ID
@@ -277,36 +294,42 @@ std::pair<int,double> shower::LArPandoraShowerCheatingAlg::TrueParticleIDFromTru
     std::vector<sim::TrackIDE> trackIDs = bt_serv->HitToTrackIDEs(clockData, hit);
     for (unsigned int idIt = 0; idIt < trackIDs.size(); ++idIt) {
       trackIDTo3EDepMap[std::abs(trackIDs[idIt].trackID)] += trackIDs[idIt].energy;
-      if(PlaneID == planeid){trackIDToEDepMap[std::abs(trackIDs[idIt].trackID)] += trackIDs[idIt].energy;}
+      if (PlaneID == planeid) {
+        trackIDToEDepMap[std::abs(trackIDs[idIt].trackID)] += trackIDs[idIt].energy;
+      }
     }
   }
 
   //Find the energy for each showermother.
-  std::map<int,double> MotherIDtoEMap;
-  std::map<int,double> MotherIDto3EMap;
-  for(std::map<int,std::vector<int> >::const_iterator showermother=ShowersMothers.begin(); showermother!=ShowersMothers.end(); ++showermother){
-    for(std::vector<int>::const_iterator daughter=(showermother->second).begin(); daughter!=(showermother->second).end(); ++daughter){
-      MotherIDtoEMap[showermother->first]  +=  trackIDToEDepMap[*daughter];
-      MotherIDto3EMap[showermother->first] +=  trackIDTo3EDepMap[*daughter];
+  std::map<int, double> MotherIDtoEMap;
+  std::map<int, double> MotherIDto3EMap;
+  for (std::map<int, std::vector<int>>::const_iterator showermother = ShowersMothers.begin();
+       showermother != ShowersMothers.end();
+       ++showermother) {
+    for (std::vector<int>::const_iterator daughter = (showermother->second).begin();
+         daughter != (showermother->second).end();
+         ++daughter) {
+      MotherIDtoEMap[showermother->first] += trackIDToEDepMap[*daughter];
+      MotherIDto3EMap[showermother->first] += trackIDTo3EDepMap[*daughter];
     }
   }
 
   //Loop over the mothers to find the most like candidate by identifying which true shower deposited the most energy in the hits.
   double maxenergy = -1;
   int objectTrack = -99999;
-  for (std::map<int,double>::iterator mapIt = MotherIDto3EMap.begin(); mapIt != MotherIDto3EMap.end(); mapIt++){
+  for (std::map<int, double>::iterator mapIt = MotherIDto3EMap.begin();
+       mapIt != MotherIDto3EMap.end();
+       mapIt++) {
     double energy_three = mapIt->second;
     double trackid = mapIt->first;
-    if (energy_three > maxenergy){
+    if (energy_three > maxenergy) {
       maxenergy = energy_three;
       objectTrack = trackid;
     }
   }
 
   //If the none of the shower mother deposited no energy then we cannot match this.
-  if(maxenergy == 0){
-    return std::make_pair(-99999,-99999);
-  }
+  if (maxenergy == 0) { return std::make_pair(-99999, -99999); }
 
-  return std::make_pair(objectTrack,MotherIDtoEMap[objectTrack]);
+  return std::make_pair(objectTrack, MotherIDtoEMap[objectTrack]);
 }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h
@@ -2,13 +2,13 @@
 #define LArPandoraShowerCheatingAlg_hxx
 
 //LArSoft Includes
-#include "nusimdata/SimulationBase/MCParticle.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h"
 #include "larsim/MCCheater/BackTrackerService.h"
 #include "larsim/MCCheater/ParticleInventoryService.h"
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h"
+#include "nusimdata/SimulationBase/MCParticle.h"
 
 namespace detinfo {
-    class DetectorClocksData;
+  class DetectorClocksData;
 }
 
 namespace shower {
@@ -16,31 +16,37 @@ namespace shower {
 }
 
 class shower::LArPandoraShowerCheatingAlg {
-  public:
-    LArPandoraShowerCheatingAlg(const fhicl::ParameterSet& pset);
+public:
+  LArPandoraShowerCheatingAlg(const fhicl::ParameterSet& pset);
 
-    std::map<int,const simb::MCParticle*> GetTrueParticleMap() const;
-    std::map<int,std::vector<int> > GetTrueChain(std::map<int,const simb::MCParticle*>& trueParticles) const;
-    void CheatDebugEVD(detinfo::DetectorClocksData const& clockData, const simb::MCParticle* trueParticle, art::Event const& Event,
-        reco::shower::ShowerElementHolder& ShowerEleHolder, const art::Ptr<recob::PFParticle>& pfparticle) const;
+  std::map<int, const simb::MCParticle*> GetTrueParticleMap() const;
+  std::map<int, std::vector<int>> GetTrueChain(
+    std::map<int, const simb::MCParticle*>& trueParticles) const;
+  void CheatDebugEVD(detinfo::DetectorClocksData const& clockData,
+                     const simb::MCParticle* trueParticle,
+                     art::Event const& Event,
+                     reco::shower::ShowerElementHolder& ShowerEleHolder,
+                     const art::Ptr<recob::PFParticle>& pfparticle) const;
 
-    int TrueParticleID(detinfo::DetectorClocksData const& clockData, const art::Ptr<recob::Hit>& hit) const;
+  int TrueParticleID(detinfo::DetectorClocksData const& clockData,
+                     const art::Ptr<recob::Hit>& hit) const;
 
-    std::pair<int,double> TrueParticleIDFromTrueChain(detinfo::DetectorClocksData const& clockData,
-        std::map<int,std::vector<int> > const& ShowersMothers, std::vector<art::Ptr<recob::Hit> > const& hits, int planeid) const;
+  std::pair<int, double> TrueParticleIDFromTrueChain(
+    detinfo::DetectorClocksData const& clockData,
+    std::map<int, std::vector<int>> const& ShowersMothers,
+    std::vector<art::Ptr<recob::Hit>> const& hits,
+    int planeid) const;
 
-  private:
+private:
+  shower::LArPandoraShowerAlg fLArPandoraShowerAlg;
 
-    shower::LArPandoraShowerAlg fLArPandoraShowerAlg;
+  art::InputTag fHitModuleLabel;
+  art::InputTag fPFParticleLabel;
+  art::ServiceHandle<cheat::ParticleInventoryService> particleInventory;
+  art::ServiceHandle<art::TFileService> tfs;
 
-    art::InputTag                                       fHitModuleLabel;
-    art::InputTag                                       fPFParticleLabel;
-    art::ServiceHandle<cheat::ParticleInventoryService> particleInventory;
-    art::ServiceHandle<art::TFileService>   tfs;
-
-    std::string fShowerStartPositionInputLabel;
-    std::string fShowerDirectionInputLabel;
-    std::string fInitialTrackSpacePointsInputLabel;
-
+  std::string fShowerStartPositionInputLabel;
+  std::string fShowerDirectionInputLabel;
+  std::string fInitialTrackSpacePointsInputLabel;
 };
 #endif

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/LArPandoraModularShowerCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/LArPandoraModularShowerCreation_module.cc
@@ -26,16 +26,16 @@
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace reco::shower {
-class LArPandoraModularShowerCreation;
+  class LArPandoraModularShowerCreation;
 }
 
 //Class
 
 class reco::shower::LArPandoraModularShowerCreation : public art::EDProducer {
-  public:
+public:
   LArPandoraModularShowerCreation(fhicl::ParameterSet const& pset);
 
-  private:
+private:
   void produce(art::Event& evt);
 
   //This function returns the art::Ptr to the data object InstanceName.
@@ -43,7 +43,8 @@ class reco::shower::LArPandoraModularShowerCreation : public art::EDProducer {
   //the unique ptr (iter).
   template <class T>
   art::Ptr<T> GetProducedElementPtr(const std::string& InstanceName,
-      const reco::shower::ShowerElementHolder& ShowerEleHolder, const int& iter = -1);
+                                    const reco::shower::ShowerElementHolder& ShowerEleHolder,
+                                    const int& iter = -1);
 
   //fcl object names
   unsigned int fNumPlanes;
@@ -76,27 +77,29 @@ class reco::shower::LArPandoraModularShowerCreation : public art::EDProducer {
 //In the background it uses the PtrMaker which requires the element index of
 //the unique ptr (iter).
 template <class T>
-art::Ptr<T> reco::shower::LArPandoraModularShowerCreation::GetProducedElementPtr(
-    const std::string& InstanceName, const reco::shower::ShowerElementHolder& ShowerEleHolder, const int& iter)
+art::Ptr<T>
+reco::shower::LArPandoraModularShowerCreation::GetProducedElementPtr(
+  const std::string& InstanceName,
+  const reco::shower::ShowerElementHolder& ShowerEleHolder,
+  const int& iter)
 {
 
   bool check_element = ShowerEleHolder.CheckElement(InstanceName);
   if (!check_element) {
     throw cet::exception("LArPandoraModularShowerCreation")
-        << "To get a element that does not exist" << std::endl;
+      << "To get a element that does not exist" << std::endl;
   }
 
   bool check_ptr = uniqueproducerPtrs.CheckUniqueProduerPtr(InstanceName);
   if (!check_ptr) {
     throw cet::exception("LArPandoraModularShowerCreation")
-        << "Tried to get a ptr that does not exist" << std::endl;
+      << "Tried to get a ptr that does not exist" << std::endl;
   }
 
   //Get the number of the shower we are on.
   int index;
-  if (iter != -1) {
-    index = iter;
-  } else {
+  if (iter != -1) { index = iter; }
+  else {
     index = ShowerEleHolder.GetShowerNumber();
   }
 
@@ -105,19 +108,20 @@ art::Ptr<T> reco::shower::LArPandoraModularShowerCreation::GetProducedElementPtr
   return artptr;
 }
 
-reco::shower::LArPandoraModularShowerCreation::LArPandoraModularShowerCreation(fhicl::ParameterSet const& pset)
-    : EDProducer { pset }
-    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
-    , fAllowPartialShowers(pset.get<bool>("AllowPartialShowers"))
-    , fVerbose(pset.get<int>("Verbose", 0))
-    , fUseAllParticles(pset.get<bool>("UseAllParticles", false))
-    , fShowerStartPositionLabel(pset.get<std::string>("ShowerStartPositionLabel"))
-    , fShowerDirectionLabel(pset.get<std::string>("ShowerDirectionLabel"))
-    , fShowerEnergyLabel(pset.get<std::string>("ShowerEnergyLabel"))
-    , fShowerLengthLabel(pset.get<std::string>("ShowerLengthLabel"))
-    , fShowerOpeningAngleLabel(pset.get<std::string>("ShowerOpeningAngleLabel"))
-    , fShowerdEdxLabel(pset.get<std::string>("ShowerdEdxLabel"))
-    , fShowerBestPlaneLabel(pset.get<std::string>("ShowerBestPlaneLabel"))
+reco::shower::LArPandoraModularShowerCreation::LArPandoraModularShowerCreation(
+  fhicl::ParameterSet const& pset)
+  : EDProducer{pset}
+  , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+  , fAllowPartialShowers(pset.get<bool>("AllowPartialShowers"))
+  , fVerbose(pset.get<int>("Verbose", 0))
+  , fUseAllParticles(pset.get<bool>("UseAllParticles", false))
+  , fShowerStartPositionLabel(pset.get<std::string>("ShowerStartPositionLabel"))
+  , fShowerDirectionLabel(pset.get<std::string>("ShowerDirectionLabel"))
+  , fShowerEnergyLabel(pset.get<std::string>("ShowerEnergyLabel"))
+  , fShowerLengthLabel(pset.get<std::string>("ShowerLengthLabel"))
+  , fShowerOpeningAngleLabel(pset.get<std::string>("ShowerOpeningAngleLabel"))
+  , fShowerdEdxLabel(pset.get<std::string>("ShowerdEdxLabel"))
+  , fShowerBestPlaneLabel(pset.get<std::string>("ShowerBestPlaneLabel"))
 {
   //Intialise the tools
   auto tool_psets = pset.get<std::vector<fhicl::ParameterSet>>("ShowerFinderTools");
@@ -129,8 +133,9 @@ reco::shower::LArPandoraModularShowerCreation::LArPandoraModularShowerCreation(f
     if (!tool_pset.has_key("PFParticleLabel")) {
 
       // I cannot pass an art::InputTag as it is mangled, so lets make a string instead
-      const std::string PFParticleLabelString(fPFParticleLabel.label() + ":" + fPFParticleLabel.instance()
-          + ":" + fPFParticleLabel.process());
+      const std::string PFParticleLabelString(fPFParticleLabel.label() + ":" +
+                                              fPFParticleLabel.instance() + ":" +
+                                              fPFParticleLabel.process());
 
       tool_pset.put<std::string>("PFParticleLabel", PFParticleLabelString);
       fhicl::ParameterSet base_pset = tool_pset.get<fhicl::ParameterSet>("BaseTools");
@@ -140,17 +145,17 @@ reco::shower::LArPandoraModularShowerCreation::LArPandoraModularShowerCreation(f
       tool_pset.put_or_replace<fhicl::ParameterSet>("BaseTools", base_pset);
 
       if (tool_pset.has_key("LArPandoraShowerCheatingAlg")) {
-        fhicl::ParameterSet cheat_alg_pset = tool_pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg");
+        fhicl::ParameterSet cheat_alg_pset =
+          tool_pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg");
         cheat_alg_pset.put<std::string>("PFParticleLabel", PFParticleLabelString);
         cheat_alg_pset.put_or_replace<fhicl::ParameterSet>("LArPandoraShowerAlg", alg_pset);
-        tool_pset.put_or_replace<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg", cheat_alg_pset);
+        tool_pset.put_or_replace<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg",
+                                                      cheat_alg_pset);
       }
     }
 
     // If we have not explicitly set verboseness for a given tool, use global level
-    if (!tool_pset.has_key("Verbose")) {
-      tool_pset.put<int>("Verbose", fVerbose);
-    }
+    if (!tool_pset.has_key("Verbose")) { tool_pset.put<int>("Verbose", fVerbose); }
 
     fShowerTools.push_back(art::make_tool<ShowerRecoTools::IShowerTool>(tool_pset));
     fShowerToolNames.push_back(tool_name);
@@ -179,15 +184,20 @@ reco::shower::LArPandoraModularShowerCreation::LArPandoraModularShowerCreation(f
 
   // Output -- showers and associations with hits and clusters
   uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<std::vector<recob::Shower>>(), "shower");
-  uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<art::Assns<recob::Shower, recob::Cluster>>(), "clusterAssociationsbase");
-  uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<art::Assns<recob::Shower, recob::Hit>>(), "hitAssociationsbase");
-  uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<art::Assns<recob::Shower, recob::SpacePoint>>(), "spShowerAssociationsbase");
-  uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<art::Assns<recob::Shower, recob::PFParticle>>(), "pfShowerAssociationsbase");
+  uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<art::Assns<recob::Shower, recob::Cluster>>(),
+                                               "clusterAssociationsbase");
+  uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<art::Assns<recob::Shower, recob::Hit>>(),
+                                               "hitAssociationsbase");
+  uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<art::Assns<recob::Shower, recob::SpacePoint>>(),
+                                               "spShowerAssociationsbase");
+  uniqueproducerPtrs.SetShowerUniqueProduerPtr(type<art::Assns<recob::Shower, recob::PFParticle>>(),
+                                               "pfShowerAssociationsbase");
 
   uniqueproducerPtrs.PrintPtrs();
 }
 
-void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
+void
+reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
 {
 
   //Ptr makers for the products
@@ -203,12 +213,12 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
   auto const clusterHandle = evt.getValidHandle<std::vector<recob::Cluster>>(fPFParticleLabel);
 
   //Get the assoications to hits, clusters and spacespoints
-  const art::FindManyP<recob::Hit>& fmh = showerEleHolder.GetFindManyP<recob::Hit>(
-      clusterHandle, evt, fPFParticleLabel);
-  const art::FindManyP<recob::Cluster>& fmcp = showerEleHolder.GetFindManyP<recob::Cluster>(
-      pfpHandle, evt, fPFParticleLabel);
-  const art::FindManyP<recob::SpacePoint>& fmspp = showerEleHolder.GetFindManyP<recob::SpacePoint>(
-      pfpHandle, evt, fPFParticleLabel);
+  const art::FindManyP<recob::Hit>& fmh =
+    showerEleHolder.GetFindManyP<recob::Hit>(clusterHandle, evt, fPFParticleLabel);
+  const art::FindManyP<recob::Cluster>& fmcp =
+    showerEleHolder.GetFindManyP<recob::Cluster>(pfpHandle, evt, fPFParticleLabel);
+  const art::FindManyP<recob::SpacePoint>& fmspp =
+    showerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, evt, fPFParticleLabel);
 
   //Holder to pass to the functions, contains the 6 properties of the shower
   // - Start Poistion
@@ -228,35 +238,36 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
     showerEleHolder.SetShowerNumber(shower_iter);
 
     //loop only over showers unless otherwise specified
-    if (!fUseAllParticles && pfp->PdgCode() != 11 && pfp->PdgCode() != 22)
-      continue;
+    if (!fUseAllParticles && pfp->PdgCode() != 11 && pfp->PdgCode() != 22) continue;
 
     //Get the associated hits,clusters and spacepoints
     const std::vector<art::Ptr<recob::Cluster>> showerClusters = fmcp.at(pfp.key());
     const std::vector<art::Ptr<recob::SpacePoint>> showerSpacePoints = fmspp.at(pfp.key());
 
     // Check the pfp has at least 1 cluster (i.e. not a pfp neutrino)
-    if (!showerClusters.size())
-      continue;
+    if (!showerClusters.size()) continue;
 
-    if (fVerbose>1)
-      mf::LogInfo("LArPandoraModularShowerCreation") << "Running on shower: " << shower_iter << std::endl;
+    if (fVerbose > 1)
+      mf::LogInfo("LArPandoraModularShowerCreation")
+        << "Running on shower: " << shower_iter << std::endl;
 
     //Calculate the shower properties
     //Loop over the shower tools
     int err = 0;
-    for (unsigned int i=0; i<fShowerTools.size(); i++) {
+    for (unsigned int i = 0; i < fShowerTools.size(); i++) {
 
       //Calculate the metric
-      if (fVerbose>1)
-        mf::LogInfo("LArPandoraModularShowerCreation") << "Running shower tool: " << fShowerToolNames[i] << std::endl;
-      std::string evd_disp_append = fShowerToolNames[i] + "_iteration" + std::to_string(0) + "_" + this->moduleDescription().moduleLabel();
+      if (fVerbose > 1)
+        mf::LogInfo("LArPandoraModularShowerCreation")
+          << "Running shower tool: " << fShowerToolNames[i] << std::endl;
+      std::string evd_disp_append = fShowerToolNames[i] + "_iteration" + std::to_string(0) + "_" +
+                                    this->moduleDescription().moduleLabel();
 
       err = fShowerTools[i]->RunShowerTool(pfp, evt, showerEleHolder, evd_disp_append);
 
       if (err && fVerbose) {
-        mf::LogError("LArPandoraModularShowerCreation") << "Error in shower tool: " << fShowerToolNames[i]
-                                                        << " with code: " << err << std::endl;
+        mf::LogError("LArPandoraModularShowerCreation")
+          << "Error in shower tool: " << fShowerToolNames[i] << " with code: " << err << std::endl;
       }
     }
 
@@ -268,43 +279,43 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
       if (!showerEleHolder.CheckElement(fShowerStartPositionLabel)) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "The start position is not set in the element holder. bailing" << std::endl;
+            << "The start position is not set in the element holder. bailing" << std::endl;
         continue;
       }
       if (!showerEleHolder.CheckElement(fShowerDirectionLabel)) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "The direction is not set in the element holder. bailing" << std::endl;
+            << "The direction is not set in the element holder. bailing" << std::endl;
         continue;
       }
       if (!showerEleHolder.CheckElement(fShowerEnergyLabel)) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "The energy is not set in the element holder. bailing" << std::endl;
+            << "The energy is not set in the element holder. bailing" << std::endl;
         continue;
       }
       if (!showerEleHolder.CheckElement(fShowerdEdxLabel)) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "The dEdx is not set in the element holder. bailing" << std::endl;
+            << "The dEdx is not set in the element holder. bailing" << std::endl;
         continue;
       }
       if (!showerEleHolder.CheckElement(fShowerBestPlaneLabel)) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "The BestPlane is not set in the element holder. bailing" << std::endl;
+            << "The BestPlane is not set in the element holder. bailing" << std::endl;
         continue;
       }
       if (!showerEleHolder.CheckElement(fShowerLengthLabel)) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "The length is not set in the element holder. bailing" << std::endl;
+            << "The length is not set in the element holder. bailing" << std::endl;
         continue;
       }
       if (!showerEleHolder.CheckElement(fShowerOpeningAngleLabel)) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "The opening angle is not set in the element holder. bailing" << std::endl;
+            << "The opening angle is not set in the element holder. bailing" << std::endl;
         continue;
       }
 
@@ -313,7 +324,8 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
       if (!elements_are_set) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "Not all the elements in the property holder which should be set are not. Bailing. " << std::endl;
+            << "Not all the elements in the property holder which should be set are not. Bailing. "
+            << std::endl;
         continue;
       }
 
@@ -322,7 +334,9 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
       if (!producers_are_set) {
         if (fVerbose)
           mf::LogError("LArPandoraModularShowerCreation")
-              << "Not all the elements in the property holder which are produced are not set. Bailing. " << std::endl;
+            << "Not all the elements in the property holder which are produced are not set. "
+               "Bailing. "
+            << std::endl;
         continue;
       }
     }
@@ -343,9 +357,11 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
 
     err = 0;
     if (showerEleHolder.CheckElement(fShowerStartPositionLabel))
-      err += showerEleHolder.GetElementAndError(fShowerStartPositionLabel, ShowerStartPosition, ShowerStartPositionErr);
+      err += showerEleHolder.GetElementAndError(
+        fShowerStartPositionLabel, ShowerStartPosition, ShowerStartPositionErr);
     if (showerEleHolder.CheckElement(fShowerDirectionLabel))
-      err += showerEleHolder.GetElementAndError(fShowerDirectionLabel, ShowerDirection, ShowerDirectionErr);
+      err += showerEleHolder.GetElementAndError(
+        fShowerDirectionLabel, ShowerDirection, ShowerDirectionErr);
     if (showerEleHolder.CheckElement(fShowerEnergyLabel))
       err += showerEleHolder.GetElementAndError(fShowerEnergyLabel, ShowerEnergy, ShowerEnergyErr);
     if (showerEleHolder.CheckElement(fShowerdEdxLabel))
@@ -359,15 +375,17 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
 
     if (err) {
       throw cet::exception("LArPandoraModularShowerCreation")
-          << "Error in LArPandoraModularShowerCreation Module. A Check on a shower property failed " << std::endl;
+        << "Error in LArPandoraModularShowerCreation Module. A Check on a shower property failed "
+        << std::endl;
     }
 
     if (fVerbose > 1) {
       //Check the shower
-      std::cout << "Shower Vertex: X:" << ShowerStartPosition.X() << " Y: "
-                << ShowerStartPosition.Y() << " Z: " << ShowerStartPosition.Z() << std::endl;
-      std::cout << "Shower Direction: X:" << ShowerDirection.X() << " Y: "
-                << ShowerDirection.Y() << " Z: " << ShowerDirection.Z() << std::endl;
+      std::cout << "Shower Vertex: X:" << ShowerStartPosition.X()
+                << " Y: " << ShowerStartPosition.Y() << " Z: " << ShowerStartPosition.Z()
+                << std::endl;
+      std::cout << "Shower Direction: X:" << ShowerDirection.X() << " Y: " << ShowerDirection.Y()
+                << " Z: " << ShowerDirection.Z() << std::endl;
       std::cout << "Shower dEdx:";
       for (unsigned int i = 0; i < fNumPlanes; i++) {
         std::cout << " Plane " << i << ": " << ShowerdEdx.at(i);
@@ -388,39 +406,56 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
 
     if (ShowerdEdx.size() != fNumPlanes) {
       throw cet::exception("LArPandoraModularShowerCreation")
-          << "dEdx vector is wrong size: " << ShowerdEdx.size() << " compared to Nplanes: " << fNumPlanes << std::endl;
+        << "dEdx vector is wrong size: " << ShowerdEdx.size()
+        << " compared to Nplanes: " << fNumPlanes << std::endl;
     }
     if (ShowerEnergy.size() != fNumPlanes) {
       throw cet::exception("LArPandoraModularShowerCreation")
-          << "Energy vector is wrong size: " << ShowerEnergy.size() << " compared to Nplanes: " << fNumPlanes << std::endl;
+        << "Energy vector is wrong size: " << ShowerEnergy.size()
+        << " compared to Nplanes: " << fNumPlanes << std::endl;
     }
 
     //Make the shower
-    recob::Shower shower(ShowerDirection, ShowerDirectionErr, ShowerStartPosition, ShowerDirectionErr,
-        ShowerEnergy, ShowerEnergyErr, ShowerdEdx, ShowerdEdxErr, BestPlane, util::kBogusI, ShowerLength, ShowerOpeningAngle);
+    recob::Shower shower(ShowerDirection,
+                         ShowerDirectionErr,
+                         ShowerStartPosition,
+                         ShowerDirectionErr,
+                         ShowerEnergy,
+                         ShowerEnergyErr,
+                         ShowerdEdx,
+                         ShowerdEdxErr,
+                         BestPlane,
+                         util::kBogusI,
+                         ShowerLength,
+                         ShowerOpeningAngle);
     showerEleHolder.SetElement(shower, "shower");
     ++shower_iter;
-    art::Ptr<recob::Shower> ShowerPtr = this->GetProducedElementPtr<recob::Shower>("shower", showerEleHolder);
+    art::Ptr<recob::Shower> ShowerPtr =
+      this->GetProducedElementPtr<recob::Shower>("shower", showerEleHolder);
 
     //Associate the pfparticle
-    uniqueproducerPtrs.AddSingle<art::Assns<recob::Shower, recob::PFParticle>>(ShowerPtr, pfp, "pfShowerAssociationsbase");
+    uniqueproducerPtrs.AddSingle<art::Assns<recob::Shower, recob::PFParticle>>(
+      ShowerPtr, pfp, "pfShowerAssociationsbase");
 
     //Add the hits for each "cluster"
     for (auto const& cluster : showerClusters) {
 
       //Associate the clusters
       std::vector<art::Ptr<recob::Hit>> ClusterHits = fmh.at(cluster.key());
-      uniqueproducerPtrs.AddSingle<art::Assns<recob::Shower, recob::Cluster>>(ShowerPtr, cluster, "clusterAssociationsbase");
+      uniqueproducerPtrs.AddSingle<art::Assns<recob::Shower, recob::Cluster>>(
+        ShowerPtr, cluster, "clusterAssociationsbase");
 
       //Associate the hits
       for (auto const& hit : ClusterHits) {
-        uniqueproducerPtrs.AddSingle<art::Assns<recob::Shower, recob::Hit>>(ShowerPtr, hit, "hitAssociationsbase");
+        uniqueproducerPtrs.AddSingle<art::Assns<recob::Shower, recob::Hit>>(
+          ShowerPtr, hit, "hitAssociationsbase");
       }
     }
 
     //Associate the spacepoints
     for (auto const& sp : showerSpacePoints) {
-      uniqueproducerPtrs.AddSingle<art::Assns<recob::Shower, recob::SpacePoint>>(ShowerPtr, sp, "spShowerAssociationsbase");
+      uniqueproducerPtrs.AddSingle<art::Assns<recob::Shower, recob::SpacePoint>>(
+        ShowerPtr, sp, "spShowerAssociationsbase");
     }
 
     //Loop over the tool data products and add them.
@@ -435,7 +470,9 @@ void reco::shower::LArPandoraModularShowerCreation::produce(art::Event& evt)
     if (!fAllowPartialShowers && assn_err > 0) {
       if (fVerbose)
         mf::LogError("LArPandoraModularShowerCreation")
-            << "A association failed and not allowing partial showers. The association will not be added to the event " << std::endl;
+          << "A association failed and not allowing partial showers. The association will not be "
+             "added to the event "
+          << std::endl;
     }
 
     //Reset the showerproperty holder.

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/LArPandoraShowerCreation_module.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/LArPandoraShowerCreation_module.cc
@@ -53,7 +53,6 @@ namespace lar_pandora {
 
     std::string m_pfParticleLabel; ///< The pf particle label
     bool m_useAllParticles;        ///< Build a recob::Track for every recob::PFParticle
-
   };
 
   DEFINE_ART_MODULE(LArPandoraShowerCreation)

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerDirectionCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerDirectionCheater_tool.cc
@@ -9,127 +9,131 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h"
 #include "lardataobj/RecoBase/Cluster.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace ShowerRecoTools {
 
-  class ShowerDirectionCheater:IShowerTool {
+  class ShowerDirectionCheater : IShowerTool {
 
-    public:
+  public:
+    ShowerDirectionCheater(const fhicl::ParameterSet& pset);
 
-      ShowerDirectionCheater(const fhicl::ParameterSet& pset);
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
+  private:
+    //Algorithm functions
+    shower::LArPandoraShowerCheatingAlg fLArPandoraShowerCheatingAlg;
 
-    private:
+    //Services
+    art::ServiceHandle<art::TFileService> tfs;
 
-      //Algorithm functions
-      shower::LArPandoraShowerCheatingAlg fLArPandoraShowerCheatingAlg;
+    //fcl
+    const art::InputTag fPFParticleLabel;
+    const unsigned int
+      fNSegments;        //Number of segement to split the shower into the perforam the RMSFlip.
+    const bool fRMSFlip; //Flip the direction by considering the rms.
+    const bool
+      fVertexFlip; //Flip the direction by considering the vertex position relative to the center position.
 
-      //Services
-      art::ServiceHandle<art::TFileService> tfs;
+    //TTree Branch variables
+    TTree* Tree;
+    float vertexDotProduct;
+    float rmsGradient;
 
-      //fcl
-      const art::InputTag fPFParticleLabel;
-      const unsigned int fNSegments; //Number of segement to split the shower into the perforam the RMSFlip.
-      const bool fRMSFlip;    //Flip the direction by considering the rms.
-      const bool fVertexFlip; //Flip the direction by considering the vertex position relative to the center position.
-
-      //TTree Branch variables
-      TTree* Tree;
-      float vertexDotProduct;
-      float rmsGradient;
-
-      const std::string fShowerStartPositionInputLabel;
-      const std::string fTrueParticleInputLabel;
-      const std::string fShowerDirectionOutputLabel;
-
+    const std::string fShowerStartPositionInputLabel;
+    const std::string fTrueParticleInputLabel;
+    const std::string fShowerDirectionOutputLabel;
   };
 
-
-  ShowerDirectionCheater::ShowerDirectionCheater(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fLArPandoraShowerCheatingAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fNSegments(pset.get<unsigned int>("NSegments")),
-    fRMSFlip(pset.get<bool>("RMSFlip")),
-    fVertexFlip(pset.get<bool>("VertexFlip")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fTrueParticleInputLabel(pset.get<std::string>("TrueParticleInputLabel")),
-    fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  ShowerDirectionCheater::ShowerDirectionCheater(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fLArPandoraShowerCheatingAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fNSegments(pset.get<unsigned int>("NSegments"))
+    , fRMSFlip(pset.get<bool>("RMSFlip"))
+    , fVertexFlip(pset.get<bool>("VertexFlip"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fTrueParticleInputLabel(pset.get<std::string>("TrueParticleInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
   {
-    if (fVertexFlip || fRMSFlip){
+    if (fVertexFlip || fRMSFlip) {
       Tree = tfs->make<TTree>("DebugTreeDirCheater", "DebugTree from shower direction cheater");
-      if (fVertexFlip) Tree->Branch("vertexDotProduct",&vertexDotProduct);
-      if (fRMSFlip)    Tree->Branch("rmsGradient",&rmsGradient);
+      if (fVertexFlip) Tree->Branch("vertexDotProduct", &vertexDotProduct);
+      if (fRMSFlip) Tree->Branch("rmsGradient", &rmsGradient);
     }
   }
 
-  int ShowerDirectionCheater::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
-
+  int
+  ShowerDirectionCheater::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                           art::Event& Event,
+                                           reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     const simb::MCParticle* trueParticle;
 
     //Get the hits from the shower:
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
-    if (ShowerEleHolder.CheckElement(fTrueParticleInputLabel)){
-      ShowerEleHolder.GetElement(fTrueParticleInputLabel,trueParticle);
-    } else {
+    if (ShowerEleHolder.CheckElement(fTrueParticleInputLabel)) {
+      ShowerEleHolder.GetElement(fTrueParticleInputLabel, trueParticle);
+    }
+    else {
 
       //Could store these in the shower element holder and just calculate once?
-      std::map<int,const simb::MCParticle*> trueParticles = fLArPandoraShowerCheatingAlg.GetTrueParticleMap();
-      std::map<int,std::vector<int> > showersMothers = fLArPandoraShowerCheatingAlg.GetTrueChain(trueParticles);
+      std::map<int, const simb::MCParticle*> trueParticles =
+        fLArPandoraShowerCheatingAlg.GetTrueParticleMap();
+      std::map<int, std::vector<int>> showersMothers =
+        fLArPandoraShowerCheatingAlg.GetTrueChain(trueParticles);
 
       //Get the clusters
-      auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster> >(fPFParticleLabel);
+      auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster>>(fPFParticleLabel);
       art::FindManyP<recob::Cluster> fmc(pfpHandle, Event, fPFParticleLabel);
-      std::vector<art::Ptr<recob::Cluster> > clusters = fmc.at(pfparticle.key());
+      std::vector<art::Ptr<recob::Cluster>> clusters = fmc.at(pfparticle.key());
 
       //Get the hit association
       art::FindManyP<recob::Hit> fmhc(clusHandle, Event, fPFParticleLabel);
 
-      std::vector<art::Ptr<recob::Hit> > showerHits;
-      for(auto const& cluster: clusters){
+      std::vector<art::Ptr<recob::Hit>> showerHits;
+      for (auto const& cluster : clusters) {
         //Get the hits
-        std::vector<art::Ptr<recob::Hit> > hits = fmhc.at(cluster.key());
-        showerHits.insert(showerHits.end(),hits.begin(),hits.end());
+        std::vector<art::Ptr<recob::Hit>> hits = fmhc.at(cluster.key());
+        showerHits.insert(showerHits.end(), hits.begin(), hits.end());
       }
 
       //Get the true particle from the shower
-      std::pair<int,double> ShowerTrackInfo = fLArPandoraShowerCheatingAlg.TrueParticleIDFromTrueChain(clockData,
-          showersMothers,showerHits,2);
+      std::pair<int, double> ShowerTrackInfo =
+        fLArPandoraShowerCheatingAlg.TrueParticleIDFromTrueChain(
+          clockData, showersMothers, showerHits, 2);
 
-      if(ShowerTrackInfo.first==-99999) {
+      if (ShowerTrackInfo.first == -99999) {
         mf::LogError("ShowerDirectionCheater") << "True shower not found, returning";
         return 1;
       }
       trueParticle = trueParticles[ShowerTrackInfo.first];
-      ShowerEleHolder.SetElement(trueParticle,fTrueParticleInputLabel);
+      ShowerEleHolder.SetElement(trueParticle, fTrueParticleInputLabel);
     }
 
-    if (!trueParticle){
+    if (!trueParticle) {
       mf::LogError("ShowerDirectionCheater") << "True shower not found, returning";
       return 1;
     }
 
-    TVector3 trueDir = TVector3{trueParticle->Px(),trueParticle->Py(),trueParticle->Pz()}.Unit();
+    TVector3 trueDir = TVector3{trueParticle->Px(), trueParticle->Py(), trueParticle->Pz()}.Unit();
 
-    TVector3 trueDirErr = {-999,-999,-999};
-    ShowerEleHolder.SetElement(trueDir,trueDirErr,fShowerDirectionOutputLabel);
+    TVector3 trueDirErr = {-999, -999, -999};
+    ShowerEleHolder.SetElement(trueDir, trueDirErr, fShowerDirectionOutputLabel);
 
-    if (fRMSFlip || fVertexFlip){
+    if (fRMSFlip || fVertexFlip) {
 
       // Reset the tree values to defaults
       rmsGradient = std::numeric_limits<float>::lowest();
@@ -138,33 +142,38 @@ namespace ShowerRecoTools {
       //Get the SpacePoints and hits
       art::FindManyP<recob::SpacePoint> fmspp(pfpHandle, Event, fPFParticleLabel);
 
-      if (!fmspp.isValid()){
-        throw cet::exception("ShowerDirectionCheater") << "Trying to get the spacepoint and failed. Something is not configured correctly. Stopping ";
+      if (!fmspp.isValid()) {
+        throw cet::exception("ShowerDirectionCheater")
+          << "Trying to get the spacepoint and failed. Something is not configured correctly. "
+             "Stopping ";
       }
 
-      auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
+      auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
       art::FindManyP<recob::Hit> fmh(spHandle, Event, fPFParticleLabel);
-      if(!fmh.isValid()){
-        throw cet::exception("ShowerDirectionCheater") << "Spacepoint and hit association not valid. Stopping.";
+      if (!fmh.isValid()) {
+        throw cet::exception("ShowerDirectionCheater")
+          << "Spacepoint and hit association not valid. Stopping.";
       }
-      std::vector<art::Ptr<recob::SpacePoint> > spacePoints = fmspp.at(pfparticle.key());
+      std::vector<art::Ptr<recob::SpacePoint>> spacePoints = fmspp.at(pfparticle.key());
 
       if (spacePoints.size() < 3) {
-        mf::LogWarning("ShowerDirectionCheater") << spacePoints.size() << " spacepoints in shower, not calculating direction" << std::endl;
+        mf::LogWarning("ShowerDirectionCheater")
+          << spacePoints.size() << " spacepoints in shower, not calculating direction" << std::endl;
         return 1;
       }
 
       //Get Shower Centre
       float TotalCharge;
 
-      const TVector3 ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, spacePoints, fmh, TotalCharge);
+      const TVector3 ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(
+        clockData, detProp, spacePoints, fmh, TotalCharge);
 
       //Check if we are pointing the correct direction or not, First try the start position
-      if(ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel) && fVertexFlip){
+      if (ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel) && fVertexFlip) {
 
         //Get the General direction as the vector between the start position and the centre
         TVector3 StartPositionVec = {-999, -999, -999};
-        ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,StartPositionVec);
+        ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPositionVec);
 
         TVector3 GeneralDir = (ShowerCentre - StartPositionVec).Unit();
 
@@ -172,9 +181,10 @@ namespace ShowerRecoTools {
         vertexDotProduct = trueDir.Dot(GeneralDir);
       }
 
-      if (fRMSFlip){
+      if (fRMSFlip) {
         //Otherwise Check against the RMS of the shower. Method adapated from EMShower Thanks Mike.
-        rmsGradient = IShowerTool::GetLArPandoraShowerAlg().RMSShowerGradient(spacePoints,ShowerCentre,trueDir, fNSegments);
+        rmsGradient = IShowerTool::GetLArPandoraShowerAlg().RMSShowerGradient(
+          spacePoints, ShowerCentre, trueDir, fNSegments);
       }
       Tree->Fill();
     }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerStartPositionCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerStartPositionCheater_tool.cc
@@ -9,112 +9,115 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h"
 #include "lardataobj/RecoBase/Cluster.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace ShowerRecoTools {
 
-  class ShowerStartPositionCheater:IShowerTool {
+  class ShowerStartPositionCheater : IShowerTool {
 
-    public:
+  public:
+    ShowerStartPositionCheater(const fhicl::ParameterSet& pset);
 
-      ShowerStartPositionCheater(const fhicl::ParameterSet& pset);
+    //Calculate Cheating Start Position
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Calculate Cheating Start Position
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+  private:
+    //Algorithm functions
+    shower::LArPandoraShowerCheatingAlg fLArPandoraShowerCheatingAlg;
 
-    private:
+    //FCL
+    const art::InputTag fPFParticleLabel;
+    const art::InputTag fHitModuleLabel;
 
-      //Algorithm functions
-      shower::LArPandoraShowerCheatingAlg fLArPandoraShowerCheatingAlg;
-
-      //FCL
-      const art::InputTag fPFParticleLabel;
-      const art::InputTag fHitModuleLabel;
-
-      const std::string fShowerStartPositionOutputLabel;
-      const std::string fTrueParticleOutputLabel;
+    const std::string fShowerStartPositionOutputLabel;
+    const std::string fTrueParticleOutputLabel;
   };
 
+  ShowerStartPositionCheater::ShowerStartPositionCheater(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fLArPandoraShowerCheatingAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel"))
+    , fShowerStartPositionOutputLabel(pset.get<std::string>("ShowerStartPositionOutputLabel"))
+    , fTrueParticleOutputLabel(pset.get<std::string>("TrueParticleOutputLabel"))
+  {}
 
-  ShowerStartPositionCheater::ShowerStartPositionCheater(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fLArPandoraShowerCheatingAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel")),
-    fShowerStartPositionOutputLabel(pset.get<std::string>("ShowerStartPositionOutputLabel")),
-    fTrueParticleOutputLabel(pset.get<std::string>("TrueParticleOutputLabel"))
+  int
+  ShowerStartPositionCheater::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                               art::Event& Event,
+                                               reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int ShowerStartPositionCheater::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     //Could store these in the shower element holder and just calculate once?
-    std::map<int,const simb::MCParticle*> trueParticles = fLArPandoraShowerCheatingAlg.GetTrueParticleMap();
-    std::map<int,std::vector<int> > showersMothers = fLArPandoraShowerCheatingAlg.GetTrueChain(trueParticles);
+    std::map<int, const simb::MCParticle*> trueParticles =
+      fLArPandoraShowerCheatingAlg.GetTrueParticleMap();
+    std::map<int, std::vector<int>> showersMothers =
+      fLArPandoraShowerCheatingAlg.GetTrueChain(trueParticles);
 
     //Get the hits from the shower:
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
     //Get the clusters
-    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster> >(fPFParticleLabel);
+    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster>>(fPFParticleLabel);
 
     art::FindManyP<recob::Cluster> fmc(pfpHandle, Event, fPFParticleLabel);
-    std::vector<art::Ptr<recob::Cluster> > clusters = fmc.at(pfparticle.key());
+    std::vector<art::Ptr<recob::Cluster>> clusters = fmc.at(pfparticle.key());
 
     //Get the hit association
     art::FindManyP<recob::Hit> fmhc(clusHandle, Event, fPFParticleLabel);
 
-    std::vector<art::Ptr<recob::Hit> > showerHits;
-    for(auto const& cluster: clusters){
+    std::vector<art::Ptr<recob::Hit>> showerHits;
+    for (auto const& cluster : clusters) {
 
       //Get the hits
-      std::vector<art::Ptr<recob::Hit> > hits = fmhc.at(cluster.key());
-      showerHits.insert(showerHits.end(),hits.begin(),hits.end());
+      std::vector<art::Ptr<recob::Hit>> hits = fmhc.at(cluster.key());
+      showerHits.insert(showerHits.end(), hits.begin(), hits.end());
     }
 
     //Get the true particle from the shower
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
 
-    std::pair<int,double> ShowerTrackInfo = fLArPandoraShowerCheatingAlg.TrueParticleIDFromTrueChain(clockData,
-        showersMothers,showerHits,2);
+    std::pair<int, double> ShowerTrackInfo =
+      fLArPandoraShowerCheatingAlg.TrueParticleIDFromTrueChain(
+        clockData, showersMothers, showerHits, 2);
 
-    if(ShowerTrackInfo.first==-99999) {
+    if (ShowerTrackInfo.first == -99999) {
       mf::LogError("ShowerStartPositionCheater") << "True Shower Not Found";
       return 1;
     }
 
     const simb::MCParticle* trueParticle = trueParticles[ShowerTrackInfo.first];
-    if (!trueParticle){
+    if (!trueParticle) {
       mf::LogError("ShowerDirectionCheater") << "True shower not found, returning";
       return 1;
     }
 
-    ShowerEleHolder.SetElement(trueParticle,fTrueParticleOutputLabel);
+    ShowerEleHolder.SetElement(trueParticle, fTrueParticleOutputLabel);
 
-    TVector3 trueStartPos = {-999,-999,-999};
+    TVector3 trueStartPos = {-999, -999, -999};
     // If the true particle is a photon, we need to be smarter.
     // Select the first traj point where tne photon loses energy
-    if (abs(trueParticle->PdgCode()) == 22){
+    if (abs(trueParticle->PdgCode()) == 22) {
       double initialEnergy = trueParticle->E();
       unsigned int TrajPoints = trueParticle->NumberTrajectoryPoints();
-      for (unsigned int trajPoint=0; trajPoint<TrajPoints; trajPoint++){
-        if (trueParticle->E(trajPoint) < initialEnergy){
+      for (unsigned int trajPoint = 0; trajPoint < TrajPoints; trajPoint++) {
+        if (trueParticle->E(trajPoint) < initialEnergy) {
           trueStartPos = trueParticle->Position(trajPoint).Vect();
           break;
         }
       }
-    } else {
+    }
+    else {
       trueStartPos = trueParticle->Position().Vect();
     }
 
-    TVector3 trueStartPosErr = {-999,-999,-999};
-    ShowerEleHolder.SetElement(trueStartPos,trueStartPosErr,fShowerStartPositionOutputLabel);
+    TVector3 trueStartPosErr = {-999, -999, -999};
+    ShowerEleHolder.SetElement(trueStartPos, trueStartPosErr, fShowerStartPositionOutputLabel);
 
     return 0;
   }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerTrackFinderCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerTrackFinderCheater_tool.cc
@@ -9,178 +9,180 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h"
 #include "lardataobj/RecoBase/Cluster.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerCheatingAlg.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace ShowerRecoTools {
 
-  class ShowerTrackFinderCheater:IShowerTool {
+  class ShowerTrackFinderCheater : IShowerTool {
 
-    public:
+  public:
+    ShowerTrackFinderCheater(const fhicl::ParameterSet& pset);
 
-      ShowerTrackFinderCheater(const fhicl::ParameterSet& pset);
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+  private:
+    //Algorithm functions
+    shower::LArPandoraShowerCheatingAlg fLArPandoraShowerCheatingAlg;
 
-    private:
+    //fcl
+    const bool fDebugEVD;
+    const art::InputTag fPFParticleLabel;
+    const art::InputTag fHitModuleLabel;
 
-      //Algorithm functions
-      shower::LArPandoraShowerCheatingAlg fLArPandoraShowerCheatingAlg;
-
-
-      //fcl
-      const bool fDebugEVD;
-      const art::InputTag fPFParticleLabel;
-      const art::InputTag fHitModuleLabel;
-
-      const std::string fTrueParticleIntputLabel;
-      const std::string fShowerStartPositionInputTag;
-      const std::string fShowerDirectionInputTag;
-      const std::string fInitialTrackHitsOutputLabel;
-      const std::string fInitialTrackSpacePointsOutputLabel;
+    const std::string fTrueParticleIntputLabel;
+    const std::string fShowerStartPositionInputTag;
+    const std::string fShowerDirectionInputTag;
+    const std::string fInitialTrackHitsOutputLabel;
+    const std::string fInitialTrackSpacePointsOutputLabel;
   };
 
+  ShowerTrackFinderCheater::ShowerTrackFinderCheater(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fLArPandoraShowerCheatingAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg"))
+    , fDebugEVD(pset.get<bool>("DebugEVD"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel"))
+    , fTrueParticleIntputLabel(pset.get<std::string>("TrueParticleIntputLabel"))
+    , fShowerStartPositionInputTag(pset.get<std::string>("ShowerStartPositionInputTag"))
+    , fShowerDirectionInputTag(pset.get<std::string>("ShowerDirectionInputTag"))
+    , fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel"))
+    , fInitialTrackSpacePointsOutputLabel(
+        pset.get<std::string>("InitialTrackSpacePointsOutputLabel"))
+  {}
 
-  ShowerTrackFinderCheater::ShowerTrackFinderCheater(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fLArPandoraShowerCheatingAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerCheatingAlg")),
-    fDebugEVD(pset.get<bool>("DebugEVD")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel")),
-    fTrueParticleIntputLabel(pset.get<std::string>("TrueParticleIntputLabel")),
-    fShowerStartPositionInputTag(pset.get<std::string>("ShowerStartPositionInputTag")),
-    fShowerDirectionInputTag(pset.get<std::string>("ShowerDirectionInputTag")),
-    fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel")),
-    fInitialTrackSpacePointsOutputLabel(pset.get<std::string>("InitialTrackSpacePointsOutputLabel"))
+  int
+  ShowerTrackFinderCheater::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                             art::Event& Event,
+                                             reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int ShowerTrackFinderCheater::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     const simb::MCParticle* trueParticle;
 
     //Get the hits from the shower:
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
 
     //Get the clusters
-    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster> >(fPFParticleLabel);
+    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster>>(fPFParticleLabel);
     art::FindManyP<recob::Cluster> fmc(pfpHandle, Event, fPFParticleLabel);
-    std::vector<art::Ptr<recob::Cluster> > clusters = fmc.at(pfparticle.key());
+    std::vector<art::Ptr<recob::Cluster>> clusters = fmc.at(pfparticle.key());
 
     //Get the hit association
     art::FindManyP<recob::Hit> fmhc(clusHandle, Event, fPFParticleLabel);
 
-    std::vector<art::Ptr<recob::Hit> > showerHits;
-    for(auto const& cluster: clusters){
+    std::vector<art::Ptr<recob::Hit>> showerHits;
+    for (auto const& cluster : clusters) {
 
       //Get the hits
-      std::vector<art::Ptr<recob::Hit> > hits = fmhc.at(cluster.key());
-      showerHits.insert(showerHits.end(),hits.begin(),hits.end());
+      std::vector<art::Ptr<recob::Hit>> hits = fmhc.at(cluster.key());
+      showerHits.insert(showerHits.end(), hits.begin(), hits.end());
     }
 
-    if (ShowerEleHolder.CheckElement(fTrueParticleIntputLabel)){
-      ShowerEleHolder.GetElement(fTrueParticleIntputLabel,trueParticle);
-    } else {
+    if (ShowerEleHolder.CheckElement(fTrueParticleIntputLabel)) {
+      ShowerEleHolder.GetElement(fTrueParticleIntputLabel, trueParticle);
+    }
+    else {
 
       //Could store these in the shower element holder and just calculate once?
-      std::map<int,const simb::MCParticle*> trueParticles = fLArPandoraShowerCheatingAlg.GetTrueParticleMap();
-      std::map<int,std::vector<int> > showersMothers = fLArPandoraShowerCheatingAlg.GetTrueChain(trueParticles);
+      std::map<int, const simb::MCParticle*> trueParticles =
+        fLArPandoraShowerCheatingAlg.GetTrueParticleMap();
+      std::map<int, std::vector<int>> showersMothers =
+        fLArPandoraShowerCheatingAlg.GetTrueChain(trueParticles);
 
       //Get the true particle from the shower
-      std::pair<int,double> ShowerTrackInfo = fLArPandoraShowerCheatingAlg.TrueParticleIDFromTrueChain(clockData,
-          showersMothers,showerHits,2);
+      std::pair<int, double> ShowerTrackInfo =
+        fLArPandoraShowerCheatingAlg.TrueParticleIDFromTrueChain(
+          clockData, showersMothers, showerHits, 2);
 
-      if(ShowerTrackInfo.first==-99999) {
+      if (ShowerTrackInfo.first == -99999) {
         mf::LogError("ShowerStartPosition") << "True Shower Not Found";
         return 1;
       }
       trueParticle = trueParticles[ShowerTrackInfo.first];
-      ShowerEleHolder.SetElement(trueParticle,fTrueParticleIntputLabel);
+      ShowerEleHolder.SetElement(trueParticle, fTrueParticleIntputLabel);
     }
 
-    if (!trueParticle){
+    if (!trueParticle) {
       mf::LogError("ShowerDirectionCheater") << "True shower not found, returning";
       return 1;
     }
 
     //This is all based on the shower vertex being known. If it is not lets not do the track
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputTag)){
-      mf::LogError("ShowerTrackFinderCheater") << "Start position not set, returning "<< std::endl;
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputTag)) {
+      mf::LogError("ShowerTrackFinderCheater") << "Start position not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fShowerDirectionInputTag)){
-      mf::LogError("ShowerTrackFinderCheater") << "Direction not set, returning "<< std::endl;
+    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputTag)) {
+      mf::LogError("ShowerTrackFinderCheater") << "Direction not set, returning " << std::endl;
       return 1;
     }
 
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputTag,ShowerStartPosition);
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputTag, ShowerStartPosition);
 
-    TVector3 ShowerDirection     = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerDirectionInputTag,ShowerDirection);
+    TVector3 ShowerDirection = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerDirectionInputTag, ShowerDirection);
 
-    auto const hitHandle = Event.getValidHandle<std::vector<recob::Hit> >(fHitModuleLabel);
+    auto const hitHandle = Event.getValidHandle<std::vector<recob::Hit>>(fHitModuleLabel);
 
     // Get the hits associated with the space points
     art::FindManyP<recob::SpacePoint> fmsph(hitHandle, Event, fPFParticleLabel);
-    if(!fmsph.isValid()){
-      throw cet::exception("ShowerTrackFinderCheater") << "Spacepoint and hit association not valid. Stopping.";
+    if (!fmsph.isValid()) {
+      throw cet::exception("ShowerTrackFinderCheater")
+        << "Spacepoint and hit association not valid. Stopping.";
     }
 
     std::vector<int> trueParticleIdVec;
 
     // If we have an electron, take the hits from the primary only
     // This will also cover the cases Pandora misclassify a track as a shower
-    if (trueParticle->PdgCode() != 22)
-    {
-      trueParticleIdVec.push_back(trueParticle->TrackId());
-    } else {
+    if (trueParticle->PdgCode() != 22) { trueParticleIdVec.push_back(trueParticle->TrackId()); }
+    else {
       // To check if we are rolling up showers, check the number of daughters the photon has
       const int nDaughters = trueParticle->NumberDaughters();
-      if (nDaughters == 0)
-      {
+      if (nDaughters == 0) {
         // If we roll up showers, we have no choice but to take all of the hits from the photon
         trueParticleIdVec.push_back(-trueParticle->TrackId());
-      } else {
+      }
+      else {
         // If we do not roll up the showers, take all of the primary daughters
-        for (int i=0; i<nDaughters; i++)
-        {
+        for (int i = 0; i < nDaughters; i++) {
           trueParticleIdVec.push_back(trueParticle->Daughter(i));
         }
       }
     }
 
-    std::vector<art::Ptr<recob::Hit> > trackHits;
-    std::vector<art::Ptr<recob::SpacePoint> > trackSpacePoints;
+    std::vector<art::Ptr<recob::Hit>> trackHits;
+    std::vector<art::Ptr<recob::SpacePoint>> trackSpacePoints;
 
     //Get the hits from the true particle
-    for (auto hit : showerHits){
+    for (auto hit : showerHits) {
       int trueHitId = fLArPandoraShowerCheatingAlg.TrueParticleID(clockData, hit);
-      if (std::find(trueParticleIdVec.cbegin(), trueParticleIdVec.cend(), trueHitId) != trueParticleIdVec.cend()){
+      if (std::find(trueParticleIdVec.cbegin(), trueParticleIdVec.cend(), trueHitId) !=
+          trueParticleIdVec.cend()) {
         trackHits.push_back(hit);
-        std::vector<art::Ptr<recob::SpacePoint> > sps = fmsph.at(hit.key());
-        if (sps.size() == 1){
-          trackSpacePoints.push_back(sps.front());
-        }
+        std::vector<art::Ptr<recob::SpacePoint>> sps = fmsph.at(hit.key());
+        if (sps.size() == 1) { trackSpacePoints.push_back(sps.front()); }
       }
     }
 
     if (trackHits.empty() || trackSpacePoints.empty())
-      mf::LogWarning("ShowerTrackFinderCheater") << "Creating intial track with " <<
-        trackHits.size() << " hits and " << trackSpacePoints.size() << " spacepoints" << std::endl;
+      mf::LogWarning("ShowerTrackFinderCheater")
+        << "Creating intial track with " << trackHits.size() << " hits and "
+        << trackSpacePoints.size() << " spacepoints" << std::endl;
 
     ShowerEleHolder.SetElement(trackHits, fInitialTrackHitsOutputLabel);
-    ShowerEleHolder.SetElement(trackSpacePoints,fInitialTrackSpacePointsOutputLabel);
+    ShowerEleHolder.SetElement(trackSpacePoints, fInitialTrackSpacePointsOutputLabel);
 
-    if (fDebugEVD){
-      fLArPandoraShowerCheatingAlg.CheatDebugEVD(clockData, trueParticle, Event, ShowerEleHolder, pfparticle);
+    if (fDebugEVD) {
+      fLArPandoraShowerCheatingAlg.CheatDebugEVD(
+        clockData, trueParticle, Event, ShowerEleHolder, pfparticle);
     }
 
     return 0;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h
@@ -10,150 +10,176 @@
 #define IShowerTool_H
 
 //Framwork Includes
-#include "fhiclcpp/ParameterSet.h"
-#include "canvas/Persistency/Common/Ptr.h"
-#include "art/Framework/Principal/Event.h"
 #include "art/Framework/Core/ProducesCollector.h"
+#include "art/Framework/Principal/Event.h"
 #include "art/Persistency/Common/PtrMaker.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "fhiclcpp/ParameterSet.h"
 
 //LArSoft Includes
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h"
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/ShowerElementHolder.hh"
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/ShowerProducedPtrsHolder.hh"
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h"
 
-namespace ShowerRecoTools{
-  class IShowerTool{
+namespace ShowerRecoTools {
+  class IShowerTool {
 
-    public:
+  public:
+    IShowerTool(const fhicl::ParameterSet& pset)
+      : fLArPandoraShowerAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerAlg"))
+      , fRunEventDisplay(pset.get<bool>("EnableEventDisplay")){};
 
-      IShowerTool(const fhicl::ParameterSet& pset) :
-        fLArPandoraShowerAlg(pset.get<fhicl::ParameterSet>("LArPandoraShowerAlg")),
-        fRunEventDisplay(pset.get<bool>("EnableEventDisplay")) {};
+    virtual ~IShowerTool() noexcept = default;
 
-      virtual ~IShowerTool() noexcept = default;
+    //Generic Elemnt Finder. Used to calculate thing about the shower.
+    virtual int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                 art::Event& Event,
+                                 reco::shower::ShowerElementHolder& ShowerEleHolder) = 0;
 
-      //Generic Elemnt Finder. Used to calculate thing about the shower.
-      virtual int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) = 0;
+    //Main function that runs the shower tool.  This includes running the derived function
+    //that calculates the shower element and also runs the event display if requested
+    int
+    RunShowerTool(const art::Ptr<recob::PFParticle>& pfparticle,
+                  art::Event& Event,
+                  reco::shower::ShowerElementHolder& ShowerEleHolder,
+                  std::string evd_display_name_append = "")
+    {
 
+      int calculation_status = CalculateElement(pfparticle, Event, ShowerEleHolder);
+      if (calculation_status != 0) return calculation_status;
+      if (fRunEventDisplay) {
+        IShowerTool::GetLArPandoraShowerAlg().DebugEVD(
+          pfparticle, Event, ShowerEleHolder, evd_display_name_append);
+      }
+      return calculation_status;
+    }
 
-      //Main function that runs the shower tool.  This includes running the derived function
-      //that calculates the shower element and also runs the event display if requested
-      int RunShowerTool(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder,
-          std::string evd_display_name_append=""
-          ){
+    //Function to initialise the producer i.e produces<std::vector<recob::Vertex> >(); commands go here.
+    virtual void
+    InitialiseProducers()
+    {}
 
-        int calculation_status = CalculateElement(pfparticle, Event, ShowerEleHolder);
-        if (calculation_status != 0) return calculation_status;
-        if (fRunEventDisplay){
-          IShowerTool::GetLArPandoraShowerAlg().DebugEVD(pfparticle,Event,ShowerEleHolder,evd_display_name_append);
-        }
-        return calculation_status;
+    //Set the point looking back at the producer module show we can make things in the module
+    void
+    SetPtr(art::ProducesCollector* collector)
+    {
+      collectorPtr = collector;
+    }
+
+    //Initialises the unique ptr holder so that the tool can access it behind the scenes.
+    void
+    InitaliseProducerPtr(reco::shower::ShowerProducedPtrsHolder& uniqueproducerPtrs)
+    {
+      UniquePtrs = &uniqueproducerPtrs;
+    }
+
+    //End function so the user can add associations
+    virtual int
+    AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                    art::Event& Event,
+                    reco::shower::ShowerElementHolder& ShowerEleHolder)
+    {
+      return 0;
+    }
+
+  protected:
+    const shower::LArPandoraShowerAlg&
+    GetLArPandoraShowerAlg() const
+    {
+      return fLArPandoraShowerAlg;
+    };
+
+  private:
+    //ptr to the holder of all the unique ptrs.
+    reco::shower::ShowerProducedPtrsHolder* UniquePtrs;
+
+    //Algorithm functions
+    shower::LArPandoraShowerAlg fLArPandoraShowerAlg;
+
+    //Flags
+    bool fRunEventDisplay;
+
+    art::ProducesCollector* collectorPtr;
+
+  protected:
+    //Function to return the art:ptr for the corrsponding index iter. This allows the user the make associations
+    template <class T>
+    art::Ptr<T>
+    GetProducedElementPtr(std::string Name,
+                          reco::shower::ShowerElementHolder& ShowerEleHolder,
+                          int iter = -1)
+    {
+
+      //Check the element has been set
+      bool check_element = ShowerEleHolder.CheckElement(Name);
+      if (!check_element) {
+        throw cet::exception("IShowerTool") << "tried to get a element that does not exist. Failed "
+                                               "at making the art ptr for Element: "
+                                            << Name << std::endl;
       }
 
-      //Function to initialise the producer i.e produces<std::vector<recob::Vertex> >(); commands go here.
-      virtual void InitialiseProducers(){}
-
-      //Set the point looking back at the producer module show we can make things in the module
-      void SetPtr(art::ProducesCollector* collector){
-        collectorPtr = collector;
+      //Check the unique ptr has been set.
+      bool check_ptr = UniquePtrs->CheckUniqueProduerPtr(Name);
+      if (!check_ptr) {
+        throw cet::exception("IShowerTool")
+          << "tried to get a ptr that does not exist. Failed at making the art ptr for Element"
+          << Name;
       }
 
-      //Initialises the unique ptr holder so that the tool can access it behind the scenes.
-      void InitaliseProducerPtr(reco::shower::ShowerProducedPtrsHolder& uniqueproducerPtrs){
-        UniquePtrs = &uniqueproducerPtrs;
+      //Check if the user has defined an index if not just use the current shower index/
+      int index;
+      if (iter != -1) { index = iter; }
+      else {
+        index = ShowerEleHolder.GetShowerNumber();
       }
 
-      //End function so the user can add associations
-      virtual int  AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder){return 0;}
+      //Make the ptr
+      return UniquePtrs->GetArtPtr<T>(Name, index);
+    }
 
-    protected:
-      const shower::LArPandoraShowerAlg& GetLArPandoraShowerAlg() const { return fLArPandoraShowerAlg; };
+    //Function so that the user can add products to the art event. This will set up the unique ptrs and the ptr makers required.
+    //Example: InitialiseProduct<std::vector<recob<vertex>>("MyVertex")
+    template <class T>
+    void
+    InitialiseProduct(std::string Name, std::string InstanceName = "")
+    {
 
-    private:
-
-      //ptr to the holder of all the unique ptrs.
-      reco::shower::ShowerProducedPtrsHolder* UniquePtrs;
-
-      //Algorithm functions
-      shower::LArPandoraShowerAlg fLArPandoraShowerAlg;
-
-      //Flags
-      bool fRunEventDisplay;
-
-      art::ProducesCollector* collectorPtr;
-
-    protected:
-
-      //Function to return the art:ptr for the corrsponding index iter. This allows the user the make associations
-      template <class T >
-        art::Ptr<T> GetProducedElementPtr(std::string Name, reco::shower::ShowerElementHolder& ShowerEleHolder, int iter=-1){
-
-          //Check the element has been set
-          bool check_element = ShowerEleHolder.CheckElement(Name);
-          if(!check_element){
-            throw cet::exception("IShowerTool") << "tried to get a element that does not exist. Failed at making the art ptr for Element: " << Name << std::endl;
-          }
-
-          //Check the unique ptr has been set.
-          bool check_ptr = UniquePtrs->CheckUniqueProduerPtr(Name);
-          if(!check_ptr){
-            throw cet::exception("IShowerTool") << "tried to get a ptr that does not exist. Failed at making the art ptr for Element" << Name;
-          }
-
-          //Check if the user has defined an index if not just use the current shower index/
-          int index;
-          if(iter != -1){
-            index = iter;
-          }
-          else{
-            index = ShowerEleHolder.GetShowerNumber();
-          }
-
-          //Make the ptr
-          return UniquePtrs->GetArtPtr<T>(Name,index);
-        }
-
-      //Function so that the user can add products to the art event. This will set up the unique ptrs and the ptr makers required.
-      //Example: InitialiseProduct<std::vector<recob<vertex>>("MyVertex")
-      template <class T>
-        void InitialiseProduct(std::string Name, std::string InstanceName=""){
-
-          if (collectorPtr == nullptr){
-            mf::LogWarning("IShowerTool") << "The art::ProducesCollector ptr has not been set";
-            return;
-          }
-
-          collectorPtr->produces<T>(InstanceName);
-          UniquePtrs->SetShowerUniqueProduerPtr(type<T>(),Name,InstanceName);
-        }
-
-
-      //Function so that the user can add assocations to the event.
-      //Example: AddSingle<art::Assn<recob::Vertex,recob::shower>((art::Ptr<recob::Vertex>) Vertex, (art::Prt<recob::shower>) Shower), "myassn")
-      template <class T,class A, class B>
-        void AddSingle(A& a, B& b, std::string Name){
-          UniquePtrs->AddSingle<T>(a,b,Name);
-        }
-
-      //Function to get the size of the vector, for the event,  that is held in the unique producer ptr that will be put in the event.
-      int GetVectorPtrSize(std::string Name){
-        return UniquePtrs->GetVectorPtrSize(Name);
+      if (collectorPtr == nullptr) {
+        mf::LogWarning("IShowerTool") << "The art::ProducesCollector ptr has not been set";
+        return;
       }
 
-      void PrintPtrs(){
-        UniquePtrs->PrintPtrs();
-      }
+      collectorPtr->produces<T>(InstanceName);
+      UniquePtrs->SetShowerUniqueProduerPtr(type<T>(), Name, InstanceName);
+    }
 
-      void PrintPtr(std::string Name){
-        UniquePtrs->PrintPtr(Name);
-      }
+    //Function so that the user can add assocations to the event.
+    //Example: AddSingle<art::Assn<recob::Vertex,recob::shower>((art::Ptr<recob::Vertex>) Vertex, (art::Prt<recob::shower>) Shower), "myassn")
+    template <class T, class A, class B>
+    void
+    AddSingle(A& a, B& b, std::string Name)
+    {
+      UniquePtrs->AddSingle<T>(a, b, Name);
+    }
 
+    //Function to get the size of the vector, for the event,  that is held in the unique producer ptr that will be put in the event.
+    int
+    GetVectorPtrSize(std::string Name)
+    {
+      return UniquePtrs->GetVectorPtrSize(Name);
+    }
+
+    void
+    PrintPtrs()
+    {
+      UniquePtrs->PrintPtrs();
+    }
+
+    void
+    PrintPtr(std::string Name)
+    {
+      UniquePtrs->PrintPtr(Name);
+    }
   };
 }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Shower2DLinearRegressionTrackHitFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Shower2DLinearRegressionTrackHitFinder_tool.cc
@@ -11,122 +11,126 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "lardataobj/RecoBase/Cluster.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
-namespace ShowerRecoTools{
+namespace ShowerRecoTools {
 
-  class Shower2DLinearRegressionTrackHitFinder:IShowerTool {
-    public:
+  class Shower2DLinearRegressionTrackHitFinder : IShowerTool {
+  public:
+    Shower2DLinearRegressionTrackHitFinder(const fhicl::ParameterSet& pset);
 
-      Shower2DLinearRegressionTrackHitFinder(const fhicl::ParameterSet& pset);
+    //Calculate the 2D initial track hits
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Calculate the 2D initial track hits
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
+  private:
+    //Function to find the
+    std::vector<art::Ptr<recob::Hit>> FindInitialTrackHits(
+      const detinfo::DetectorPropertiesData& detProp,
+      std::vector<art::Ptr<recob::Hit>>& hits);
 
-    private:
+    //Function to perform a weighted regression fit.
+    Int_t WeightedFit(const Int_t n,
+                      const Double_t* x,
+                      const Double_t* y,
+                      const Double_t* w,
+                      Double_t* parm);
 
-      //Function to find the
-      std::vector<art::Ptr<recob::Hit> > FindInitialTrackHits(
-          const detinfo::DetectorPropertiesData& detProp,
-          std::vector<art::Ptr<recob::Hit> >& hits);
-
-      //Function to perform a weighted regression fit.
-      Int_t WeightedFit(const Int_t n, const Double_t *x, const Double_t *y,
-          const Double_t *w,  Double_t *parm);
-
-      //fcl parameters
-      unsigned int               fNfitpass;           //Number of time to fit the straight
-      //line the hits.
-      std::vector<unsigned int>  fNfithits;           //Max number of hits to fit to.
-      std::vector<double>        fToler;              //Tolerance or each interaction.
-      //Defined as the perpendicualar
-      //distance from the best fit line.
-      bool                       fApplyChargeWeight;  //Apply charge weighting to the fit.
-      art::InputTag              fPFParticleLabel;
-      int                        fVerbose;
-      art::InputTag              fHitLabel;
-      std::string                fShowerStartPositionInputLabel;
-      std::string                fShowerDirectionInputLabel;
-      std::string                fInitialTrackHitsOutputLabel;
-      std::string                fInitialTrackSpacePointsOutputLabel;
+    //fcl parameters
+    unsigned int fNfitpass; //Number of time to fit the straight
+    //line the hits.
+    std::vector<unsigned int> fNfithits; //Max number of hits to fit to.
+    std::vector<double> fToler;          //Tolerance or each interaction.
+    //Defined as the perpendicualar
+    //distance from the best fit line.
+    bool fApplyChargeWeight; //Apply charge weighting to the fit.
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
+    art::InputTag fHitLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionInputLabel;
+    std::string fInitialTrackHitsOutputLabel;
+    std::string fInitialTrackSpacePointsOutputLabel;
   };
 
-
   Shower2DLinearRegressionTrackHitFinder::Shower2DLinearRegressionTrackHitFinder(
-      const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fNfitpass(pset.get<unsigned int>("Nfitpass")),
-    fNfithits(pset.get<std::vector<unsigned int> >("Nfithits")),
-    fToler(pset.get<std::vector<double> >("Toler")),
-    fApplyChargeWeight(pset.get<bool>("ApplyChargeWeight")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fHitLabel(pset.get<art::InputTag>("HitsModuleLabel")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel")),
-    fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel")),
-    fInitialTrackSpacePointsOutputLabel(pset.get<std::string>("InitialTrackSpacePointsOutputLabel"))
+    const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fNfitpass(pset.get<unsigned int>("Nfitpass"))
+    , fNfithits(pset.get<std::vector<unsigned int>>("Nfithits"))
+    , fToler(pset.get<std::vector<double>>("Toler"))
+    , fApplyChargeWeight(pset.get<bool>("ApplyChargeWeight"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fHitLabel(pset.get<art::InputTag>("HitsModuleLabel"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+    , fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel"))
+    , fInitialTrackSpacePointsOutputLabel(
+        pset.get<std::string>("InitialTrackSpacePointsOutputLabel"))
   {
-    if (fNfitpass!=fNfithits.size() ||
-        fNfitpass!=fToler.size()) {
+    if (fNfitpass != fNfithits.size() || fNfitpass != fToler.size()) {
       throw art::Exception(art::errors::Configuration)
-        << "Shower2DLinearRegressionTrackHitFinderEMShower: fNfithits and fToler need to have size fNfitpass";
+        << "Shower2DLinearRegressionTrackHitFinderEMShower: fNfithits and fToler need to have size "
+           "fNfitpass";
     }
   }
 
-  int Shower2DLinearRegressionTrackHitFinder::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
+  int
+  Shower2DLinearRegressionTrackHitFinder::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //This is all based on the shower vertex being known. If it is not lets not do the track
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
         mf::LogError("Shower2DLinearRegressionTrackHitFinder")
-          << "Start position not set, returning "<< std::endl;
+          << "Start position not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)) {
       if (fVerbose)
         mf::LogError("Shower2DLinearRegressionTrackHitFinder")
-          << "Direction not set, returning "<< std::endl;
+          << "Direction not set, returning " << std::endl;
       return 1;
     }
 
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,ShowerStartPosition);
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, ShowerStartPosition);
 
-    TVector3 ShowerDirection     = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerDirectionInputLabel,ShowerDirection);
+    TVector3 ShowerDirection = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerDirectionInputLabel, ShowerDirection);
 
     // Get the assocated pfParicle vertex PFParticles
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
     //Get the clusters
-    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster> >(fPFParticleLabel);
+    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster>>(fPFParticleLabel);
 
-    const art::FindManyP<recob::Cluster>& fmc = ShowerEleHolder.GetFindManyP<recob::Cluster>
-      (pfpHandle, Event, fPFParticleLabel);
-    std::vector<art::Ptr<recob::Cluster> > clusters = fmc.at(pfparticle.key());
+    const art::FindManyP<recob::Cluster>& fmc =
+      ShowerEleHolder.GetFindManyP<recob::Cluster>(pfpHandle, Event, fPFParticleLabel);
+    std::vector<art::Ptr<recob::Cluster>> clusters = fmc.at(pfparticle.key());
 
-    if(clusters.size()<2){
+    if (clusters.size() < 2) {
       if (fVerbose)
         mf::LogError("Shower2DLinearRegressionTrackHitFinder")
-          << "Not enough clusters: "<<clusters.size() << std::endl;
+          << "Not enough clusters: " << clusters.size() << std::endl;
       return 1;
     }
 
     //Get the hit association
-    const art::FindManyP<recob::Hit>& fmhc = ShowerEleHolder.GetFindManyP<recob::Hit>
-      (clusHandle, Event, fPFParticleLabel);
-    std::map<geo::PlaneID, std::vector<art::Ptr<recob::Hit> > > plane_clusters;
+    const art::FindManyP<recob::Hit>& fmhc =
+      ShowerEleHolder.GetFindManyP<recob::Hit>(clusHandle, Event, fPFParticleLabel);
+    std::map<geo::PlaneID, std::vector<art::Ptr<recob::Hit>>> plane_clusters;
     //Loop over the clusters in the plane and get the hits
-    for(auto const& cluster: clusters){
+    for (auto const& cluster : clusters) {
 
       //Get the hits
-      std::vector<art::Ptr<recob::Hit> > hits = fmhc.at(cluster.key());
+      std::vector<art::Ptr<recob::Hit>> hits = fmhc.at(cluster.key());
 
       for (auto hit : hits) {
         geo::WireID wire = hit->WireID();
@@ -139,23 +143,26 @@ namespace ShowerRecoTools{
       //plane_clusters[plane].insert(plane_clusters[plane].end(),hits.begin(),hits.end());
     }
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
-    std::vector<art::Ptr<recob::Hit> > InitialTrackHits;
+    std::vector<art::Ptr<recob::Hit>> InitialTrackHits;
     //Loop over the clusters and order the hits and get the initial track hits in that plane
-    for(auto const& cluster: plane_clusters){
+    for (auto const& cluster : plane_clusters) {
 
       //Get the hits
-      std::vector<art::Ptr<recob::Hit> > hits = cluster.second;
+      std::vector<art::Ptr<recob::Hit>> hits = cluster.second;
 
       //Order the hits
-      IShowerTool::GetLArPandoraShowerAlg().OrderShowerHits(detProp, hits,ShowerStartPosition,ShowerDirection);
+      IShowerTool::GetLArPandoraShowerAlg().OrderShowerHits(
+        detProp, hits, ShowerStartPosition, ShowerDirection);
 
       //Find the initial track hits
-      std::vector<art::Ptr<recob::Hit> > trackhits = FindInitialTrackHits(detProp, hits);
+      std::vector<art::Ptr<recob::Hit>> trackhits = FindInitialTrackHits(detProp, hits);
 
-      InitialTrackHits.insert(InitialTrackHits.end(),trackhits.begin(),trackhits.end());
+      InitialTrackHits.insert(InitialTrackHits.end(), trackhits.begin(), trackhits.end());
     }
 
     //Holders for the initial track values.
@@ -163,17 +170,17 @@ namespace ShowerRecoTools{
 
     //Get the associated spacepoints
     //Get the hits
-    auto const hitHandle = Event.getValidHandle<std::vector<recob::Hit> >(fHitLabel);
+    auto const hitHandle = Event.getValidHandle<std::vector<recob::Hit>>(fHitLabel);
 
     //get the sp<->hit association
-    const art::FindManyP<recob::SpacePoint>& fmsp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>
-      (hitHandle,Event,fPFParticleLabel);
+    const art::FindManyP<recob::SpacePoint>& fmsp =
+      ShowerEleHolder.GetFindManyP<recob::SpacePoint>(hitHandle, Event, fPFParticleLabel);
 
     //Get the spacepoints associated to the track hit
-    std::vector<art::Ptr<recob::SpacePoint > > intitaltrack_sp;
-    for(auto const& hit: InitialTrackHits){
-      std::vector<art::Ptr<recob::SpacePoint > > sps = fmsp.at(hit.key());
-      for(auto const sp: sps){
+    std::vector<art::Ptr<recob::SpacePoint>> intitaltrack_sp;
+    for (auto const& hit : InitialTrackHits) {
+      std::vector<art::Ptr<recob::SpacePoint>> sps = fmsp.at(hit.key());
+      for (auto const sp : sps) {
         intitaltrack_sp.push_back(sp);
       }
     }
@@ -182,11 +189,13 @@ namespace ShowerRecoTools{
   }
 
   //Function to calculate the what are the initial tracks hits. Adapted from EMShower FindInitialTrackHits
-  std::vector<art::Ptr<recob::Hit> > Shower2DLinearRegressionTrackHitFinder::FindInitialTrackHits(
-      const detinfo::DetectorPropertiesData& detProp,
-      std::vector<art::Ptr<recob::Hit> >& hits){
+  std::vector<art::Ptr<recob::Hit>>
+  Shower2DLinearRegressionTrackHitFinder::FindInitialTrackHits(
+    const detinfo::DetectorPropertiesData& detProp,
+    std::vector<art::Ptr<recob::Hit>>& hits)
+  {
 
-    std::vector<art::Ptr<recob::Hit> > trackHits;
+    std::vector<art::Ptr<recob::Hit>> trackHits;
 
     double parm[2];
     int fitok = 0;
@@ -194,31 +203,34 @@ namespace ShowerRecoTools{
     std::vector<double> tfit;
     std::vector<double> cfit;
 
-    for (size_t i = 0; i<fNfitpass; ++i){
+    for (size_t i = 0; i < fNfitpass; ++i) {
 
       // Fit a straight line through hits
       unsigned int nhits = 0;
-      for (auto &hit: hits){
+      for (auto& hit : hits) {
 
         //Not sure I am a fan of doing things in wire tick space. What if id doesn't not iterate properly or the
         //two planes in each TPC are not symmetric.
         TVector2 coord = IShowerTool::GetLArPandoraShowerAlg().HitCoordinates(detProp, hit);
 
-        if (i==0||(std::abs((coord.Y()-(parm[0]+coord.X()*parm[1]))*std::cos(std::atan(parm[1])))<fToler[i-1])||fitok==1){
+        if (i == 0 ||
+            (std::abs((coord.Y() - (parm[0] + coord.X() * parm[1])) *
+                      std::cos(std::atan(parm[1]))) < fToler[i - 1]) ||
+            fitok == 1) {
           ++nhits;
-          if (nhits==fNfithits[i]+1) break;
+          if (nhits == fNfithits[i] + 1) break;
           wfit.push_back(coord.X());
           tfit.push_back(coord.Y());
 
-          if(fApplyChargeWeight) { cfit.push_back(hit->Integral());
-          } else { cfit.push_back(1.); };
-          if (i==fNfitpass-1) {
-            trackHits.push_back(hit);
-          }
+          if (fApplyChargeWeight) { cfit.push_back(hit->Integral()); }
+          else {
+            cfit.push_back(1.);
+          };
+          if (i == fNfitpass - 1) { trackHits.push_back(hit); }
         }
       }
 
-      if (i<fNfitpass-1&&wfit.size()){
+      if (i < fNfitpass - 1 && wfit.size()) {
         fitok = WeightedFit(wfit.size(), &wfit[0], &tfit[0], &cfit[0], &parm[0]);
       }
 
@@ -230,46 +242,51 @@ namespace ShowerRecoTools{
   }
 
   //Stolen from EMShowerAlg, a linear regression fitting function
-  Int_t Shower2DLinearRegressionTrackHitFinder::WeightedFit(const Int_t n, const Double_t *x, const Double_t *y, const Double_t *w,  Double_t *parm){
+  Int_t
+  Shower2DLinearRegressionTrackHitFinder::WeightedFit(const Int_t n,
+                                                      const Double_t* x,
+                                                      const Double_t* y,
+                                                      const Double_t* w,
+                                                      Double_t* parm)
+  {
 
-    Double_t sumx=0.;
-    Double_t sumx2=0.;
-    Double_t sumy=0.;
-    Double_t sumy2=0.;
-    Double_t sumxy=0.;
-    Double_t sumw=0.;
+    Double_t sumx = 0.;
+    Double_t sumx2 = 0.;
+    Double_t sumy = 0.;
+    Double_t sumy2 = 0.;
+    Double_t sumxy = 0.;
+    Double_t sumw = 0.;
     Double_t eparm[2];
 
-    parm[0]  = 0.;
-    parm[1]  = 0.;
+    parm[0] = 0.;
+    parm[1] = 0.;
     eparm[0] = 0.;
     eparm[1] = 0.;
 
-    for (Int_t i=0; i<n; i++) {
-      sumx += x[i]*w[i];
-      sumx2 += x[i]*x[i]*w[i];
-      sumy += y[i]*w[i];
-      sumy2 += y[i]*y[i]*w[i];
-      sumxy += x[i]*y[i]*w[i];
+    for (Int_t i = 0; i < n; i++) {
+      sumx += x[i] * w[i];
+      sumx2 += x[i] * x[i] * w[i];
+      sumy += y[i] * w[i];
+      sumy2 += y[i] * y[i] * w[i];
+      sumxy += x[i] * y[i] * w[i];
       sumw += w[i];
     }
 
-    if (sumx2*sumw-sumx*sumx==0.) return 1;
-    if (sumx2-sumx*sumx/sumw==0.) return 1;
+    if (sumx2 * sumw - sumx * sumx == 0.) return 1;
+    if (sumx2 - sumx * sumx / sumw == 0.) return 1;
 
-    parm[0] = (sumy*sumx2-sumx*sumxy)/(sumx2*sumw-sumx*sumx);
-    parm[1] = (sumxy-sumx*sumy/sumw)/(sumx2-sumx*sumx/sumw);
+    parm[0] = (sumy * sumx2 - sumx * sumxy) / (sumx2 * sumw - sumx * sumx);
+    parm[1] = (sumxy - sumx * sumy / sumw) / (sumx2 - sumx * sumx / sumw);
 
-    eparm[0] = sumx2*(sumx2*sumw-sumx*sumx);
-    eparm[1] = (sumx2-sumx*sumx/sumw);
+    eparm[0] = sumx2 * (sumx2 * sumw - sumx * sumx);
+    eparm[1] = (sumx2 - sumx * sumx / sumw);
 
-    if (eparm[0]<0. || eparm[1]<0.) return 1;
+    if (eparm[0] < 0. || eparm[1] < 0.) return 1;
 
-    eparm[0] = sqrt(eparm[0])/(sumx2*sumw-sumx*sumx);
-    eparm[1] = sqrt(eparm[1])/(sumx2-sumx*sumx/sumw);
+    eparm[0] = sqrt(eparm[0]) / (sumx2 * sumw - sumx * sumx);
+    eparm[1] = sqrt(eparm[1]) / (sumx2 - sumx * sumx / sumw);
 
     return 0;
-
   }
 }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Shower3DCylinderTrackHitFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Shower3DCylinderTrackHitFinder_tool.cc
@@ -11,149 +11,155 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
-namespace ShowerRecoTools{
+namespace ShowerRecoTools {
 
-  class Shower3DCylinderTrackHitFinder:IShowerTool {
-    public:
+  class Shower3DCylinderTrackHitFinder : IShowerTool {
+  public:
+    Shower3DCylinderTrackHitFinder(const fhicl::ParameterSet& pset);
 
-      Shower3DCylinderTrackHitFinder(const fhicl::ParameterSet& pset);
+    //Generic Track Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Generic Track Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
+  private:
+    std::vector<art::Ptr<recob::SpacePoint>> FindTrackSpacePoints(
+      std::vector<art::Ptr<recob::SpacePoint>>& spacePoints,
+      TVector3& showerStartPosition,
+      TVector3& showerDirection);
 
-    private:
+    //Fcl paramters
+    float fMaxProjectionDist;    //Maximum projection along shower direction.
+    float fMaxPerpendicularDist; //Maximum perpendicular distance, radius of cylinder
+    bool fForwardHitsOnly;       //Only take hits downstream of shower vertex
+    //(projection>0)
 
-      std::vector<art::Ptr<recob::SpacePoint> > FindTrackSpacePoints(std::vector<art::Ptr<recob::SpacePoint> >& spacePoints,
-          TVector3& showerStartPosition,TVector3& showerDirection);
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
 
-
-      //Fcl paramters
-      float fMaxProjectionDist;    //Maximum projection along shower direction.
-      float fMaxPerpendicularDist; //Maximum perpendicular distance, radius of cylinder
-      bool  fForwardHitsOnly;      //Only take hits downstream of shower vertex
-      //(projection>0)
-
-      art::InputTag fPFParticleLabel;
-      int           fVerbose;
-
-      std::string fShowerStartPositionInputLabel;
-      std::string fInitialTrackHitsOutputLabel;
-      std::string fInitialTrackSpacePointsOutputLabel;
-      std::string fShowerDirectionInputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fInitialTrackHitsOutputLabel;
+    std::string fInitialTrackSpacePointsOutputLabel;
+    std::string fShowerDirectionInputLabel;
   };
 
+  Shower3DCylinderTrackHitFinder::Shower3DCylinderTrackHitFinder(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fMaxProjectionDist(pset.get<float>("MaxProjectionDist"))
+    , fMaxPerpendicularDist(pset.get<float>("MaxPerpendicularDist"))
+    , fForwardHitsOnly(pset.get<bool>("ForwardHitsOnly"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel"))
+    , fInitialTrackSpacePointsOutputLabel(
+        pset.get<std::string>("InitialTrackSpacePointsOutputLabel"))
+    , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+  {}
 
-  Shower3DCylinderTrackHitFinder::Shower3DCylinderTrackHitFinder(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fMaxProjectionDist(pset.get<float>("MaxProjectionDist")),
-    fMaxPerpendicularDist(pset.get<float>("MaxPerpendicularDist")),
-    fForwardHitsOnly(pset.get<bool>("ForwardHitsOnly")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel")),
-    fInitialTrackSpacePointsOutputLabel(pset.get<std::string>("InitialTrackSpacePointsOutputLabel")),
-    fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+  int
+  Shower3DCylinderTrackHitFinder::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int Shower3DCylinderTrackHitFinder::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     //This is all based on the shower vertex being known. If it is not lets not do the track
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("Shower3DCylinderTrackHitFinder") << "Start position not set, returning "<< std::endl;
+        mf::LogError("Shower3DCylinderTrackHitFinder")
+          << "Start position not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement("ShowerDirection")){
+    if (!ShowerEleHolder.CheckElement("ShowerDirection")) {
       if (fVerbose)
-        mf::LogError("Shower3DCylinderTrackHitFinder") << "Direction not set, returning "<< std::endl;
+        mf::LogError("Shower3DCylinderTrackHitFinder")
+          << "Direction not set, returning " << std::endl;
       return 1;
     }
 
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,ShowerStartPosition);
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, ShowerStartPosition);
 
-    TVector3 ShowerDirection     = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerDirectionInputLabel,ShowerDirection);
+    TVector3 ShowerDirection = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerDirectionInputLabel, ShowerDirection);
 
     // Get the assocated pfParicle Handle
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
     // Get the spacepoint - PFParticle assn
-    const art::FindManyP<recob::SpacePoint>& fmspp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>(
-        pfpHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::SpacePoint>& fmspp =
+      ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
 
     // Get the spacepoints
-    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
+    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
 
     // Get the hits associated with the space points
-    const art::FindManyP<recob::Hit>& fmhsp = ShowerEleHolder.GetFindManyP<recob::Hit>(
-        spHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Hit>& fmhsp =
+      ShowerEleHolder.GetFindManyP<recob::Hit>(spHandle, Event, fPFParticleLabel);
 
     // Get the SpacePoints
-    std::vector<art::Ptr<recob::SpacePoint> > spacePoints = fmspp.at(pfparticle.key());
+    std::vector<art::Ptr<recob::SpacePoint>> spacePoints = fmspp.at(pfparticle.key());
 
     //We cannot progress with no spacepoints.
-    if(spacePoints.empty()){
+    if (spacePoints.empty()) {
       if (fVerbose)
-        mf::LogError("Shower3DCylinderTrackHitFinder") << "No space points, returning "<< std::endl;
+        mf::LogError("Shower3DCylinderTrackHitFinder")
+          << "No space points, returning " << std::endl;
       return 1;
     }
 
     // Order the spacepoints
-    IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(spacePoints,ShowerStartPosition,ShowerDirection);
+    IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(
+      spacePoints, ShowerStartPosition, ShowerDirection);
 
     // Get only the space points from the track
-    std::vector<art::Ptr<recob::SpacePoint> > trackSpacePoints;
-    trackSpacePoints = FindTrackSpacePoints(spacePoints,ShowerStartPosition,ShowerDirection);
+    std::vector<art::Ptr<recob::SpacePoint>> trackSpacePoints;
+    trackSpacePoints = FindTrackSpacePoints(spacePoints, ShowerStartPosition, ShowerDirection);
 
     // Get the hits associated to the space points and seperate them by planes
-    std::vector<art::Ptr<recob::Hit> > trackHits;
-    for(auto const& spacePoint: trackSpacePoints){
+    std::vector<art::Ptr<recob::Hit>> trackHits;
+    for (auto const& spacePoint : trackSpacePoints) {
       const art::Ptr<recob::Hit> hit = fmhsp.at(spacePoint.key()).front();
       // const art::Ptr<recob::Hit> hit = fohsp.at(spacePoint.key());
       trackHits.push_back(hit);
     }
 
     ShowerEleHolder.SetElement(trackHits, fInitialTrackHitsOutputLabel);
-    ShowerEleHolder.SetElement(trackSpacePoints,fInitialTrackSpacePointsOutputLabel);
+    ShowerEleHolder.SetElement(trackSpacePoints, fInitialTrackSpacePointsOutputLabel);
 
     return 0;
   }
 
-  std::vector<art::Ptr<recob::SpacePoint> > Shower3DCylinderTrackHitFinder::FindTrackSpacePoints(
-      std::vector<art::Ptr<recob::SpacePoint> >& spacePoints, TVector3& showerStartPosition,
-      TVector3& showerDirection){
+  std::vector<art::Ptr<recob::SpacePoint>>
+  Shower3DCylinderTrackHitFinder::FindTrackSpacePoints(
+    std::vector<art::Ptr<recob::SpacePoint>>& spacePoints,
+    TVector3& showerStartPosition,
+    TVector3& showerDirection)
+  {
 
     // Make a vector to hold the output space points
-    std::vector<art::Ptr<recob::SpacePoint> > trackSpacePoints;
+    std::vector<art::Ptr<recob::SpacePoint>> trackSpacePoints;
 
-    for (const auto& spacePoint : spacePoints){
+    for (const auto& spacePoint : spacePoints) {
       // Calculate the projection along direction and perpendicular distance
       // from "axis" of shower TODO: change alg to return a pair for efficiency
-      double proj = IShowerTool::GetLArPandoraShowerAlg().SpacePointProjection(spacePoint,
-          showerStartPosition, showerDirection);
-      double perp = IShowerTool::GetLArPandoraShowerAlg().SpacePointPerpendicular(spacePoint,
-          showerStartPosition, showerDirection, proj);
+      double proj = IShowerTool::GetLArPandoraShowerAlg().SpacePointProjection(
+        spacePoint, showerStartPosition, showerDirection);
+      double perp = IShowerTool::GetLArPandoraShowerAlg().SpacePointPerpendicular(
+        spacePoint, showerStartPosition, showerDirection, proj);
 
-      if (fForwardHitsOnly && proj<0)
-        continue;
+      if (fForwardHitsOnly && proj < 0) continue;
 
-      if (std::abs(proj)<fMaxProjectionDist && std::abs(perp)<fMaxPerpendicularDist)
+      if (std::abs(proj) < fMaxProjectionDist && std::abs(perp) < fMaxPerpendicularDist)
         trackSpacePoints.push_back(spacePoint);
     }
     return trackSpacePoints;
   }
 
 }
-
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::Shower3DCylinderTrackHitFinder)

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerDirectionTopologyDecision_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerDirectionTopologyDecision_tool.cc
@@ -14,66 +14,74 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerDirectionTopologyDecisionTool : public IShowerTool {
 
-  class ShowerDirectionTopologyDecisionTool: public IShowerTool {
+  public:
+    ShowerDirectionTopologyDecisionTool(const fhicl::ParameterSet& pset);
 
-    public:
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerDirectionTopologyDecisionTool(const fhicl::ParameterSet& pset);
-
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder) override;
-
-    private:
-
-      int   fVerbose;
-      float fAngleCut;
-      std::string fFirstDirectionInputLabel;
-      std::string fSecondDirectionInputLabel;
-      std::string fShowerDirectionOutputLabel;
+  private:
+    int fVerbose;
+    float fAngleCut;
+    std::string fFirstDirectionInputLabel;
+    std::string fSecondDirectionInputLabel;
+    std::string fShowerDirectionOutputLabel;
   };
 
+  ShowerDirectionTopologyDecisionTool::ShowerDirectionTopologyDecisionTool(
+    const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fAngleCut(pset.get<float>("AngleCut"))
+    , fFirstDirectionInputLabel(pset.get<std::string>("FirstDirectionInputLabel"))
+    , fSecondDirectionInputLabel(pset.get<std::string>("SecondDirectionInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  {}
 
-  ShowerDirectionTopologyDecisionTool::ShowerDirectionTopologyDecisionTool(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fVerbose(pset.get<int>("Verbose")),
-    fAngleCut(pset.get<float>("AngleCut")),
-    fFirstDirectionInputLabel(pset.get<std::string>("FirstDirectionInputLabel")),
-    fSecondDirectionInputLabel(pset.get<std::string>("SecondDirectionInputLabel")),
-    fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  int
+  ShowerDirectionTopologyDecisionTool::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int ShowerDirectionTopologyDecisionTool::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     //Check the relevent products
-    if(!ShowerEleHolder.CheckElement(fFirstDirectionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fFirstDirectionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerDirectionTopologyDecision") << "fFirstDirectionInputLabel is is not set. Stopping.";
+        mf::LogError("ShowerDirectionTopologyDecision")
+          << "fFirstDirectionInputLabel is is not set. Stopping.";
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fSecondDirectionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fSecondDirectionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerDirectionTopologyDecision") << "fSecondDirectionInputLabel is is not set. Stopping.";
+        mf::LogError("ShowerDirectionTopologyDecision")
+          << "fSecondDirectionInputLabel is is not set. Stopping.";
       return 1;
     }
 
     //Get the relevent products
     TVector3 FirstShowerDirection;
     TVector3 FirstShowerDirectionError;
-    ShowerEleHolder.GetElementAndError(fFirstDirectionInputLabel,FirstShowerDirection,FirstShowerDirectionError);
+    ShowerEleHolder.GetElementAndError(
+      fFirstDirectionInputLabel, FirstShowerDirection, FirstShowerDirectionError);
 
     TVector3 SecondShowerDirection;
     TVector3 SecondShowerDirectionError;
-    ShowerEleHolder.GetElementAndError(fSecondDirectionInputLabel,SecondShowerDirection,SecondShowerDirectionError);
+    ShowerEleHolder.GetElementAndError(
+      fSecondDirectionInputLabel, SecondShowerDirection, SecondShowerDirectionError);
 
     //Use the first tool if directions agree within the chosen angle
-    if(FirstShowerDirection.Angle(SecondShowerDirection) < fAngleCut ){
-      ShowerEleHolder.SetElement(FirstShowerDirection,FirstShowerDirectionError,fShowerDirectionOutputLabel);
-    } else {
-      ShowerEleHolder.SetElement(SecondShowerDirection,SecondShowerDirectionError,fShowerDirectionOutputLabel);
+    if (FirstShowerDirection.Angle(SecondShowerDirection) < fAngleCut) {
+      ShowerEleHolder.SetElement(
+        FirstShowerDirection, FirstShowerDirectionError, fShowerDirectionOutputLabel);
+    }
+    else {
+      ShowerEleHolder.SetElement(
+        SecondShowerDirection, SecondShowerDirectionError, fShowerDirectionOutputLabel);
     }
     return 0;
   }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerExampleTool_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerExampleTool_tool.cc
@@ -9,68 +9,65 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
-#include "lardataobj/RecoBase/Vertex.h"
 #include "lardataobj/RecoBase/Shower.h"
+#include "lardataobj/RecoBase/Vertex.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace ShowerRecoTools {
 
-  class ShowerExampleTool: public IShowerTool {
+  class ShowerExampleTool : public IShowerTool {
 
-    public:
+  public:
+    ShowerExampleTool(const fhicl::ParameterSet& pset);
 
-      ShowerExampleTool(const fhicl::ParameterSet& pset);
+    //Example Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Example Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
+  private:
+    //Function to initialise the producer i.e produces<std::vector<recob::Vertex> >(); commands go here.
+    void InitialiseProducers() override;
 
-    private:
+    //Function to add the assoctions
+    int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                        art::Event& Event,
+                        reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Function to initialise the producer i.e produces<std::vector<recob::Vertex> >(); commands go here.
-      void InitialiseProducers() override;
-
-      //Function to add the assoctions
-      int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder) override;
-
-      //prehaps you want a fcl parameter.
-      art::InputTag fPFParticleLabel;
-      int           fVerbose;
-
+    //prehaps you want a fcl parameter.
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
   };
 
+  ShowerExampleTool::ShowerExampleTool(const fhicl::ParameterSet& pset)
+    : //Setup the algs and others here
+    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+  {}
 
-  ShowerExampleTool::ShowerExampleTool(const fhicl::ParameterSet& pset) :
-    //Setup the algs and others here
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose"))
-  {
-  }
-
-  void ShowerExampleTool::InitialiseProducers()
+  void
+  ShowerExampleTool::InitialiseProducers()
   {
     //Do you create something and you want to save it the event. Initialsie here. For every event with have a vector of showers so each one has a vertex. This is what we are saving. Make sure to use the name "myvertex" later down the line.
-    InitialiseProduct<std::vector<recob::Vertex> >("myvertex");
+    InitialiseProduct<std::vector<recob::Vertex>>("myvertex");
 
     //We can also do associations
-    InitialiseProduct<art::Assns<recob::Shower, recob::Vertex> >("myvertexassan");
+    InitialiseProduct<art::Assns<recob::Shower, recob::Vertex>>("myvertexassan");
   }
 
-
-  int ShowerExampleTool::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
+  int
+  ShowerExampleTool::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                      art::Event& Event,
+                                      reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //In here calculate a shower or element (or multiple). It can be something used to create the recob::shower i.e. the direction. These have specific names so be careful to make these correctly. Alternative you can create something completely new e.g. recob::Vertex and add it the shower element holder
 
     //Now we are calculating the property of the shower like pfparticle. You have access to everything in the event. Maybe you want the vertex.
 
-    auto const vtxHandle = Event.getValidHandle<std::vector<recob::Vertex> >(fPFParticleLabel);
-    std::vector<art::Ptr<recob::Vertex> > vertices;
+    auto const vtxHandle = Event.getValidHandle<std::vector<recob::Vertex>>(fPFParticleLabel);
+    std::vector<art::Ptr<recob::Vertex>> vertices;
     art::fill_ptr_vector(vertices, vtxHandle);
 
     //Remember the module goes through the tools and if you want to (fcl param) it will loop over them twice. You can check to see if a element has been set with a specific name:
@@ -79,54 +76,52 @@ namespace ShowerRecoTools {
     TVector3 ShowerDirection = {-999, -999, -999};
 
     //Then you can go and get that element if you want to use it and fill it in for you.
-    if(shower_direction_set){
-      ShowerEleHolder.GetElement("ShowerDirection",ShowerDirection);
-    }
+    if (shower_direction_set) { ShowerEleHolder.GetElement("ShowerDirection", ShowerDirection); }
 
     //Do some crazy physics - Some legacy code in here for ease.
     art::Ptr<recob::Vertex> proposed_vertex = vertices[0];
-    double xyz[3] = {-999,-999,-999};
+    double xyz[3] = {-999, -999, -999};
     proposed_vertex->XYZ(xyz);
 
-    if(ShowerDirection.X() < 0){
-      xyz[0] = - xyz[0];
-      xyz[1] = - xyz[1];
-      xyz[2] = - xyz[2];
+    if (ShowerDirection.X() < 0) {
+      xyz[0] = -xyz[0];
+      xyz[1] = -xyz[1];
+      xyz[2] = -xyz[2];
     }
     recob::Vertex new_vertex = recob::Vertex(xyz);
     TVector3 recobshower_vertex = {xyz[0], xyz[1], xyz[2]};
-    TVector3 recobshower_err = {xyz[0]*0.1, xyz[1]*0.1, xyz[2]*0.1};
+    TVector3 recobshower_err = {xyz[0] * 0.1, xyz[1] * 0.1, xyz[2] * 0.1};
     //You can set elements of the recob::shower just choose the right name (you can acess them later). You can give the property an error anf this must be done the for standard recob::shower properties; The standard is to access the name via a fcl file.
-    ShowerEleHolder.SetElement(recobshower_vertex,recobshower_err,"ShowerStartPosition");
+    ShowerEleHolder.SetElement(recobshower_vertex, recobshower_err, "ShowerStartPosition");
 
     //You can also set the same element with a different name so that you can compare downstream two tools.
     //The standard is to actually define the name in fcl.
-    ShowerEleHolder.SetElement(recobshower_vertex,recobshower_err,"ShowerExampleTool_ShowerStartPosition");
+    ShowerEleHolder.SetElement(
+      recobshower_vertex, recobshower_err, "ShowerExampleTool_ShowerStartPosition");
 
     //Or you can set one of the save elements
-    ShowerEleHolder.SetElement(new_vertex,"myvertex");
+    ShowerEleHolder.SetElement(new_vertex, "myvertex");
 
     //Or a new unsave one.
-    std::vector<double> xyz_vec = {xyz[0],xyz[1],xyz[2]};
-    ShowerEleHolder.SetElement(xyz_vec,"xyz");
+    std::vector<double> xyz_vec = {xyz[0], xyz[1], xyz[2]};
+    ShowerEleHolder.SetElement(xyz_vec, "xyz");
 
     //If you want to check if your element was actually made before the shower is made you can set a bool. If partial showers is turned off then the shower will not be made if this element is not filled. Properties i.e. elements with errors i.e. ShowerStartPosition  will not be checked. There is no way to store properties in the Event, only products are stored. You can make your own class which holds the error. The defualt is not to check the element. The recob::shower properties are checked however.
-    ShowerEleHolder.SetElement(xyz_vec,"xyz",true);
+    ShowerEleHolder.SetElement(xyz_vec, "xyz", true);
 
     //You can see if an element will be checked before the shower is save with
     bool will_be_checked = ShowerEleHolder.CheckElementTag("xyz");
 
-    if(will_be_checked){std::cout << "Element checked at save time" << std::endl;}
+    if (will_be_checked) { std::cout << "Element checked at save time" << std::endl; }
 
     //You can also changed the tag.
-    ShowerEleHolder.SetElementTag("xyz",false);
+    ShowerEleHolder.SetElementTag("xyz", false);
 
     //Note: Elements that are actually saved because you defined them in InitialiseProducers will be checked regardless. We don't want you saving nothign now.
 
     //You can also get the shower number that you are current one (the first shower number is 0).
     int showernum = ShowerEleHolder.GetShowerNumber();
-    if (fVerbose>1)
-      std::cout << "You on are shower: " << showernum << std::endl;
+    if (fVerbose > 1) std::cout << "You on are shower: " << showernum << std::endl;
 
     //You can also read out what ptr are set and what elements are set:.
     PrintPtrs();
@@ -138,24 +133,27 @@ namespace ShowerRecoTools {
     return 0;
   }
 
-  int ShowerExampleTool::AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder
-      ){
+  int
+  ShowerExampleTool::AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                                     art::Event& Event,
+                                     reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
     //Here you add elements to associations defined. You can get the art::Ptrs by  GetProducedElementPtr<T>. Then you can add single like a usally association using AddSingle<assn<T>. Assn below.
 
     //First check the element has been set
-    if(!ShowerEleHolder.CheckElement("myvertex")){
-      if (fVerbose)
-        mf::LogError("ShowerExampleTooAddAssn") << "vertex not set."<< std::endl;
+    if (!ShowerEleHolder.CheckElement("myvertex")) {
+      if (fVerbose) mf::LogError("ShowerExampleTooAddAssn") << "vertex not set." << std::endl;
       return 1;
     }
 
     //Then you can get the size of the vector which the unique ptr hold so that you can do associations. If you are comfortable in the fact that your element will always be made when a shower is made you don't need to to do this you can just get the art ptr as:      const art::Ptr<recob::Vertex> vertexptr = GetProducedElementPtr<recob::Vertex>("myvertex", ShowerEleHolder);. Note doing this when you allow partial showers to be set can screw up the assocation for the partial shower.
     int ptrsize = GetVectorPtrSize("myvertex");
 
-    const art::Ptr<recob::Vertex> vertexptr = GetProducedElementPtr<recob::Vertex>("myvertex", ShowerEleHolder,ptrsize);
-    const art::Ptr<recob::Shower> showerptr = GetProducedElementPtr<recob::Shower>("shower", ShowerEleHolder);
-    AddSingle<art::Assns<recob::Shower, recob::Vertex> >(showerptr,vertexptr,"myvertexassan");
+    const art::Ptr<recob::Vertex> vertexptr =
+      GetProducedElementPtr<recob::Vertex>("myvertex", ShowerEleHolder, ptrsize);
+    const art::Ptr<recob::Shower> showerptr =
+      GetProducedElementPtr<recob::Shower>("shower", ShowerEleHolder);
+    AddSingle<art::Assns<recob::Shower, recob::Vertex>>(showerptr, vertexptr, "myvertexassan");
 
     return 0;
   }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerIncrementalTrackHitFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerIncrementalTrackHitFinder_tool.cc
@@ -13,241 +13,266 @@
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 //Root Includes
-#include "TPrincipal.h"
 #include "TGraph2D.h"
+#include "TPrincipal.h"
 
 namespace ShowerRecoTools {
 
+  class ShowerIncrementalTrackHitFinder : public IShowerTool {
 
-  class ShowerIncrementalTrackHitFinder: public IShowerTool {
+  public:
+    ShowerIncrementalTrackHitFinder(const fhicl::ParameterSet& pset);
 
-    public:
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerIncrementalTrackHitFinder(const fhicl::ParameterSet& pset);
+  private:
+    std::vector<art::Ptr<recob::SpacePoint>> RunIncrementalSpacePointFinder(
+      const art::Event& Event,
+      std::vector<art::Ptr<recob::SpacePoint>> const& sps,
+      const art::FindManyP<recob::Hit>& fmh);
 
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
+    void PruneFrontOfSPSPool(std::vector<art::Ptr<recob::SpacePoint>>& sps_pool,
+                             std::vector<art::Ptr<recob::SpacePoint>> const& initial_track);
 
-    private:
+    void PruneTrack(std::vector<art::Ptr<recob::SpacePoint>>& initial_track);
 
-      std::vector<art::Ptr<recob::SpacePoint> > RunIncrementalSpacePointFinder(
-          const art::Event& Event,
-          std::vector< art::Ptr< recob::SpacePoint> > const& sps,
-          const art::FindManyP<recob::Hit> & fmh);
+    void AddSpacePointsToSegment(std::vector<art::Ptr<recob::SpacePoint>>& segment,
+                                 std::vector<art::Ptr<recob::SpacePoint>>& sps_pool,
+                                 size_t num_sps_to_take);
 
-      void PruneFrontOfSPSPool(
-          std::vector<art::Ptr<recob::SpacePoint> > & sps_pool,
-          std::vector<art::Ptr<recob::SpacePoint> > const& initial_track);
+    bool IsSegmentValid(std::vector<art::Ptr<recob::SpacePoint>> const& segment);
 
-      void PruneTrack(std::vector<art::Ptr<recob::SpacePoint> > & initial_track);
+    bool IncrementallyFitSegment(const detinfo::DetectorClocksData& clockData,
+                                 const detinfo::DetectorPropertiesData& detProp,
+                                 std::vector<art::Ptr<recob::SpacePoint>>& segment,
+                                 std::vector<art::Ptr<recob::SpacePoint>>& sps_pool,
+                                 const art::FindManyP<recob::Hit>& fmh,
+                                 double current_residual);
 
-      void AddSpacePointsToSegment(
-          std::vector<art::Ptr<recob::SpacePoint> > & segment,
-          std::vector<art::Ptr<recob::SpacePoint> > & sps_pool,
-          size_t num_sps_to_take);
+    double FitSegmentAndCalculateResidual(const detinfo::DetectorClocksData& clockData,
+                                          const detinfo::DetectorPropertiesData& detProp,
+                                          std::vector<art::Ptr<recob::SpacePoint>>& segment,
+                                          const art::FindManyP<recob::Hit>& fmh);
 
-      bool IsSegmentValid(std::vector<art::Ptr<recob::SpacePoint> > const& segment);
+    double FitSegmentAndCalculateResidual(const detinfo::DetectorClocksData& clockData,
+                                          const detinfo::DetectorPropertiesData& detProp,
+                                          std::vector<art::Ptr<recob::SpacePoint>>& segment,
+                                          const art::FindManyP<recob::Hit>& fmh,
+                                          int& max_residual_point);
 
-      bool IncrementallyFitSegment(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          std::vector<art::Ptr<recob::SpacePoint> > & segment,
-          std::vector<art::Ptr< recob::SpacePoint> > & sps_pool,
-          const art::FindManyP<recob::Hit>  & fmh,
-          double current_residual);
+    bool RecursivelyReplaceLastSpacePointAndRefit(
+      const detinfo::DetectorClocksData& clockData,
+      const detinfo::DetectorPropertiesData& detProp,
+      std::vector<art::Ptr<recob::SpacePoint>>& segment,
+      std::vector<art::Ptr<recob::SpacePoint>>& reduced_sps_pool,
+      const art::FindManyP<recob::Hit>& fmh,
+      double current_residual);
 
-      double FitSegmentAndCalculateResidual(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          std::vector<art::Ptr<recob::SpacePoint> > & segment,
-          const art::FindManyP<recob::Hit> & fmh);
-
-      double FitSegmentAndCalculateResidual(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          std::vector<art::Ptr<recob::SpacePoint> > & segment,
-          const art::FindManyP<recob::Hit> & fmh,
-          int& max_residual_point);
-
-
-      bool RecursivelyReplaceLastSpacePointAndRefit(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          std::vector<art::Ptr<recob::SpacePoint> > & segment,
-          std::vector<art::Ptr< recob::SpacePoint> > & reduced_sps_pool,
-          const art::FindManyP<recob::Hit>  & fmh,
-          double current_residual);
-
-      bool IsResidualOK(double new_residual, double current_residual) { return new_residual - current_residual < fMaxResidualDiff; };
-      bool IsResidualOK(double new_residual, double current_residual, size_t no_sps) { return (new_residual - current_residual < fMaxResidualDiff && new_residual/no_sps < fMaxAverageResidual); };
-      bool IsResidualOK(double residual, size_t no_sps) {return residual/no_sps < fMaxAverageResidual;}
-
-      double CalculateResidual(std::vector<art::Ptr<recob::SpacePoint> >& sps,
-          TVector3& PCAEigenvector,
-          TVector3& TrackPosition);
-
-      double CalculateResidual(std::vector<art::Ptr<recob::SpacePoint> >& sps,
-          TVector3& PCAEigenvector,
-          TVector3& TrackPosition,
-          int& max_residual_point);
-
-      //Function to calculate the shower direction using a charge weight 3D PCA calculation.
-      TVector3 ShowerPCAVector(std::vector<art::Ptr<recob::SpacePoint> >& sps);
-
-      TVector3 ShowerPCAVector(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          const std::vector<art::Ptr<recob::SpacePoint> >& sps,
-          const art::FindManyP<recob::Hit>& fmh);
-
-      std::vector<art::Ptr<recob::SpacePoint> > CreateFakeShowerTrajectory(TVector3 start_position, TVector3 start_direction);
-      std::vector<art::Ptr<recob::SpacePoint> > CreateFakeSPLine(TVector3 start_position, TVector3 start_direction, int npoints);
-      void RunTestOfIncrementalSpacePointFinder(const art::Event& Event, const art::FindManyP<recob::Hit>& dud_fmh);
-
-      void MakeTrackSeed(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          std::vector< art::Ptr< recob::SpacePoint> >& segment,
-          const art::FindManyP<recob::Hit> & fmh);
-
-
-      //Services
-      art::InputTag fPFParticleLabel;
-      int           fVerbose;
-      bool          fUseShowerDirection;
-      bool          fChargeWeighted;
-      bool          fForwardHitsOnly;
-      float         fMaxResidualDiff;
-      float         fMaxAverageResidual;
-      int           fStartFitSize;
-      int           fNMissPoints;
-      float         fTrackMaxAdjacentSPDistance;
-      bool          fRunTest;
-      bool          fMakeTrackSeed;
-      float         fStartDistanceCut;
-      float         fDistanceCut;
-      std::string   fShowerStartPositionInputLabel;
-      std::string   fShowerDirectionInputLabel;
-      std::string   fInitialTrackHitsOutputLabel;
-      std::string   fInitialTrackSpacePointsOutputLabel;
-  };
-
-
-  ShowerIncrementalTrackHitFinder::ShowerIncrementalTrackHitFinder(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fUseShowerDirection(pset.get<bool>("UseShowerDirection")),
-    fChargeWeighted(pset.get<bool>("ChargeWeighted")),
-    fForwardHitsOnly(pset.get<bool>("ForwardHitsOnly")),
-    fMaxResidualDiff(pset.get<float>("MaxResidualDiff")),
-    fMaxAverageResidual(pset.get<float>("MaxAverageResidual")),
-    fStartFitSize(pset.get<int>("StartFitSize")),
-    fNMissPoints(pset.get<int>("NMissPoints")),
-    fTrackMaxAdjacentSPDistance(pset.get<float>("TrackMaxAdjacentSPDistance")),
-    fRunTest(0),
-    fMakeTrackSeed(pset.get<bool>("MakeTrackSeed")),
-    fStartDistanceCut(pset.get<float>("StartDistanceCut")),
-    fDistanceCut(pset.get<float>("DistanceCut")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel")),
-
-    fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel")),
-    fInitialTrackSpacePointsOutputLabel(pset.get<std::string>("InitialTrackSpacePointsOutputLabel"))
+    bool
+    IsResidualOK(double new_residual, double current_residual)
     {
-      if(fStartFitSize == 0){
-        throw cet::exception("ShowerIncrementalTrackHitFinder") << "We cannot make a track if you don't gives us at leats one hit. Change fStartFitSize please to something sensible";
-      }
+      return new_residual - current_residual < fMaxResidualDiff;
+    };
+    bool
+    IsResidualOK(double new_residual, double current_residual, size_t no_sps)
+    {
+      return (new_residual - current_residual < fMaxResidualDiff &&
+              new_residual / no_sps < fMaxAverageResidual);
+    };
+    bool
+    IsResidualOK(double residual, size_t no_sps)
+    {
+      return residual / no_sps < fMaxAverageResidual;
     }
 
-  int ShowerIncrementalTrackHitFinder::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
+    double CalculateResidual(std::vector<art::Ptr<recob::SpacePoint>>& sps,
+                             TVector3& PCAEigenvector,
+                             TVector3& TrackPosition);
+
+    double CalculateResidual(std::vector<art::Ptr<recob::SpacePoint>>& sps,
+                             TVector3& PCAEigenvector,
+                             TVector3& TrackPosition,
+                             int& max_residual_point);
+
+    //Function to calculate the shower direction using a charge weight 3D PCA calculation.
+    TVector3 ShowerPCAVector(std::vector<art::Ptr<recob::SpacePoint>>& sps);
+
+    TVector3 ShowerPCAVector(const detinfo::DetectorClocksData& clockData,
+                             const detinfo::DetectorPropertiesData& detProp,
+                             const std::vector<art::Ptr<recob::SpacePoint>>& sps,
+                             const art::FindManyP<recob::Hit>& fmh);
+
+    std::vector<art::Ptr<recob::SpacePoint>> CreateFakeShowerTrajectory(TVector3 start_position,
+                                                                        TVector3 start_direction);
+    std::vector<art::Ptr<recob::SpacePoint>> CreateFakeSPLine(TVector3 start_position,
+                                                              TVector3 start_direction,
+                                                              int npoints);
+    void RunTestOfIncrementalSpacePointFinder(const art::Event& Event,
+                                              const art::FindManyP<recob::Hit>& dud_fmh);
+
+    void MakeTrackSeed(const detinfo::DetectorClocksData& clockData,
+                       const detinfo::DetectorPropertiesData& detProp,
+                       std::vector<art::Ptr<recob::SpacePoint>>& segment,
+                       const art::FindManyP<recob::Hit>& fmh);
+
+    //Services
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
+    bool fUseShowerDirection;
+    bool fChargeWeighted;
+    bool fForwardHitsOnly;
+    float fMaxResidualDiff;
+    float fMaxAverageResidual;
+    int fStartFitSize;
+    int fNMissPoints;
+    float fTrackMaxAdjacentSPDistance;
+    bool fRunTest;
+    bool fMakeTrackSeed;
+    float fStartDistanceCut;
+    float fDistanceCut;
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionInputLabel;
+    std::string fInitialTrackHitsOutputLabel;
+    std::string fInitialTrackSpacePointsOutputLabel;
+  };
+
+  ShowerIncrementalTrackHitFinder::ShowerIncrementalTrackHitFinder(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fUseShowerDirection(pset.get<bool>("UseShowerDirection"))
+    , fChargeWeighted(pset.get<bool>("ChargeWeighted"))
+    , fForwardHitsOnly(pset.get<bool>("ForwardHitsOnly"))
+    , fMaxResidualDiff(pset.get<float>("MaxResidualDiff"))
+    , fMaxAverageResidual(pset.get<float>("MaxAverageResidual"))
+    , fStartFitSize(pset.get<int>("StartFitSize"))
+    , fNMissPoints(pset.get<int>("NMissPoints"))
+    , fTrackMaxAdjacentSPDistance(pset.get<float>("TrackMaxAdjacentSPDistance"))
+    , fRunTest(0)
+    , fMakeTrackSeed(pset.get<bool>("MakeTrackSeed"))
+    , fStartDistanceCut(pset.get<float>("StartDistanceCut"))
+    , fDistanceCut(pset.get<float>("DistanceCut"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+    ,
+
+    fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel"))
+    , fInitialTrackSpacePointsOutputLabel(
+        pset.get<std::string>("InitialTrackSpacePointsOutputLabel"))
+  {
+    if (fStartFitSize == 0) {
+      throw cet::exception("ShowerIncrementalTrackHitFinder")
+        << "We cannot make a track if you don't gives us at leats one hit. Change fStartFitSize "
+           "please to something sensible";
+    }
+  }
+
+  int
+  ShowerIncrementalTrackHitFinder::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //This is all based on the shower vertex being known. If it is not lets not do the track
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerIncrementalTrackHitFinder") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerIncrementalTrackHitFinder")
+          << "Start position not set, returning " << std::endl;
       return 1;
     }
 
     // Get the assocated pfParicle Handle
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
     // Get the spacepoint - PFParticle assn
-    const art::FindManyP<recob::SpacePoint>& fmspp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>(
-        pfpHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::SpacePoint>& fmspp =
+      ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
 
     // Get the spacepoints
-    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
+    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
 
     // Get the hits associated with the space points
-    const art::FindManyP<recob::Hit>& fmh = ShowerEleHolder.GetFindManyP<recob::Hit>(
-        spHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Hit>& fmh =
+      ShowerEleHolder.GetFindManyP<recob::Hit>(spHandle, Event, fPFParticleLabel);
 
     // Get the SpacePoints
-    std::vector<art::Ptr<recob::SpacePoint> > spacePoints = fmspp.at(pfparticle.key());
+    std::vector<art::Ptr<recob::SpacePoint>> spacePoints = fmspp.at(pfparticle.key());
 
     //We cannot progress with no spacepoints.
-    if(spacePoints.empty()){
+    if (spacePoints.empty()) {
       if (fVerbose)
-        mf::LogError("ShowerIncrementalTrackHitFinder") << "No space points, returning "<< std::endl;
+        mf::LogError("ShowerIncrementalTrackHitFinder")
+          << "No space points, returning " << std::endl;
       return 1;
     }
 
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,ShowerStartPosition);
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, ShowerStartPosition);
 
     //Decide if the you want to use the direction of the shower or make one.
-    if(fUseShowerDirection){
+    if (fUseShowerDirection) {
 
-      if(!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)){
+      if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)) {
         if (fVerbose)
-          mf::LogError("ShowerIncrementalTrackHitFinder") << "Direction not set, returning "<< std::endl;
+          mf::LogError("ShowerIncrementalTrackHitFinder")
+            << "Direction not set, returning " << std::endl;
         return 1;
       }
 
-      TVector3 ShowerDirection = {-999,-999,-999};
-      ShowerEleHolder.GetElement(fShowerDirectionInputLabel,ShowerDirection);
+      TVector3 ShowerDirection = {-999, -999, -999};
+      ShowerEleHolder.GetElement(fShowerDirectionInputLabel, ShowerDirection);
 
       //Order the spacepoints
-      IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(spacePoints,ShowerStartPosition,ShowerDirection);
+      IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(
+        spacePoints, ShowerStartPosition, ShowerDirection);
       //Remove the back hits if requird.
-      if (fForwardHitsOnly){
-        int back_sps=0;
-        for (auto spacePoint : spacePoints){
-          double proj = IShowerTool::GetLArPandoraShowerAlg().SpacePointProjection(spacePoint,ShowerStartPosition, ShowerDirection);
-          if(proj<0){
-            ++back_sps;
-          }
-          if(proj>0){
-            break;
-          }
+      if (fForwardHitsOnly) {
+        int back_sps = 0;
+        for (auto spacePoint : spacePoints) {
+          double proj = IShowerTool::GetLArPandoraShowerAlg().SpacePointProjection(
+            spacePoint, ShowerStartPosition, ShowerDirection);
+          if (proj < 0) { ++back_sps; }
+          if (proj > 0) { break; }
         }
         spacePoints.erase(spacePoints.begin(), spacePoints.begin() + back_sps);
       }
-    } else {
+    }
+    else {
       //Order the spacepoint using the magnitude away from the vertex
-      IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(spacePoints,ShowerStartPosition);
+      IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(spacePoints,
+                                                                   ShowerStartPosition);
     }
 
     //Remove the first x spacepoints
     int frontsp = 0;
-    for (auto spacePoint : spacePoints){
-      double dist = (IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(spacePoint) - ShowerStartPosition).Mag();
-      if(dist > fStartDistanceCut){break;}
+    for (auto spacePoint : spacePoints) {
+      double dist =
+        (IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(spacePoint) - ShowerStartPosition)
+          .Mag();
+      if (dist > fStartDistanceCut) { break; }
       ++frontsp;
     }
     spacePoints.erase(spacePoints.begin(), spacePoints.begin() + frontsp);
 
     //Bin anything above x cm
-    int sp_iter=0;
-    for (auto spacePoint : spacePoints){
-      double dist = (IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(spacePoint) - ShowerStartPosition).Mag();
-      if(dist > fDistanceCut){break;}
+    int sp_iter = 0;
+    for (auto spacePoint : spacePoints) {
+      double dist =
+        (IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(spacePoint) - ShowerStartPosition)
+          .Mag();
+      if (dist > fDistanceCut) { break; }
       ++sp_iter;
     }
-    spacePoints.erase(spacePoints.begin()+sp_iter, spacePoints.end());
+    spacePoints.erase(spacePoints.begin() + sp_iter, spacePoints.end());
 
-    if(spacePoints.size() < 3){
+    if (spacePoints.size() < 3) {
       if (fVerbose)
-        mf::LogError("ShowerIncrementalTrackHitFinder") << "Not enough spacepoints bailing"<< std::endl;
+        mf::LogError("ShowerIncrementalTrackHitFinder")
+          << "Not enough spacepoints bailing" << std::endl;
       return 1;
     }
 
@@ -255,13 +280,14 @@ namespace ShowerRecoTools {
     if (fRunTest) RunTestOfIncrementalSpacePointFinder(Event, fmh);
 
     //Actually runt he algorithm.
-    std::vector<art::Ptr<recob::SpacePoint> > track_sps = RunIncrementalSpacePointFinder(Event, spacePoints, fmh);
+    std::vector<art::Ptr<recob::SpacePoint>> track_sps =
+      RunIncrementalSpacePointFinder(Event, spacePoints, fmh);
 
     // Get the hits associated to the space points and seperate them by planes
-    std::vector<art::Ptr<recob::Hit> > trackHits;
-    for(auto const& spacePoint: track_sps){
-      std::vector<art::Ptr<recob::Hit> > hits = fmh.at(spacePoint.key());
-      for(auto const& hit: hits){
+    std::vector<art::Ptr<recob::Hit>> trackHits;
+    for (auto const& spacePoint : track_sps) {
+      std::vector<art::Ptr<recob::Hit>> hits = fmh.at(spacePoint.key());
+      for (auto const& hit : hits) {
         trackHits.push_back(hit);
       }
     }
@@ -273,14 +299,15 @@ namespace ShowerRecoTools {
     return 0;
   }
 
-
-  TVector3 ShowerIncrementalTrackHitFinder::ShowerPCAVector(std::vector<art::Ptr<recob::SpacePoint> >& sps){
+  TVector3
+  ShowerIncrementalTrackHitFinder::ShowerPCAVector(std::vector<art::Ptr<recob::SpacePoint>>& sps)
+  {
 
     //Initialise the the PCA.
-    TPrincipal *pca = new TPrincipal(3,"");
+    TPrincipal* pca = new TPrincipal(3, "");
 
     //Normalise the spacepoints, charge weight and add to the PCA.
-    for(auto& sp: sps){
+    for (auto& sp : sps) {
 
       TVector3 sp_position = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp);
 
@@ -299,7 +326,7 @@ namespace ShowerRecoTools {
     //Get the Eigenvectors.
     const TMatrixD* Eigenvectors = pca->GetEigenVectors();
 
-    TVector3 Eigenvector = { (*Eigenvectors)[0][0], (*Eigenvectors)[1][0], (*Eigenvectors)[2][0] };
+    TVector3 Eigenvector = {(*Eigenvectors)[0][0], (*Eigenvectors)[1][0], (*Eigenvectors)[2][0]};
 
     delete pca;
 
@@ -307,44 +334,47 @@ namespace ShowerRecoTools {
   }
 
   //Function to calculate the shower direction using a charge weight 3D PCA calculation.
-  TVector3 ShowerIncrementalTrackHitFinder::ShowerPCAVector(const detinfo::DetectorClocksData& clockData,
-      const detinfo::DetectorPropertiesData& detProp,
-      const std::vector<art::Ptr<recob::SpacePoint> >& sps,
-      const art::FindManyP<recob::Hit>& fmh){
+  TVector3
+  ShowerIncrementalTrackHitFinder::ShowerPCAVector(
+    const detinfo::DetectorClocksData& clockData,
+    const detinfo::DetectorPropertiesData& detProp,
+    const std::vector<art::Ptr<recob::SpacePoint>>& sps,
+    const art::FindManyP<recob::Hit>& fmh)
+  {
 
     //Initialise the the PCA.
-    TPrincipal *pca = new TPrincipal(3,"");
+    TPrincipal* pca = new TPrincipal(3, "");
 
     float TotalCharge = 0;
 
     //Normalise the spacepoints, charge weight and add to the PCA.
-    for(auto& sp: sps){
+    for (auto& sp : sps) {
 
       TVector3 sp_position = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp);
 
       float wht = 1;
 
-      if(fChargeWeighted){
+      if (fChargeWeighted) {
 
         //Get the charge.
-        float Charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(sp,fmh);
+        float Charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(sp, fmh);
         //        std::cout << "Charge: " << Charge << std::endl;
 
         //Get the time of the spacepoint
-        float Time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(sp,fmh);
+        float Time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(sp, fmh);
 
         //Correct for the lifetime at the moment.
-        Charge *= std::exp((sampling_rate(clockData) * Time ) / (detProp.ElectronLifetime()*1e3));
+        Charge *= std::exp((sampling_rate(clockData) * Time) / (detProp.ElectronLifetime() * 1e3));
         //        std::cout << "Charge: "<< Charge << std::endl;
 
         //Charge Weight
-        wht *= std::sqrt(Charge/TotalCharge);
+        wht *= std::sqrt(Charge / TotalCharge);
       }
 
       double sp_coord[3];
-      sp_coord[0] = sp_position.X()*wht;
-      sp_coord[1] = sp_position.Y()*wht;
-      sp_coord[2] = sp_position.Z()*wht;
+      sp_coord[0] = sp_position.X() * wht;
+      sp_coord[1] = sp_position.Y() * wht;
+      sp_coord[2] = sp_position.Z() * wht;
 
       //Add to the PCA
       pca->AddRow(sp_coord);
@@ -356,7 +386,7 @@ namespace ShowerRecoTools {
     //Get the Eigenvectors.
     const TMatrixD* Eigenvectors = pca->GetEigenVectors();
 
-    TVector3 Eigenvector = { (*Eigenvectors)[0][0], (*Eigenvectors)[1][0], (*Eigenvectors)[2][0] };
+    TVector3 Eigenvector = {(*Eigenvectors)[0][0], (*Eigenvectors)[1][0], (*Eigenvectors)[2][0]};
 
     delete pca;
 
@@ -365,73 +395,78 @@ namespace ShowerRecoTools {
 
   //Function to remove the spacepoint with the highest residual until we have a track which matches the
   //residual criteria.
-  void ShowerIncrementalTrackHitFinder::MakeTrackSeed(const detinfo::DetectorClocksData& clockData,
-      const detinfo::DetectorPropertiesData& detProp,
-      std::vector< art::Ptr< recob::SpacePoint> >& segment,
-      const art::FindManyP<recob::Hit> & fmh){
+  void
+  ShowerIncrementalTrackHitFinder::MakeTrackSeed(const detinfo::DetectorClocksData& clockData,
+                                                 const detinfo::DetectorPropertiesData& detProp,
+                                                 std::vector<art::Ptr<recob::SpacePoint>>& segment,
+                                                 const art::FindManyP<recob::Hit>& fmh)
+  {
 
-    bool ok=true;
+    bool ok = true;
 
     int maxresidual_point = 0;
 
     //Check the residual
-    double residual = FitSegmentAndCalculateResidual(clockData, detProp, segment, fmh, maxresidual_point);
+    double residual =
+      FitSegmentAndCalculateResidual(clockData, detProp, segment, fmh, maxresidual_point);
 
     //Is it okay
     ok = IsResidualOK(residual, segment.size());
 
     //Remove points until we can fit a track.
-    while(!ok && segment.size()!=1){
+    while (!ok && segment.size() != 1) {
 
       //Remove the point with the highest residual
-      for (auto sp = segment.begin(); sp != segment.end();  ++sp){
-        if(sp->key() == (unsigned) maxresidual_point){
+      for (auto sp = segment.begin(); sp != segment.end(); ++sp) {
+        if (sp->key() == (unsigned)maxresidual_point) {
           segment.erase(sp);
           break;
         }
       }
 
       //Check the residual
-      double residual = FitSegmentAndCalculateResidual(clockData, detProp, segment, fmh, maxresidual_point);
+      double residual =
+        FitSegmentAndCalculateResidual(clockData, detProp, segment, fmh, maxresidual_point);
 
       //Is it okay
       ok = IsResidualOK(residual, segment.size());
-
     }
   }
 
-  std::vector<art::Ptr<recob::SpacePoint> > ShowerIncrementalTrackHitFinder::RunIncrementalSpacePointFinder(
-      const art::Event& Event,
-      std::vector< art::Ptr< recob::SpacePoint> > const& sps,
-      const art::FindManyP<recob::Hit> & fmh){
+  std::vector<art::Ptr<recob::SpacePoint>>
+  ShowerIncrementalTrackHitFinder::RunIncrementalSpacePointFinder(
+    const art::Event& Event,
+    std::vector<art::Ptr<recob::SpacePoint>> const& sps,
+    const art::FindManyP<recob::Hit>& fmh)
+  {
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
     //Create space point pool (yes we are copying the input vector because we're going to twiddle with it
-    std::vector<art::Ptr<recob::SpacePoint> > sps_pool = sps;
-    std::vector<art::Ptr<recob::SpacePoint> > initial_track;
-    std::vector<art::Ptr<recob::SpacePoint> > track_segment_copy;
+    std::vector<art::Ptr<recob::SpacePoint>> sps_pool = sps;
+    std::vector<art::Ptr<recob::SpacePoint>> initial_track;
+    std::vector<art::Ptr<recob::SpacePoint>> track_segment_copy;
 
-    while (sps_pool.size() > 0){
+    while (sps_pool.size() > 0) {
       //PruneFrontOfSPSPool(sps_pool, initial_track);
 
-      std::vector<art::Ptr<recob::SpacePoint> > track_segment;
+      std::vector<art::Ptr<recob::SpacePoint>> track_segment;
       AddSpacePointsToSegment(track_segment, sps_pool, (size_t)(fStartFitSize));
-      if (!IsSegmentValid(track_segment)){
+      if (!IsSegmentValid(track_segment)) {
         //Clear the pool and lets leave this place
         sps_pool.clear();
         break;
       }
 
       //Lets really try to make the initial track seed.
-      if(fMakeTrackSeed && sps_pool.size()+fStartFitSize == sps.size()){
+      if (fMakeTrackSeed && sps_pool.size() + fStartFitSize == sps.size()) {
         MakeTrackSeed(clockData, detProp, track_segment, fmh);
-        if(track_segment.empty())
-          break;
+        if (track_segment.empty()) break;
 
         track_segment_copy = track_segment;
-
       }
 
       //A sleight of hand coming up.  We are going to move the last sp from the segment back into the pool so
@@ -446,13 +481,13 @@ namespace ShowerRecoTools {
       IncrementallyFitSegment(clockData, detProp, track_segment, sps_pool, fmh, current_residual);
 
       //Check if the track has grown in size at all
-      if (initial_segment_size == track_segment.size()){
+      if (initial_segment_size == track_segment.size()) {
         //The incremental fitter could not grow th track at all.  SAD!
         //Clear the pool and let's get out of here
         sps_pool.clear();
         break;
       }
-      else{
+      else {
         //We did some good fitting and everyone is really happy with it
         //Let's store all of the hits in the final space point vector
         AddSpacePointsToSegment(initial_track, track_segment, track_segment.size());
@@ -460,8 +495,7 @@ namespace ShowerRecoTools {
     }
 
     //If we have failed then no worry we have the seed. We shall just give those points.
-    if(fMakeTrackSeed && initial_track.empty())
-      initial_track = track_segment_copy;
+    if (fMakeTrackSeed && initial_track.empty()) initial_track = track_segment_copy;
 
     //Runt the algorithm that attepmts to remove hits too far away from the track.
     PruneTrack(initial_track);
@@ -469,63 +503,76 @@ namespace ShowerRecoTools {
     return initial_track;
   }
 
-  void ShowerIncrementalTrackHitFinder::PruneFrontOfSPSPool(
-      std::vector<art::Ptr<recob::SpacePoint> > & sps_pool,
-      std::vector<art::Ptr<recob::SpacePoint> > const& initial_track){
+  void
+  ShowerIncrementalTrackHitFinder::PruneFrontOfSPSPool(
+    std::vector<art::Ptr<recob::SpacePoint>>& sps_pool,
+    std::vector<art::Ptr<recob::SpacePoint>> const& initial_track)
+  {
 
     //If the initial track is empty then there is no pruning to do
     if (initial_track.empty()) return;
-    double distance = IShowerTool::GetLArPandoraShowerAlg().DistanceBetweenSpacePoints(initial_track.back(), sps_pool.front());
-    while (distance > 1 && sps_pool.size() > 0){
+    double distance = IShowerTool::GetLArPandoraShowerAlg().DistanceBetweenSpacePoints(
+      initial_track.back(), sps_pool.front());
+    while (distance > 1 && sps_pool.size() > 0) {
       sps_pool.erase(sps_pool.begin());
-      distance = IShowerTool::GetLArPandoraShowerAlg().DistanceBetweenSpacePoints(initial_track.back(), sps_pool.front());
+      distance = IShowerTool::GetLArPandoraShowerAlg().DistanceBetweenSpacePoints(
+        initial_track.back(), sps_pool.front());
     }
     return;
   }
 
-  void ShowerIncrementalTrackHitFinder::PruneTrack(std::vector<art::Ptr<recob::SpacePoint> > & initial_track){
+  void
+  ShowerIncrementalTrackHitFinder::PruneTrack(
+    std::vector<art::Ptr<recob::SpacePoint>>& initial_track)
+  {
 
     if (initial_track.empty()) return;
-    std::vector<art::Ptr<recob::SpacePoint> >::iterator sps_it = initial_track.begin();
-    while (sps_it != std::next(initial_track.end(),-1)){
-      std::vector<art::Ptr<recob::SpacePoint> >::iterator next_sps_it = std::next(sps_it,1);
-      double distance = IShowerTool::GetLArPandoraShowerAlg().DistanceBetweenSpacePoints(*sps_it,*next_sps_it);
-      if (distance > fTrackMaxAdjacentSPDistance){
-        initial_track.erase(next_sps_it);
-      }
-      else{
+    std::vector<art::Ptr<recob::SpacePoint>>::iterator sps_it = initial_track.begin();
+    while (sps_it != std::next(initial_track.end(), -1)) {
+      std::vector<art::Ptr<recob::SpacePoint>>::iterator next_sps_it = std::next(sps_it, 1);
+      double distance =
+        IShowerTool::GetLArPandoraShowerAlg().DistanceBetweenSpacePoints(*sps_it, *next_sps_it);
+      if (distance > fTrackMaxAdjacentSPDistance) { initial_track.erase(next_sps_it); }
+      else {
         sps_it++;
       }
     }
     return;
   }
 
-
-  void ShowerIncrementalTrackHitFinder::AddSpacePointsToSegment(
-      std::vector<art::Ptr<recob::SpacePoint> > & segment,
-      std::vector<art::Ptr<recob::SpacePoint> > & sps_pool,
-      size_t num_sps_to_take){
+  void
+  ShowerIncrementalTrackHitFinder::AddSpacePointsToSegment(
+    std::vector<art::Ptr<recob::SpacePoint>>& segment,
+    std::vector<art::Ptr<recob::SpacePoint>>& sps_pool,
+    size_t num_sps_to_take)
+  {
     size_t new_segment_size = segment.size() + num_sps_to_take;
-    while (segment.size() < new_segment_size && sps_pool.size() > 0){
+    while (segment.size() < new_segment_size && sps_pool.size() > 0) {
       segment.push_back(sps_pool[0]);
       sps_pool.erase(sps_pool.begin());
     }
     return;
   }
 
-  bool ShowerIncrementalTrackHitFinder::IsSegmentValid(std::vector<art::Ptr<recob::SpacePoint> > const& segment){
+  bool
+  ShowerIncrementalTrackHitFinder::IsSegmentValid(
+    std::vector<art::Ptr<recob::SpacePoint>> const& segment)
+  {
     bool ok = true;
     if (segment.size() < (size_t)(fStartFitSize)) return !ok;
 
     return ok;
   }
 
-  bool ShowerIncrementalTrackHitFinder::IncrementallyFitSegment(const detinfo::DetectorClocksData& clockData,
-      const detinfo::DetectorPropertiesData& detProp,
-      std::vector<art::Ptr<recob::SpacePoint> > & segment,
-      std::vector<art::Ptr< recob::SpacePoint> > & sps_pool,
-      const art::FindManyP<recob::Hit> & fmh,
-      double current_residual){
+  bool
+  ShowerIncrementalTrackHitFinder::IncrementallyFitSegment(
+    const detinfo::DetectorClocksData& clockData,
+    const detinfo::DetectorPropertiesData& detProp,
+    std::vector<art::Ptr<recob::SpacePoint>>& segment,
+    std::vector<art::Ptr<recob::SpacePoint>>& sps_pool,
+    const art::FindManyP<recob::Hit>& fmh,
+    double current_residual)
+  {
 
     bool ok = true;
     //Firstly, are there any space points left???
@@ -538,23 +585,24 @@ namespace ShowerRecoTools {
     double residual = FitSegmentAndCalculateResidual(clockData, detProp, segment, fmh);
 
     ok = IsResidualOK(residual, current_residual, segment.size());
-    if (!ok){
+    if (!ok) {
       //Create a sub pool of space points to pass to the refitter
-      std::vector<art::Ptr<recob::SpacePoint> > sub_sps_pool;
+      std::vector<art::Ptr<recob::SpacePoint>> sub_sps_pool;
       AddSpacePointsToSegment(sub_sps_pool, sps_pool, fNMissPoints);
       //We'll need an additional copy of this pool, as we will need the space points if we have to start a new
       //segment later, but all of the funtionality drains the pools during use
-      std::vector<art::Ptr<recob::SpacePoint> > sub_sps_pool_cache = sub_sps_pool;
+      std::vector<art::Ptr<recob::SpacePoint>> sub_sps_pool_cache = sub_sps_pool;
       //The most recently added SP to the segment is bad but it will get thrown away by RecursivelyReplaceLastSpacePointAndRefit
       //It's possible that we will need it if we end up forming an entirely new line from scratch, so
       //add the bad SP to the front of the cache
       sub_sps_pool_cache.insert(sub_sps_pool_cache.begin(), segment.back());
-      ok = RecursivelyReplaceLastSpacePointAndRefit(clockData, detProp, segment, sub_sps_pool, fmh, current_residual);
-      if (ok){
+      ok = RecursivelyReplaceLastSpacePointAndRefit(
+        clockData, detProp, segment, sub_sps_pool, fmh, current_residual);
+      if (ok) {
         //The refitting may have dropped a couple of points but it managed to find a point that kept the residual
         //at a sensible value.
         //Add the remaining SPS in the reduced pool back t othe start of the larger pool
-        while (sub_sps_pool.size() > 0){
+        while (sub_sps_pool.size() > 0) {
           sps_pool.insert(sps_pool.begin(), sub_sps_pool.back());
           sub_sps_pool.pop_back();
         }
@@ -565,7 +613,7 @@ namespace ShowerRecoTools {
         //All of the space points in the reduced pool could not sensibly refit the track.  The reduced pool will be
         //empty so move all of the cached space points back into the main pool
         //        std::cout<<"The refitting was NOT a success, dumping  all " << sub_sps_pool_cache.size() << "  sps back into the pool" << std::endl;
-        while (sub_sps_pool_cache.size() > 0){
+        while (sub_sps_pool_cache.size() > 0) {
           sps_pool.insert(sps_pool.begin(), sub_sps_pool_cache.back());
           sub_sps_pool_cache.pop_back();
         }
@@ -583,51 +631,68 @@ namespace ShowerRecoTools {
     return IncrementallyFitSegment(clockData, detProp, segment, sps_pool, fmh, current_residual);
   }
 
-  double ShowerIncrementalTrackHitFinder::FitSegmentAndCalculateResidual(const detinfo::DetectorClocksData& clockData,
-      const detinfo::DetectorPropertiesData& detProp,
-      std::vector<art::Ptr<recob::SpacePoint> > & segment,
-      const art::FindManyP<recob::Hit> & fmh){
+  double
+  ShowerIncrementalTrackHitFinder::FitSegmentAndCalculateResidual(
+    const detinfo::DetectorClocksData& clockData,
+    const detinfo::DetectorPropertiesData& detProp,
+    std::vector<art::Ptr<recob::SpacePoint>>& segment,
+    const art::FindManyP<recob::Hit>& fmh)
+  {
 
     TVector3 primary_axis;
-    if (fChargeWeighted) primary_axis = ShowerPCAVector(clockData, detProp, segment, fmh);
-    else primary_axis = ShowerPCAVector(segment);
+    if (fChargeWeighted)
+      primary_axis = ShowerPCAVector(clockData, detProp, segment, fmh);
+    else
+      primary_axis = ShowerPCAVector(segment);
 
     TVector3 segment_centre;
-    if (fChargeWeighted) segment_centre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, segment,fmh);
-    else segment_centre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(segment);
+    if (fChargeWeighted)
+      segment_centre =
+        IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, segment, fmh);
+    else
+      segment_centre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(segment);
 
     double residual = CalculateResidual(segment, primary_axis, segment_centre);
 
     return residual;
   }
 
-  double ShowerIncrementalTrackHitFinder::FitSegmentAndCalculateResidual(const detinfo::DetectorClocksData& clockData,
-      const detinfo::DetectorPropertiesData& detProp,
-      std::vector<art::Ptr<recob::SpacePoint> > & segment,
-      const art::FindManyP<recob::Hit> & fmh,
-      int& max_residual_point){
+  double
+  ShowerIncrementalTrackHitFinder::FitSegmentAndCalculateResidual(
+    const detinfo::DetectorClocksData& clockData,
+    const detinfo::DetectorPropertiesData& detProp,
+    std::vector<art::Ptr<recob::SpacePoint>>& segment,
+    const art::FindManyP<recob::Hit>& fmh,
+    int& max_residual_point)
+  {
 
     TVector3 primary_axis;
-    if (fChargeWeighted) primary_axis = ShowerPCAVector(clockData, detProp, segment, fmh);
-    else primary_axis = ShowerPCAVector(segment);
+    if (fChargeWeighted)
+      primary_axis = ShowerPCAVector(clockData, detProp, segment, fmh);
+    else
+      primary_axis = ShowerPCAVector(segment);
 
     TVector3 segment_centre;
-    if (fChargeWeighted) segment_centre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, segment,fmh);
-    else segment_centre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(segment);
+    if (fChargeWeighted)
+      segment_centre =
+        IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, segment, fmh);
+    else
+      segment_centre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(segment);
 
     double residual = CalculateResidual(segment, primary_axis, segment_centre, max_residual_point);
 
     return residual;
   }
 
-
-
-  bool ShowerIncrementalTrackHitFinder::RecursivelyReplaceLastSpacePointAndRefit(const detinfo::DetectorClocksData& clockData,
-      const detinfo::DetectorPropertiesData& detProp,
-      std::vector<art::Ptr<recob::SpacePoint> > & segment,
-      std::vector<art::Ptr< recob::SpacePoint> > & reduced_sps_pool,
-      const art::FindManyP<recob::Hit>  & fmh,
-      double current_residual){
+  bool
+  ShowerIncrementalTrackHitFinder::RecursivelyReplaceLastSpacePointAndRefit(
+    const detinfo::DetectorClocksData& clockData,
+    const detinfo::DetectorPropertiesData& detProp,
+    std::vector<art::Ptr<recob::SpacePoint>>& segment,
+    std::vector<art::Ptr<recob::SpacePoint>>& reduced_sps_pool,
+    const art::FindManyP<recob::Hit>& fmh,
+    double current_residual)
+  {
 
     bool ok = true;
     //If the pool is empty, then there is nothing to do (sad)
@@ -641,127 +706,157 @@ namespace ShowerRecoTools {
     ok = IsResidualOK(residual, current_residual, segment.size());
     //    std::cout<<"recursive refit: isok " << ok << "  res: " << residual << "  curr res: " << current_residual << std::endl;
     if (ok) return ok;
-    return RecursivelyReplaceLastSpacePointAndRefit(clockData, detProp, segment, reduced_sps_pool, fmh, current_residual);
+    return RecursivelyReplaceLastSpacePointAndRefit(
+      clockData, detProp, segment, reduced_sps_pool, fmh, current_residual);
   }
 
-  double ShowerIncrementalTrackHitFinder::CalculateResidual(std::vector<art::Ptr<recob::SpacePoint> >& sps, TVector3& PCAEigenvector, TVector3& TrackPosition){
+  double
+  ShowerIncrementalTrackHitFinder::CalculateResidual(std::vector<art::Ptr<recob::SpacePoint>>& sps,
+                                                     TVector3& PCAEigenvector,
+                                                     TVector3& TrackPosition)
+  {
 
     double Residual = 0;
 
-    for(auto const& sp: sps){
+    for (auto const& sp : sps) {
 
       //Get the relative position of the spacepoint
-      TVector3 pos= IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - TrackPosition;
+      TVector3 pos = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - TrackPosition;
 
       //Gen the perpendicular distance
-      double len  = pos.Dot(PCAEigenvector);
-      double perp = (pos - len*PCAEigenvector).Mag();
+      double len = pos.Dot(PCAEigenvector);
+      double perp = (pos - len * PCAEigenvector).Mag();
 
       Residual += perp;
-
     }
     return Residual;
   }
 
-
-  double ShowerIncrementalTrackHitFinder::CalculateResidual(std::vector<art::Ptr<recob::SpacePoint> >& sps, TVector3& PCAEigenvector, TVector3& TrackPosition, int& max_residual_point){
+  double
+  ShowerIncrementalTrackHitFinder::CalculateResidual(std::vector<art::Ptr<recob::SpacePoint>>& sps,
+                                                     TVector3& PCAEigenvector,
+                                                     TVector3& TrackPosition,
+                                                     int& max_residual_point)
+  {
 
     double Residual = 0;
-    double max_residual  = -999;
+    double max_residual = -999;
 
-    for(auto const& sp: sps){
+    for (auto const& sp : sps) {
 
       //Get the relative position of the spacepoint
-      TVector3 pos= IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - TrackPosition;
+      TVector3 pos = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - TrackPosition;
 
       //Gen the perpendicular distance
-      double len  = pos.Dot(PCAEigenvector);
-      double perp = (pos - len*PCAEigenvector).Mag();
+      double len = pos.Dot(PCAEigenvector);
+      double perp = (pos - len * PCAEigenvector).Mag();
 
       Residual += perp;
 
-      if(perp > max_residual){
+      if (perp > max_residual) {
         max_residual = perp;
         max_residual_point = sp.key();
       }
-
     }
     return Residual;
   }
 
-
-
-  std::vector<art::Ptr<recob::SpacePoint> > ShowerIncrementalTrackHitFinder::CreateFakeShowerTrajectory(TVector3 start_position, TVector3 start_direction){
-    std::vector<art::Ptr<recob::SpacePoint> > fake_sps;
-    std::vector<art::Ptr<recob::SpacePoint> > segment_a = CreateFakeSPLine(start_position, start_direction, 20);
+  std::vector<art::Ptr<recob::SpacePoint>>
+  ShowerIncrementalTrackHitFinder::CreateFakeShowerTrajectory(TVector3 start_position,
+                                                              TVector3 start_direction)
+  {
+    std::vector<art::Ptr<recob::SpacePoint>> fake_sps;
+    std::vector<art::Ptr<recob::SpacePoint>> segment_a =
+      CreateFakeSPLine(start_position, start_direction, 20);
     fake_sps.insert(std::end(fake_sps), std::begin(segment_a), std::end(segment_a));
 
     //make a new segment:
-    TVector3 sp_position = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(fake_sps.back());
+    TVector3 sp_position =
+      IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(fake_sps.back());
     TVector3 direction = start_direction;
-    direction.RotateX(10.*3.142/180.);
-    std::vector<art::Ptr<recob::SpacePoint> > segment_b = CreateFakeSPLine(sp_position, direction, 10);
+    direction.RotateX(10. * 3.142 / 180.);
+    std::vector<art::Ptr<recob::SpacePoint>> segment_b =
+      CreateFakeSPLine(sp_position, direction, 10);
     fake_sps.insert(std::end(fake_sps), std::begin(segment_b), std::end(segment_b));
 
     //Now make three branches that come from the end of the segment
-    TVector3 branching_position = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(fake_sps.back());
+    TVector3 branching_position =
+      IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(fake_sps.back());
 
     TVector3 direction_branch_a = direction;
-    direction_branch_a.RotateZ(15.*3.142/180.);
-    std::vector<art::Ptr<recob::SpacePoint> > branch_a = CreateFakeSPLine(branching_position, direction_branch_a, 6);
+    direction_branch_a.RotateZ(15. * 3.142 / 180.);
+    std::vector<art::Ptr<recob::SpacePoint>> branch_a =
+      CreateFakeSPLine(branching_position, direction_branch_a, 6);
     fake_sps.insert(std::end(fake_sps), std::begin(branch_a), std::end(branch_a));
 
     TVector3 direction_branch_b = direction;
-    direction_branch_b.RotateY(20.*3.142/180.);
-    std::vector<art::Ptr<recob::SpacePoint> > branch_b = CreateFakeSPLine(branching_position, direction_branch_b, 10);
+    direction_branch_b.RotateY(20. * 3.142 / 180.);
+    std::vector<art::Ptr<recob::SpacePoint>> branch_b =
+      CreateFakeSPLine(branching_position, direction_branch_b, 10);
     fake_sps.insert(std::end(fake_sps), std::begin(branch_b), std::end(branch_b));
 
     TVector3 direction_branch_c = direction;
-    direction_branch_c.RotateX(3.*3.142/180.);
-    std::vector<art::Ptr<recob::SpacePoint> > branch_c = CreateFakeSPLine(branching_position, direction_branch_c, 20);
+    direction_branch_c.RotateX(3. * 3.142 / 180.);
+    std::vector<art::Ptr<recob::SpacePoint>> branch_c =
+      CreateFakeSPLine(branching_position, direction_branch_c, 20);
     fake_sps.insert(std::end(fake_sps), std::begin(branch_c), std::end(branch_c));
 
     return fake_sps;
   }
 
-  std::vector<art::Ptr<recob::SpacePoint> > ShowerIncrementalTrackHitFinder::CreateFakeSPLine(TVector3 start_position, TVector3 start_direction, int npoints){
-    std::vector<art::Ptr<recob::SpacePoint> > fake_sps;
+  std::vector<art::Ptr<recob::SpacePoint>>
+  ShowerIncrementalTrackHitFinder::CreateFakeSPLine(TVector3 start_position,
+                                                    TVector3 start_direction,
+                                                    int npoints)
+  {
+    std::vector<art::Ptr<recob::SpacePoint>> fake_sps;
     art::ProductID prod_id(std::string("totally_genuine"));
     size_t current_id = 500000;
 
     double step_length = 0.2;
-    for (double i_point = 0; i_point < npoints; i_point++){
-      TVector3 new_position = start_position + i_point*step_length*start_direction;
+    for (double i_point = 0; i_point < npoints; i_point++) {
+      TVector3 new_position = start_position + i_point * step_length * start_direction;
       Double32_t xyz[3] = {new_position.X(), new_position.Y(), new_position.Z()};
-      Double32_t err[3] = {0.,0.,0.};
-      recob::SpacePoint *sp = new recob::SpacePoint(xyz,err,0,1);
+      Double32_t err[3] = {0., 0., 0.};
+      recob::SpacePoint* sp = new recob::SpacePoint(xyz, err, 0, 1);
       fake_sps.emplace_back(art::Ptr<recob::SpacePoint>(prod_id, sp, current_id++));
     }
     return fake_sps;
   }
 
-  void ShowerIncrementalTrackHitFinder::RunTestOfIncrementalSpacePointFinder(const art::Event& Event,
-      const art::FindManyP<recob::Hit>& dud_fmh){
-    TVector3 start_position(50,50,50);
-    TVector3 start_direction(0,0,1);
-    std::vector<art::Ptr<recob::SpacePoint> > fake_sps = CreateFakeShowerTrajectory(start_position,start_direction);
+  void
+  ShowerIncrementalTrackHitFinder::RunTestOfIncrementalSpacePointFinder(
+    const art::Event& Event,
+    const art::FindManyP<recob::Hit>& dud_fmh)
+  {
+    TVector3 start_position(50, 50, 50);
+    TVector3 start_direction(0, 0, 1);
+    std::vector<art::Ptr<recob::SpacePoint>> fake_sps =
+      CreateFakeShowerTrajectory(start_position, start_direction);
 
-    IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(fake_sps,start_position);
+    IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(fake_sps, start_position);
 
-    std::vector<art::Ptr<recob::SpacePoint> > track_sps = RunIncrementalSpacePointFinder(Event, fake_sps, dud_fmh);
+    std::vector<art::Ptr<recob::SpacePoint>> track_sps =
+      RunIncrementalSpacePointFinder(Event, fake_sps, dud_fmh);
 
     TGraph2D graph_sps;
-    for (size_t i_sp = 0; i_sp < fake_sps.size(); i_sp++){
-      graph_sps.SetPoint(graph_sps.GetN(), fake_sps[i_sp]->XYZ()[0], fake_sps[i_sp]->XYZ()[1], fake_sps[i_sp]->XYZ()[2]);
+    for (size_t i_sp = 0; i_sp < fake_sps.size(); i_sp++) {
+      graph_sps.SetPoint(graph_sps.GetN(),
+                         fake_sps[i_sp]->XYZ()[0],
+                         fake_sps[i_sp]->XYZ()[1],
+                         fake_sps[i_sp]->XYZ()[2]);
     }
     TGraph2D graph_track_sps;
-    for (size_t i_sp = 0; i_sp < track_sps.size(); i_sp++){
-      graph_track_sps.SetPoint(graph_track_sps.GetN(), track_sps[i_sp]->XYZ()[0], track_sps[i_sp]->XYZ()[1], track_sps[i_sp]->XYZ()[2]);
+    for (size_t i_sp = 0; i_sp < track_sps.size(); i_sp++) {
+      graph_track_sps.SetPoint(graph_track_sps.GetN(),
+                               track_sps[i_sp]->XYZ()[0],
+                               track_sps[i_sp]->XYZ()[1],
+                               track_sps[i_sp]->XYZ()[2]);
     }
 
-    art::ServiceHandle<art::TFileService>   tfs;
+    art::ServiceHandle<art::TFileService> tfs;
 
-    TCanvas* canvas = tfs->make<TCanvas>("test_inc_can","test_inc_can");
+    TCanvas* canvas = tfs->make<TCanvas>("test_inc_can", "test_inc_can");
     canvas->SetName("test_inc_can");
     graph_sps.SetMarkerStyle(8);
     graph_sps.SetMarkerColor(1);
@@ -780,4 +875,3 @@ namespace ShowerRecoTools {
 }
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerIncrementalTrackHitFinder)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerLengthPercentile_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerLengthPercentile_tool.cc
@@ -14,109 +14,107 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerLengthPercentile : public IShowerTool {
 
-  class ShowerLengthPercentile: public IShowerTool {
+  public:
+    ShowerLengthPercentile(const fhicl::ParameterSet& pset);
 
-    public:
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerLengthPercentile(const fhicl::ParameterSet& pset);
+  private:
+    float fPercentile;
 
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      float fPercentile;
-
-      art::InputTag fPFParticleLabel;
-      int           fVerbose;
-      std::string   fShowerStartPositionInputLabel;
-      std::string   fShowerDirectionInputLabel;
-      std::string   fShowerLengthOutputLabel;
-      std::string   fShowerOpeningAngleOutputLabel;
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionInputLabel;
+    std::string fShowerLengthOutputLabel;
+    std::string fShowerOpeningAngleOutputLabel;
   };
 
+  ShowerLengthPercentile::ShowerLengthPercentile(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPercentile(pset.get<float>("Percentile"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+    , fShowerLengthOutputLabel(pset.get<std::string>("ShowerLengthOutputLabel"))
+    , fShowerOpeningAngleOutputLabel(pset.get<std::string>("ShowerOpeningAngleOutputLabel"))
+  {}
 
-  ShowerLengthPercentile::ShowerLengthPercentile(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPercentile(pset.get<float>("Percentile")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel")),
-    fShowerLengthOutputLabel(pset.get<std::string>("ShowerLengthOutputLabel")),
-    fShowerOpeningAngleOutputLabel(pset.get<std::string>("ShowerOpeningAngleOutputLabel"))
+  int
+  ShowerLengthPercentile::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                           art::Event& Event,
+                                           reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int ShowerLengthPercentile::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     //Get the start position
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerLengthPercentile") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerLengthPercentile") << "Start position not set, returning " << std::endl;
       return 1;
     }
     //Only consider hits in the same tpcs as the vertex.
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,ShowerStartPosition);
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, ShowerStartPosition);
 
     // Get the assocated pfParicle Handle
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
     // Get the spacepoint - PFParticle assn
-    const art::FindManyP<recob::SpacePoint>& fmspp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>(
-        pfpHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::SpacePoint>& fmspp =
+      ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
 
     // Get the SpacePoints
-    std::vector<art::Ptr<recob::SpacePoint> > spacePoints = fmspp.at(pfparticle.key());
-    if (spacePoints.empty()){
+    std::vector<art::Ptr<recob::SpacePoint>> spacePoints = fmspp.at(pfparticle.key());
+    if (spacePoints.empty()) {
       if (fVerbose)
-        mf::LogError("ShowerLengthPercentile") << "No Spacepoints, returning" <<std::endl;
+        mf::LogError("ShowerLengthPercentile") << "No Spacepoints, returning" << std::endl;
       return 1;
     }
 
-
-    if(!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerLengthPercentile") << "Direction not set, returning "<< std::endl;
+        mf::LogError("ShowerLengthPercentile") << "Direction not set, returning " << std::endl;
       return 1;
     }
 
-    TVector3 ShowerDirection     = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerDirectionInputLabel,ShowerDirection);
+    TVector3 ShowerDirection = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerDirectionInputLabel, ShowerDirection);
 
     //Order the spacepoints
-    IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(spacePoints,ShowerStartPosition,ShowerDirection);
+    IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePoints(
+      spacePoints, ShowerStartPosition, ShowerDirection);
 
     //Find the length as the value that contains % of the hits
-    int lengthIter = fPercentile*spacePoints.size();
+    int lengthIter = fPercentile * spacePoints.size();
 
     //Find the length
     double ShowerLength = IShowerTool::GetLArPandoraShowerAlg().SpacePointProjection(
-        spacePoints[lengthIter], ShowerStartPosition, ShowerDirection);
+      spacePoints[lengthIter], ShowerStartPosition, ShowerDirection);
     double ShowerMaxProjection = IShowerTool::GetLArPandoraShowerAlg().SpacePointProjection(
-        spacePoints[spacePoints.size() -1], ShowerStartPosition, ShowerDirection);
+      spacePoints[spacePoints.size() - 1], ShowerStartPosition, ShowerDirection);
 
     double ShowerLengthError = ShowerMaxProjection - ShowerLength;
 
     //Order the spacepoints in perpendicular
-    IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePointsPerpendicular(spacePoints,ShowerStartPosition,ShowerDirection);
+    IShowerTool::GetLArPandoraShowerAlg().OrderShowerSpacePointsPerpendicular(
+      spacePoints, ShowerStartPosition, ShowerDirection);
 
     //Find the length as the value that contains % of the hits
-    int perpIter = fPercentile*spacePoints.size();
+    int perpIter = fPercentile * spacePoints.size();
 
     //Find the width of the shower
     double ShowerWidth = IShowerTool::GetLArPandoraShowerAlg().SpacePointPerpendicular(
-        spacePoints[perpIter], ShowerStartPosition, ShowerDirection);
+      spacePoints[perpIter], ShowerStartPosition, ShowerDirection);
     // double ShowerMaxWidth = IShowerTool::GetLArPandoraShowerAlg().SpacePointPerpendicular(
     //     spacePoints[spacePoints.size() -1], ShowerStartPosition, ShowerDirection);
 
-    double ShowerAngle = std::atan(ShowerWidth/ShowerLength);
+    double ShowerAngle = std::atan(ShowerWidth / ShowerLength);
     double ShowerAngleError = -999; //TODO: Do properly
 
     // Fill the shower element holder

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerLinearEnergy_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerLinearEnergy_tool.cc
@@ -11,127 +11,127 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "lardataobj/RecoBase/Cluster.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace ShowerRecoTools {
 
-  class ShowerLinearEnergy:IShowerTool {
+  class ShowerLinearEnergy : IShowerTool {
 
-    public:
+  public:
+    ShowerLinearEnergy(const fhicl::ParameterSet& pset);
 
-      ShowerLinearEnergy(const fhicl::ParameterSet& pset);
+    //Physics Function. Calculate the shower Energy.
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerElementHolder) override;
 
-      //Physics Function. Calculate the shower Energy.
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerElementHolder
-          ) override;
-    private:
+  private:
+    double CalculateEnergy(const detinfo::DetectorClocksData& clockData,
+                           const detinfo::DetectorPropertiesData& detProp,
+                           const std::vector<art::Ptr<recob::Hit>>& hits,
+                           const geo::PlaneID::PlaneID_t plane) const;
 
-      double CalculateEnergy(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          const std::vector<art::Ptr<recob::Hit> >& hits,
-          const geo::PlaneID::PlaneID_t plane) const;
+    //fcl parameters
+    unsigned int fNumPlanes;
+    std::vector<double> fGradients;  //Gradient of the linear fit of total charge to total energy
+    std::vector<double> fIntercepts; //Intercept of the linear fit of total charge to total energy
 
-      //fcl parameters
-      unsigned int        fNumPlanes;
-      std::vector<double> fGradients;   //Gradient of the linear fit of total charge to total energy
-      std::vector<double> fIntercepts;  //Intercept of the linear fit of total charge to total energy
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
 
-      art::InputTag fPFParticleLabel;
-      int           fVerbose;
+    std::string fShowerEnergyOutputLabel;
+    std::string fShowerBestPlaneOutputLabel;
 
-      std::string fShowerEnergyOutputLabel;
-      std::string fShowerBestPlaneOutputLabel;
-
-      //Services
-      art::ServiceHandle<geo::Geometry> fGeom;
-
+    //Services
+    art::ServiceHandle<geo::Geometry> fGeom;
   };
 
-  ShowerLinearEnergy::ShowerLinearEnergy(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fGradients(pset.get<std::vector<double> >("Gradients")),
-    fIntercepts(pset.get<std::vector<double> >("Intercepts")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fShowerEnergyOutputLabel(pset.get<std::string>("ShowerEnergyOutputLabel")),
-    fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel"))
+  ShowerLinearEnergy::ShowerLinearEnergy(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fGradients(pset.get<std::vector<double>>("Gradients"))
+    , fIntercepts(pset.get<std::vector<double>>("Intercepts"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fShowerEnergyOutputLabel(pset.get<std::string>("ShowerEnergyOutputLabel"))
+    , fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel"))
   {
     fNumPlanes = fGeom->Nplanes();
-    if (fNumPlanes!=fGradients.size() || fNumPlanes!=fIntercepts.size()){
+    if (fNumPlanes != fGradients.size() || fNumPlanes != fIntercepts.size()) {
       throw cet::exception("ShowerLinearEnergy")
         << "The number of planes does not match the size of the fcl parametes passed: Num Planes: "
-        << fNumPlanes << ", Gradients size: " << fGradients.size() << ", Intercpts size: "
-        << fIntercepts.size();
+        << fNumPlanes << ", Gradients size: " << fGradients.size()
+        << ", Intercpts size: " << fIntercepts.size();
     }
   }
 
-  int ShowerLinearEnergy::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder
-      ){
+  int
+  ShowerLinearEnergy::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                       art::Event& Event,
+                                       reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     // Get the assocated pfParicle vertex PFParticles
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
     //Get the clusters
-    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster> >(fPFParticleLabel);
+    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster>>(fPFParticleLabel);
 
-    const art::FindManyP<recob::Cluster>& fmc = ShowerEleHolder.GetFindManyP<recob::Cluster>(
-        pfpHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Cluster>& fmc =
+      ShowerEleHolder.GetFindManyP<recob::Cluster>(pfpHandle, Event, fPFParticleLabel);
     // art::FindManyP<recob::Cluster> fmc(pfpHandle, Event, fPFParticleLabel);
-    std::vector<art::Ptr<recob::Cluster> > clusters = fmc.at(pfparticle.key());
+    std::vector<art::Ptr<recob::Cluster>> clusters = fmc.at(pfparticle.key());
 
     //Get the hit association
-    const art::FindManyP<recob::Hit>& fmhc = ShowerEleHolder.GetFindManyP<recob::Hit>(
-        clusHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Hit>& fmhc =
+      ShowerEleHolder.GetFindManyP<recob::Hit>(clusHandle, Event, fPFParticleLabel);
     // art::FindManyP<recob::Hit> fmhc(clusHandle, Event, fPFParticleLabel);
 
-    std::map<geo::PlaneID::PlaneID_t, std::vector<art::Ptr<recob::Hit> > > planeHits;
+    std::map<geo::PlaneID::PlaneID_t, std::vector<art::Ptr<recob::Hit>>> planeHits;
 
     //Loop over the clusters in the plane and get the hits
-    for(auto const& cluster: clusters){
+    for (auto const& cluster : clusters) {
 
       //Get the hits
-      std::vector<art::Ptr<recob::Hit> > hits = fmhc.at(cluster.key());
+      std::vector<art::Ptr<recob::Hit>> hits = fmhc.at(cluster.key());
 
       //Get the plane.
       const geo::PlaneID::PlaneID_t plane(cluster->Plane().Plane);
 
-      planeHits[plane].insert(planeHits[plane].end(),hits.begin(),hits.end());
+      planeHits[plane].insert(planeHits[plane].end(), hits.begin(), hits.end());
     }
 
     // Calculate the energy for each plane && best plane
-    geo::PlaneID::PlaneID_t bestPlane  = std::numeric_limits<geo::PlaneID::PlaneID_t>::max();
+    geo::PlaneID::PlaneID_t bestPlane = std::numeric_limits<geo::PlaneID::PlaneID_t>::max();
     unsigned int bestPlaneNumHits = 0;
 
     //Holder for the final product
     std::vector<double> energyVec(fNumPlanes, -999.);
     std::vector<double> energyError(fNumPlanes, -999.);
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
-    for(auto const& [plane, hits]: planeHits){
+    for (auto const& [plane, hits] : planeHits) {
 
       unsigned int planeNumHits = hits.size();
 
       //Calculate the Energy for
-      double Energy = CalculateEnergy(clockData, detProp, hits,plane);
+      double Energy = CalculateEnergy(clockData, detProp, hits, plane);
       // If the energy is negative, leave it at -999
-      if (Energy>0)
-        energyVec.at(plane) = Energy;
+      if (Energy > 0) energyVec.at(plane) = Energy;
 
       if (planeNumHits > bestPlaneNumHits) {
-        bestPlane        = plane;
+        bestPlane = plane;
         bestPlaneNumHits = planeNumHits;
       }
     }
 
     ShowerEleHolder.SetElement(energyVec, energyError, fShowerEnergyOutputLabel);
     // Only set the best plane if it has some hits in it
-    if (bestPlane < fGeom->Nplanes()){
+    if (bestPlane < fGeom->Nplanes()) {
       // Need to cast as an int for legacy default of -999
       // have to define a new variable as we pass-by-reference when filling
       int bestPlaneVal(bestPlane);
@@ -143,24 +143,24 @@ namespace ShowerRecoTools {
 
   //Function to calculate the energy of a shower in a plane. Using a linear map between charge and Energy.
   //Exactly the same method as the ShowerEnergyAlg.cxx. Thanks Mike.
-  double ShowerLinearEnergy::CalculateEnergy(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          const std::vector<art::Ptr<recob::Hit> >& hits,
-          const geo::PlaneID::PlaneID_t plane) const {
+  double
+  ShowerLinearEnergy::CalculateEnergy(const detinfo::DetectorClocksData& clockData,
+                                      const detinfo::DetectorPropertiesData& detProp,
+                                      const std::vector<art::Ptr<recob::Hit>>& hits,
+                                      const geo::PlaneID::PlaneID_t plane) const
+  {
 
     double totalCharge = 0, totalEnergy = 0;
 
-    for (auto const& hit: hits){
-      totalCharge += (hit->Integral() * std::exp((sampling_rate(clockData)* hit->PeakTime()) / (detProp.ElectronLifetime()*1e3) ) );
+    for (auto const& hit : hits) {
+      totalCharge += (hit->Integral() * std::exp((sampling_rate(clockData) * hit->PeakTime()) /
+                                                 (detProp.ElectronLifetime() * 1e3)));
     }
 
     totalEnergy = (totalCharge * fGradients.at(plane)) + fIntercepts.at(plane);
 
     return totalEnergy;
-
   }
 }
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerLinearEnergy)
-
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerNumElectronsEnergy_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerNumElectronsEnergy_tool.cc
@@ -12,9 +12,9 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
-#include "lardataobj/RecoBase/Cluster.h"
 #include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h"
+#include "lardataobj/RecoBase/Cluster.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "larreco/Calorimetry/CalorimetryAlg.h"
 
 //C++ Includes
@@ -22,118 +22,118 @@
 
 namespace ShowerRecoTools {
 
-  class ShowerNumElectronsEnergy:IShowerTool {
+  class ShowerNumElectronsEnergy : IShowerTool {
 
-    public:
+  public:
+    ShowerNumElectronsEnergy(const fhicl::ParameterSet& pset);
 
-      ShowerNumElectronsEnergy(const fhicl::ParameterSet& pset);
+    //Physics Function. Calculate the shower Energy.
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerElementHolder) override;
 
-      //Physics Function. Calculate the shower Energy.
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerElementHolder
-          ) override;
+  private:
+    double CalculateEnergy(const detinfo::DetectorClocksData& clockData,
+                           const detinfo::DetectorPropertiesData& detProp,
+                           const std::vector<art::Ptr<recob::Hit>>& hits,
+                           const geo::PlaneID::PlaneID_t plane) const;
 
-    private:
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
 
-      double CalculateEnergy(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          const std::vector<art::Ptr<recob::Hit> >& hits,
-          const geo::PlaneID::PlaneID_t plane) const;
+    std::string fShowerEnergyOutputLabel;
+    std::string fShowerBestPlaneOutputLabel;
 
-      art::InputTag fPFParticleLabel;
-      int fVerbose;
+    //Services
+    art::ServiceHandle<geo::Geometry> fGeom;
+    calo::CalorimetryAlg fCalorimetryAlg;
 
-      std::string fShowerEnergyOutputLabel;
-      std::string fShowerBestPlaneOutputLabel;
-
-      //Services
-      art::ServiceHandle<geo::Geometry> fGeom;
-      calo::CalorimetryAlg              fCalorimetryAlg;
-
-      // Declare stuff
-      double fRecombinationFactor;
+    // Declare stuff
+    double fRecombinationFactor;
   };
 
-  ShowerNumElectronsEnergy::ShowerNumElectronsEnergy(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fShowerEnergyOutputLabel(pset.get<std::string>("ShowerEnergyOutputLabel")),
-    fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel")),
-    fCalorimetryAlg(pset.get<fhicl::ParameterSet>("CalorimetryAlg")),
-    fRecombinationFactor(pset.get<double>("RecombinationFactor"))
-  {
-  }
+  ShowerNumElectronsEnergy::ShowerNumElectronsEnergy(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fShowerEnergyOutputLabel(pset.get<std::string>("ShowerEnergyOutputLabel"))
+    , fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel"))
+    , fCalorimetryAlg(pset.get<fhicl::ParameterSet>("CalorimetryAlg"))
+    , fRecombinationFactor(pset.get<double>("RecombinationFactor"))
+  {}
 
-  int ShowerNumElectronsEnergy::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder
-      ){
+  int
+  ShowerNumElectronsEnergy::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                             art::Event& Event,
+                                             reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     if (fVerbose)
-      std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Shower Reco Energy Tool ~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
+      std::cout
+        << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Shower Reco Energy Tool ~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        << std::endl;
 
     // Get the assocated pfParicle vertex PFParticles
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
     //Get the clusters
-    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster> >(fPFParticleLabel);
+    auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster>>(fPFParticleLabel);
 
-    const art::FindManyP<recob::Cluster>& fmc = ShowerEleHolder.GetFindManyP<recob::Cluster>(
-        pfpHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Cluster>& fmc =
+      ShowerEleHolder.GetFindManyP<recob::Cluster>(pfpHandle, Event, fPFParticleLabel);
     // art::FindManyP<recob::Cluster> fmc(pfpHandle, Event, fPFParticleLabel);
-    std::vector<art::Ptr<recob::Cluster> > clusters = fmc.at(pfparticle.key());
+    std::vector<art::Ptr<recob::Cluster>> clusters = fmc.at(pfparticle.key());
 
     //Get the hit association
-    const art::FindManyP<recob::Hit>& fmhc = ShowerEleHolder.GetFindManyP<recob::Hit>(
-        clusHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Hit>& fmhc =
+      ShowerEleHolder.GetFindManyP<recob::Hit>(clusHandle, Event, fPFParticleLabel);
     // art::FindManyP<recob::Hit> fmhc(clusHandle, Event, fPFParticleLabel);
 
-    std::map<geo::PlaneID::PlaneID_t, std::vector<art::Ptr<recob::Hit> > > planeHits;
+    std::map<geo::PlaneID::PlaneID_t, std::vector<art::Ptr<recob::Hit>>> planeHits;
 
     //Loop over the clusters in the plane and get the hits
-    for(auto const& cluster: clusters){
+    for (auto const& cluster : clusters) {
 
       //Get the hits
-      std::vector<art::Ptr<recob::Hit> > hits = fmhc.at(cluster.key());
+      std::vector<art::Ptr<recob::Hit>> hits = fmhc.at(cluster.key());
 
       //Get the plane.
       const geo::PlaneID::PlaneID_t plane(cluster->Plane().Plane);
 
-      planeHits[plane].insert(planeHits[plane].end(),hits.begin(),hits.end());
+      planeHits[plane].insert(planeHits[plane].end(), hits.begin(), hits.end());
     }
 
     // Calculate the energy for each plane && best plane
-    geo::PlaneID::PlaneID_t bestPlane  = std::numeric_limits<geo::PlaneID::PlaneID_t>::max();
+    geo::PlaneID::PlaneID_t bestPlane = std::numeric_limits<geo::PlaneID::PlaneID_t>::max();
     unsigned int bestPlaneNumHits = 0;
 
     //Holder for the final product
     std::vector<double> energyVec(fGeom->Nplanes(), -999.);
     std::vector<double> energyError(fGeom->Nplanes(), -999.);
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
-    for(auto const& [plane, hits]: planeHits){
+    for (auto const& [plane, hits] : planeHits) {
 
       unsigned int planeNumHits = hits.size();
 
       //Calculate the Energy for
       double Energy = CalculateEnergy(clockData, detProp, hits, plane);
       // If the energy is negative, leave it at -999
-      if (Energy>0)
-        energyVec.at(plane) = Energy;
+      if (Energy > 0) energyVec.at(plane) = Energy;
 
       if (planeNumHits > bestPlaneNumHits) {
-        bestPlane        = plane;
+        bestPlane = plane;
         bestPlaneNumHits = planeNumHits;
       }
     }
 
     ShowerEleHolder.SetElement(energyVec, energyError, fShowerEnergyOutputLabel);
     // Only set the best plane if it has some hits in it
-    if (bestPlane < fGeom->Nplanes()){
+    if (bestPlane < fGeom->Nplanes()) {
       // Need to cast as an int for legacy default of -999
       // have to define a new variable as we pass-by-reference when filling
       int bestPlaneVal(bestPlane);
@@ -144,18 +144,23 @@ namespace ShowerRecoTools {
   }
 
   // function to calculate the reco energy
-  double ShowerNumElectronsEnergy::CalculateEnergy(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          const std::vector<art::Ptr<recob::Hit> >& hits,
-          const geo::PlaneID::PlaneID_t plane) const {
+  double
+  ShowerNumElectronsEnergy::CalculateEnergy(const detinfo::DetectorClocksData& clockData,
+                                            const detinfo::DetectorPropertiesData& detProp,
+                                            const std::vector<art::Ptr<recob::Hit>>& hits,
+                                            const geo::PlaneID::PlaneID_t plane) const
+  {
 
     double totalCharge = 0;
     double totalEnergy = 0;
     double correctedtotalCharge = 0;
     double nElectrons = 0;
 
-    for (auto const& hit :hits){
-      totalCharge += hit->Integral() * fCalorimetryAlg.LifetimeCorrection(clockData, detProp, hit->PeakTime()); // obtain charge and correct for lifetime
+    for (auto const& hit : hits) {
+      totalCharge +=
+        hit->Integral() *
+        fCalorimetryAlg.LifetimeCorrection(
+          clockData, detProp, hit->PeakTime()); // obtain charge and correct for lifetime
     }
 
     // correct charge due to recombination

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCADirection_tool.cc
@@ -10,106 +10,112 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "lardataobj/RecoBase/PCAxis.h"
 #include "lardataobj/RecoBase/Shower.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 //C++ Includes
 #include <Eigen/Dense>
 
 namespace ShowerRecoTools {
 
-  class ShowerPCADirection: public IShowerTool {
+  class ShowerPCADirection : public IShowerTool {
 
-    public:
+  public:
+    ShowerPCADirection(const fhicl::ParameterSet& pset);
 
-      ShowerPCADirection(const fhicl::ParameterSet& pset);
+    //Calculate the direction of the shower.
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Calculate the direction of the shower.
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
+  private:
+    void InitialiseProducers() override;
 
-    private:
+    //Function to add the assoctions
+    int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                        art::Event& Event,
+                        reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      void InitialiseProducers() override;
+    // Define standard art tool interface
+    recob::PCAxis CalculateShowerPCA(
+      const detinfo::DetectorClocksData& clockData,
+      const detinfo::DetectorPropertiesData& detProp,
+      const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints_pfp,
+      const art::FindManyP<recob::Hit>& fmh,
+      TVector3& ShowerCentre);
 
-      //Function to add the assoctions
-      int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+    TVector3 GetPCAxisVector(recob::PCAxis& PCAxis);
 
-      // Define standard art tool interface
-      recob::PCAxis CalculateShowerPCA(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          const std::vector<art::Ptr<recob::SpacePoint> >& spacePoints_pfp,
-          const art::FindManyP<recob::Hit>& fmh, TVector3& ShowerCentre);
+    //fcl
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
+    unsigned int
+      fNSegments; //Used in the RMS gradient. How many segments should we split the shower into.
+    bool fUseStartPosition; //If we use the start position the drection of the
+    //PCA vector is decided as (Shower Centre - Shower Start Position).
+    bool fChargeWeighted; //Should the PCA axis be charge weighted.
 
-      TVector3 GetPCAxisVector(recob::PCAxis& PCAxis);
-
-      //fcl
-      art::InputTag fPFParticleLabel;
-      int                        fVerbose;
-      unsigned int fNSegments;        //Used in the RMS gradient. How many segments should we split the shower into.
-      bool fUseStartPosition;  //If we use the start position the drection of the
-      //PCA vector is decided as (Shower Centre - Shower Start Position).
-      bool fChargeWeighted;    //Should the PCA axis be charge weighted.
-
-      std::string fShowerStartPositionInputLabel;
-      std::string fShowerDirectionOutputLabel;
-      std::string fShowerCentreOutputLabel;
-      std::string fShowerPCAOutputLabel;
-
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionOutputLabel;
+    std::string fShowerCentreOutputLabel;
+    std::string fShowerPCAOutputLabel;
   };
 
-  ShowerPCADirection::ShowerPCADirection(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fNSegments(pset.get<unsigned int>("NSegments")),
-    fUseStartPosition(pset.get<bool>("UseStartPosition")),
-    fChargeWeighted(pset.get<bool>("ChargeWeighted")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel")),
-    fShowerCentreOutputLabel(pset.get<std::string>("ShowerCentreOutputLabel")),
-    fShowerPCAOutputLabel(pset.get<std::string>("ShowerPCAOutputLabel"))
+  ShowerPCADirection::ShowerPCADirection(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fNSegments(pset.get<unsigned int>("NSegments"))
+    , fUseStartPosition(pset.get<bool>("UseStartPosition"))
+    , fChargeWeighted(pset.get<bool>("ChargeWeighted"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+    , fShowerCentreOutputLabel(pset.get<std::string>("ShowerCentreOutputLabel"))
+    , fShowerPCAOutputLabel(pset.get<std::string>("ShowerPCAOutputLabel"))
+  {}
+
+  void
+  ShowerPCADirection::InitialiseProducers()
   {
+    InitialiseProduct<std::vector<recob::PCAxis>>(fShowerPCAOutputLabel);
+    InitialiseProduct<art::Assns<recob::Shower, recob::PCAxis>>("ShowerPCAxisAssn");
+    InitialiseProduct<art::Assns<recob::PFParticle, recob::PCAxis>>("PFParticlePCAxisAssn");
   }
 
-  void ShowerPCADirection::InitialiseProducers()
+  int
+  ShowerPCADirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                       art::Event& Event,
+                                       reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-    InitialiseProduct<std::vector<recob::PCAxis> >(fShowerPCAOutputLabel);
-    InitialiseProduct<art::Assns<recob::Shower, recob::PCAxis> >("ShowerPCAxisAssn");
-    InitialiseProduct<art::Assns<recob::PFParticle, recob::PCAxis> >("PFParticlePCAxisAssn");
-  }
-
-  int ShowerPCADirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     // Get the assocated pfParicle vertex PFParticles
-    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
-    const art::FindManyP<recob::SpacePoint>& fmspp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>(
-        pfpHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::SpacePoint>& fmspp =
+      ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
 
     //Get the spacepoints handle and the hit assoication
-    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
+    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
 
-    const art::FindManyP<recob::Hit>& fmh = ShowerEleHolder.GetFindManyP<recob::Hit>(
-        spHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Hit>& fmh =
+      ShowerEleHolder.GetFindManyP<recob::Hit>(spHandle, Event, fPFParticleLabel);
 
     //Spacepoints
-    std::vector<art::Ptr<recob::SpacePoint> > spacePoints_pfp = fmspp.at(pfparticle.key());
+    std::vector<art::Ptr<recob::SpacePoint>> spacePoints_pfp = fmspp.at(pfparticle.key());
 
     //We cannot progress with no spacepoints.
-    if(spacePoints_pfp.size() < 3) {
-      mf::LogWarning("ShowerPCADirection") << spacePoints_pfp.size() << " spacepoints in shower, not calculating direction" << std::endl;
+    if (spacePoints_pfp.size() < 3) {
+      mf::LogWarning("ShowerPCADirection")
+        << spacePoints_pfp.size() << " spacepoints in shower, not calculating direction"
+        << std::endl;
       return 1;
     }
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
     //Find the PCA vector
     TVector3 ShowerCentre;
@@ -117,20 +123,21 @@ namespace ShowerRecoTools {
     TVector3 PCADirection = GetPCAxisVector(PCA);
 
     //Save the shower the center for downstream tools
-    TVector3 ShowerCentreErr = {-999,-999,-999};
-    ShowerEleHolder.SetElement(ShowerCentre,ShowerCentreErr,fShowerCentreOutputLabel);
+    TVector3 ShowerCentreErr = {-999, -999, -999};
+    ShowerEleHolder.SetElement(ShowerCentre, ShowerCentreErr, fShowerCentreOutputLabel);
     ShowerEleHolder.SetElement(PCA, fShowerPCAOutputLabel);
 
     //Check if we are pointing the correct direction or not, First try the start position
-    if(fUseStartPosition){
-      if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (fUseStartPosition) {
+      if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
         if (fVerbose)
-          mf::LogError("ShowerPCADirection") << "fUseStartPosition is set but ShowerStartPosition is not set. Bailing" << std::endl;
+          mf::LogError("ShowerPCADirection")
+            << "fUseStartPosition is set but ShowerStartPosition is not set. Bailing" << std::endl;
         return 1;
       }
       //Get the General direction as the vector between the start position and the centre
       TVector3 StartPositionVec = {-999, -999, -999};
-      ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,StartPositionVec);
+      ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPositionVec);
 
       // Calculate the general direction of the shower
       TVector3 GeneralDir = (ShowerCentre - StartPositionVec).Unit();
@@ -139,41 +146,45 @@ namespace ShowerRecoTools {
       double DotProduct = PCADirection.Dot(GeneralDir);
 
       //If the dotproduct is negative the Direction needs Flipping
-      if(DotProduct < 0){
-        PCADirection[0] = - PCADirection[0];
-        PCADirection[1] = - PCADirection[1];
-        PCADirection[2] = - PCADirection[2];
+      if (DotProduct < 0) {
+        PCADirection[0] = -PCADirection[0];
+        PCADirection[1] = -PCADirection[1];
+        PCADirection[2] = -PCADirection[2];
       }
 
       //To do
-      TVector3 PCADirectionErr = {-999,-999,-999};
-      ShowerEleHolder.SetElement(PCADirection,PCADirectionErr,fShowerDirectionOutputLabel);
+      TVector3 PCADirectionErr = {-999, -999, -999};
+      ShowerEleHolder.SetElement(PCADirection, PCADirectionErr, fShowerDirectionOutputLabel);
       return 0;
     }
 
     //Otherwise Check against the RMS of the shower. Method adapated from EMShower Thanks Mike.
-    double RMSGradient = IShowerTool::GetLArPandoraShowerAlg().RMSShowerGradient(spacePoints_pfp,ShowerCentre,PCADirection, fNSegments);
+    double RMSGradient = IShowerTool::GetLArPandoraShowerAlg().RMSShowerGradient(
+      spacePoints_pfp, ShowerCentre, PCADirection, fNSegments);
 
     // If the alg fails to calculate the gradient it will return 0. In this case do nothing
     // If the gradient is negative, flip the direction of the shower
-    if(RMSGradient < -std::numeric_limits<double>::epsilon()){
-      PCADirection[0] = - PCADirection[0];
-      PCADirection[1] = - PCADirection[1];
-      PCADirection[2] = - PCADirection[2];
+    if (RMSGradient < -std::numeric_limits<double>::epsilon()) {
+      PCADirection[0] = -PCADirection[0];
+      PCADirection[1] = -PCADirection[1];
+      PCADirection[2] = -PCADirection[2];
     }
 
     //To do
-    TVector3 PCADirectionErr = {-999,-999,-999};
+    TVector3 PCADirectionErr = {-999, -999, -999};
 
-    ShowerEleHolder.SetElement(PCADirection,PCADirectionErr,fShowerDirectionOutputLabel);
+    ShowerEleHolder.SetElement(PCADirection, PCADirectionErr, fShowerDirectionOutputLabel);
     return 0;
   }
 
   //Function to calculate the shower direction using a charge weight 3D PCA calculation.
-  recob::PCAxis ShowerPCADirection::CalculateShowerPCA(const detinfo::DetectorClocksData& clockData,
-      const detinfo::DetectorPropertiesData& detProp,
-      const std::vector<art::Ptr<recob::SpacePoint> >& sps,
-      const art::FindManyP<recob::Hit>& fmh, TVector3& ShowerCentre){
+  recob::PCAxis
+  ShowerPCADirection::CalculateShowerPCA(const detinfo::DetectorClocksData& clockData,
+                                         const detinfo::DetectorPropertiesData& detProp,
+                                         const std::vector<art::Ptr<recob::SpacePoint>>& sps,
+                                         const art::FindManyP<recob::Hit>& fmh,
+                                         TVector3& ShowerCentre)
+  {
 
     float TotalCharge = 0;
     float sumWeights = 0;
@@ -185,14 +196,16 @@ namespace ShowerRecoTools {
     float yz = 0;
 
     //Get the Shower Centre
-    if (fChargeWeighted){
-      ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, sps, fmh, TotalCharge);
-    } else {
+    if (fChargeWeighted) {
+      ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(
+        clockData, detProp, sps, fmh, TotalCharge);
+    }
+    else {
       ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(sps);
     }
 
     //Normalise the spacepoints, charge weight and add to the PCA.
-    for(auto& sp: sps){
+    for (auto& sp : sps) {
 
       TVector3 sp_position = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp);
 
@@ -201,19 +214,19 @@ namespace ShowerRecoTools {
       //Normalise the spacepoint position.
       sp_position = sp_position - ShowerCentre;
 
-      if(fChargeWeighted){
+      if (fChargeWeighted) {
 
         //Get the charge.
-        float Charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(sp,fmh);
+        float Charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(sp, fmh);
 
         //Get the time of the spacepoint
-        float Time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(sp,fmh);
+        float Time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(sp, fmh);
 
         //Correct for the lifetime at the moment.
-        Charge *= std::exp((sampling_rate(clockData) * Time ) / (detProp.ElectronLifetime()*1e3));
+        Charge *= std::exp((sampling_rate(clockData) * Time) / (detProp.ElectronLifetime() * 1e3));
 
         //Charge Weight
-        wht *= std::sqrt(Charge/TotalCharge);
+        wht *= std::sqrt(Charge / TotalCharge);
       }
 
       xx += sp_position.X() * sp_position.X() * wht;
@@ -223,17 +236,13 @@ namespace ShowerRecoTools {
       xz += sp_position.X() * sp_position.Z() * wht;
       yz += sp_position.Y() * sp_position.Z() * wht;
       sumWeights += wht;
-
     }
 
     // Using Eigen package
     Eigen::Matrix3f matrix;
 
     // Construct covariance matrix
-    matrix <<
-      xx, xy, xz,
-      xy, yy, yz,
-      xz, yz ,zz;
+    matrix << xx, xy, xz, xy, yy, yz, xz, yz, zz;
 
     // Normalise from the sum of weights
     matrix /= sumWeights;
@@ -248,42 +257,48 @@ namespace ShowerRecoTools {
     const bool svdOk = true; //TODO: Should probably think about this a bit more
     const int nHits = sps.size();
     // For some reason eigen sorts the eigenvalues from smallest to largest, reverse it
-    const double eigenValues[3] = {eigenValuesVector(2), eigenValuesVector(1), eigenValuesVector(0)};
-    std::vector<std::vector<double> > eigenVectors = {
-      { eigenVectorsMatrix(0,2), eigenVectorsMatrix(1,2), eigenVectorsMatrix(2,2) },
-      { eigenVectorsMatrix(0,1), eigenVectorsMatrix(1,1), eigenVectorsMatrix(2,1) },
-      { eigenVectorsMatrix(0,0), eigenVectorsMatrix(1,0), eigenVectorsMatrix(2,0) }};
+    const double eigenValues[3] = {
+      eigenValuesVector(2), eigenValuesVector(1), eigenValuesVector(0)};
+    std::vector<std::vector<double>> eigenVectors = {
+      {eigenVectorsMatrix(0, 2), eigenVectorsMatrix(1, 2), eigenVectorsMatrix(2, 2)},
+      {eigenVectorsMatrix(0, 1), eigenVectorsMatrix(1, 1), eigenVectorsMatrix(2, 1)},
+      {eigenVectorsMatrix(0, 0), eigenVectorsMatrix(1, 0), eigenVectorsMatrix(2, 0)}};
     const double avePos[3] = {ShowerCentre[0], ShowerCentre[1], ShowerCentre[2]};
 
-    return  recob::PCAxis(svdOk, nHits, eigenValues, eigenVectors, avePos);
+    return recob::PCAxis(svdOk, nHits, eigenValues, eigenVectors, avePos);
   }
 
-  TVector3 ShowerPCADirection::GetPCAxisVector(recob::PCAxis& PCAxis){
+  TVector3
+  ShowerPCADirection::GetPCAxisVector(recob::PCAxis& PCAxis)
+  {
 
     //Get the Eigenvectors.
     std::vector<double> EigenVector = PCAxis.getEigenVectors()[0];
 
-    return TVector3(EigenVector[0], EigenVector[1],  EigenVector[2]);
+    return TVector3(EigenVector[0], EigenVector[1], EigenVector[2]);
   }
 
-
-  int ShowerPCADirection::AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
+  int
+  ShowerPCADirection::AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                                      art::Event& Event,
+                                      reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //First check the element has been set
-    if(!ShowerEleHolder.CheckElement(fShowerPCAOutputLabel)){
-      if (fVerbose)
-        mf::LogError("ShowerPCADirection: Add Assns") << "PCA not set."<< std::endl;
+    if (!ShowerEleHolder.CheckElement(fShowerPCAOutputLabel)) {
+      if (fVerbose) mf::LogError("ShowerPCADirection: Add Assns") << "PCA not set." << std::endl;
       return 1;
     }
 
     int ptrSize = GetVectorPtrSize(fShowerPCAOutputLabel);
 
-    const art::Ptr<recob::PCAxis> pcaPtr = GetProducedElementPtr<recob::PCAxis>(fShowerPCAOutputLabel, ShowerEleHolder, ptrSize-1);
-    const art::Ptr<recob::Shower> showerPtr = GetProducedElementPtr<recob::Shower>("shower", ShowerEleHolder);
+    const art::Ptr<recob::PCAxis> pcaPtr =
+      GetProducedElementPtr<recob::PCAxis>(fShowerPCAOutputLabel, ShowerEleHolder, ptrSize - 1);
+    const art::Ptr<recob::Shower> showerPtr =
+      GetProducedElementPtr<recob::Shower>("shower", ShowerEleHolder);
 
-    AddSingle<art::Assns<recob::Shower, recob::PCAxis> >(showerPtr,pcaPtr,"ShowerPCAxisAssn");
-    AddSingle<art::Assns<recob::PFParticle, recob::PCAxis> >(pfpPtr,pcaPtr,"PFParticlePCAxisAssn");
+    AddSingle<art::Assns<recob::Shower, recob::PCAxis>>(showerPtr, pcaPtr, "ShowerPCAxisAssn");
+    AddSingle<art::Assns<recob::PFParticle, recob::PCAxis>>(pfpPtr, pcaPtr, "PFParticlePCAxisAssn");
 
     return 0;
   }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCAEigenvalueLength_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCAEigenvalueLength_tool.cc
@@ -10,58 +10,54 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "lardataobj/RecoBase/PCAxis.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace ShowerRecoTools {
 
+  class ShowerPCAEigenvalueLength : public IShowerTool {
 
-  class ShowerPCAEigenvalueLength: public IShowerTool {
+  public:
+    ShowerPCAEigenvalueLength(const fhicl::ParameterSet& pset);
 
-    public:
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerPCAEigenvalueLength(const fhicl::ParameterSet& pset);
-
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      art::InputTag fPFParticleLabel;
-      int           fVerbose;
-      std::string fShowerPCAInputLabel;
-      std::string fShowerLengthOutputLabel;
-      std::string fShowerOpeningAngleOutputLabel;
-      float fNSigma;
+  private:
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
+    std::string fShowerPCAInputLabel;
+    std::string fShowerLengthOutputLabel;
+    std::string fShowerOpeningAngleOutputLabel;
+    float fNSigma;
   };
 
+  ShowerPCAEigenvalueLength::ShowerPCAEigenvalueLength(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fShowerPCAInputLabel(pset.get<std::string>("ShowerPCAInputLabel"))
+    , fShowerLengthOutputLabel(pset.get<std::string>("ShowerLengthOutputLabel"))
+    , fShowerOpeningAngleOutputLabel(pset.get<std::string>("ShowerOpeningAngleOutputLabel"))
+    , fNSigma(pset.get<float>("NSigma"))
+  {}
 
-  ShowerPCAEigenvalueLength::ShowerPCAEigenvalueLength(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fShowerPCAInputLabel(pset.get<std::string>("ShowerPCAInputLabel")),
-    fShowerLengthOutputLabel(pset.get<std::string>("ShowerLengthOutputLabel")),
-    fShowerOpeningAngleOutputLabel(pset.get<std::string>("ShowerOpeningAngleOutputLabel")),
-    fNSigma(pset.get<float>("NSigma"))
+  int
+  ShowerPCAEigenvalueLength::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                              art::Event& Event,
+                                              reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
 
-  int ShowerPCAEigenvalueLength::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
-
-
-    if(!ShowerEleHolder.CheckElement(fShowerPCAInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerPCAInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerPCAEigenvalueLength") << "PCA not set, returning "<< std::endl;
+        mf::LogError("ShowerPCAEigenvalueLength") << "PCA not set, returning " << std::endl;
       return 1;
     }
 
     recob::PCAxis PCA = recob::PCAxis();
-    ShowerEleHolder.GetElement(fShowerPCAInputLabel,PCA);
+    ShowerEleHolder.GetElement(fShowerPCAInputLabel, PCA);
 
     const double* eigenValues = PCA.getEigenValues();
 
@@ -81,7 +77,7 @@ namespace ShowerRecoTools {
     double secondaryEigenValue = (eigenValues)[1];
     double ShowerWidth = std::sqrt(secondaryEigenValue) * 2 * fNSigma;
 
-    double ShowerAngle = std::atan(ShowerWidth/ShowerLength);
+    double ShowerAngle = std::atan(ShowerWidth / ShowerLength);
     double ShowerAngleError = -999;
 
     // Fill the shower element holder

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCAPropergationStartPosition_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCAPropergationStartPosition_tool.cc
@@ -14,111 +14,111 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerPCAPropergationStartPosition : public IShowerTool {
 
-  class ShowerPCAPropergationStartPosition: public IShowerTool {
+  public:
+    ShowerPCAPropergationStartPosition(const fhicl::ParameterSet& pset);
 
-    public:
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerPCAPropergationStartPosition(const fhicl::ParameterSet& pset);
-
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      //fcl parameters
-      art::InputTag fPFParticleLabel;
-      int           fVerbose;
-      std::string   fShowerStartPositionOutputLabel;
-      std::string   fShowerCentreInputLabel;
-      std::string   fShowerDirectionInputLabel;
-      std::string   fShowerStartPositionInputLabel;
+  private:
+    //fcl parameters
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
+    std::string fShowerStartPositionOutputLabel;
+    std::string fShowerCentreInputLabel;
+    std::string fShowerDirectionInputLabel;
+    std::string fShowerStartPositionInputLabel;
   };
 
+  ShowerPCAPropergationStartPosition::ShowerPCAPropergationStartPosition(
+    const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fShowerStartPositionOutputLabel(pset.get<std::string>("ShowerStartPositionOutputLabel"))
+    , fShowerCentreInputLabel(pset.get<std::string>("ShowerCentreInputLabel"))
+    , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+  {}
 
-  ShowerPCAPropergationStartPosition::ShowerPCAPropergationStartPosition(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fShowerStartPositionOutputLabel(pset.get<std::string>("ShowerStartPositionOutputLabel")),
-    fShowerCentreInputLabel(pset.get<std::string>("ShowerCentreInputLabel")),
-    fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+  int
+  ShowerPCAPropergationStartPosition::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
 
-  int ShowerPCAPropergationStartPosition::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
-
-    TVector3 ShowerCentre = {-999,-999,-999};
+    TVector3 ShowerCentre = {-999, -999, -999};
 
     //Get the start position and direction and center
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerPCAPropergationStartPosition") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerPCAPropergationStartPosition")
+          << "Start position not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerPCAPropergationStartPosition") << "Direction not set, returning "<< std::endl;
+        mf::LogError("ShowerPCAPropergationStartPosition")
+          << "Direction not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fShowerCentreInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerCentreInputLabel)) {
 
-      auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-      auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+      auto const clockData =
+        art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+      auto const detProp =
+        art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
       // Get the assocated pfParicle vertex PFParticles
-      auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
+      auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
 
-      const art::FindManyP<recob::SpacePoint>& fmspp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>(
-          pfpHandle, Event, fPFParticleLabel);
+      const art::FindManyP<recob::SpacePoint>& fmspp =
+        ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
 
       //Get the spacepoints handle and the hit assoication
-      auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
+      auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
 
-      const art::FindManyP<recob::Hit>& fmh = ShowerEleHolder.GetFindManyP<recob::Hit>(
-          spHandle, Event, fPFParticleLabel);
+      const art::FindManyP<recob::Hit>& fmh =
+        ShowerEleHolder.GetFindManyP<recob::Hit>(spHandle, Event, fPFParticleLabel);
 
       //Spacepoints
-      std::vector<art::Ptr<recob::SpacePoint> > spacePoints_pfp = fmspp.at(pfparticle.key());
+      std::vector<art::Ptr<recob::SpacePoint>> spacePoints_pfp = fmspp.at(pfparticle.key());
 
       //We cannot progress with no spacepoints.
-      if(spacePoints_pfp.empty())
-        return 1;
+      if (spacePoints_pfp.empty()) return 1;
 
       //Get the shower center
-      ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, spacePoints_pfp,fmh);
-
+      ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(
+        clockData, detProp, spacePoints_pfp, fmh);
     }
-    else{
-      ShowerEleHolder.GetElement(fShowerCentreInputLabel,ShowerCentre);
+    else {
+      ShowerEleHolder.GetElement(fShowerCentreInputLabel, ShowerCentre);
     }
 
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, ShowerStartPosition);
 
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,ShowerStartPosition);
-
-    TVector3 ShowerDirection     = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerDirectionInputLabel,ShowerDirection);
+    TVector3 ShowerDirection = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerDirectionInputLabel, ShowerDirection);
 
     //Get the projection
-    double projection = ShowerDirection.Dot(ShowerStartPosition-ShowerCentre);
+    double projection = ShowerDirection.Dot(ShowerStartPosition - ShowerCentre);
 
     //Get the position.
-    TVector3 ShowerNewStartPosition = projection*ShowerDirection + ShowerCentre;
-    TVector3 ShowerNewStartPositionErr = {-999,-999,-999};
+    TVector3 ShowerNewStartPosition = projection * ShowerDirection + ShowerCentre;
+    TVector3 ShowerNewStartPositionErr = {-999, -999, -999};
 
-    ShowerEleHolder.SetElement(ShowerNewStartPosition,ShowerNewStartPositionErr,fShowerStartPositionOutputLabel);
+    ShowerEleHolder.SetElement(
+      ShowerNewStartPosition, ShowerNewStartPositionErr, fShowerStartPositionOutputLabel);
 
     return 0;
-
   }
 
 }
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerPCAPropergationStartPosition)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPandoraSlidingFitTrackFinder_tool.cc
@@ -11,132 +11,145 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
+#include "lardataobj/RecoBase/Shower.h"
+#include "lardataobj/RecoBase/Track.h"
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
-#include "lardataobj/RecoBase/Track.h"
-#include "lardataobj/RecoBase/Shower.h"
 
-namespace ShowerRecoTools{
+namespace ShowerRecoTools {
 
-  class ShowerPandoraSlidingFitTrackFinder:IShowerTool {
-    public:
+  class ShowerPandoraSlidingFitTrackFinder : IShowerTool {
+  public:
+    ShowerPandoraSlidingFitTrackFinder(const fhicl::ParameterSet& pset);
 
-      ShowerPandoraSlidingFitTrackFinder(const fhicl::ParameterSet& pset);
+    //Generic Track Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Generic Track Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder) override;
-    private:
+  private:
+    void InitialiseProducers() override;
 
-      void InitialiseProducers() override;
+    //Function to add the assoctions
+    int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                        art::Event& Event,
+                        reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Function to add the assoctions
-      int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+    // Define standard art tool interface.
+    art::ServiceHandle<geo::Geometry> fGeom;
 
-
-      // Define standard art tool interface.
-      art::ServiceHandle<geo::Geometry> fGeom;
-
-      //fcl paramaters
-      int   fVerbose;
-      float fSlidingFitHalfWindow; //To Describe
-      float fMinTrajectoryPoints;  //Minimum number of trajectory point to say the track is good.
-      std::string fInitialTrackOutputLabel;
-      std::string fInitialTrackLengthOutputLabel;
-      std::string fShowerStartPositionInputLabel;
-      std::string fShowerDirectionInputLabel;
-      std::string fInitialTrackSpacePointsInputLabel;
-      std::string fInitialTrackHitsInputLabel;
+    //fcl paramaters
+    int fVerbose;
+    float fSlidingFitHalfWindow; //To Describe
+    float fMinTrajectoryPoints;  //Minimum number of trajectory point to say the track is good.
+    std::string fInitialTrackOutputLabel;
+    std::string fInitialTrackLengthOutputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionInputLabel;
+    std::string fInitialTrackSpacePointsInputLabel;
+    std::string fInitialTrackHitsInputLabel;
   };
 
+  ShowerPandoraSlidingFitTrackFinder::ShowerPandoraSlidingFitTrackFinder(
+    const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fSlidingFitHalfWindow(pset.get<float>("SlidingFitHalfWindow"))
+    , fMinTrajectoryPoints(pset.get<float>("MinTrajectoryPoints"))
+    , fInitialTrackOutputLabel(pset.get<std::string>("InitialTrackOutputLabel"))
+    , fInitialTrackLengthOutputLabel(pset.get<std::string>("InitialTrackLengthOutputLabel"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+    , fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel"))
+    , fInitialTrackHitsInputLabel(pset.get<std::string>("InitialTrackHitsInputLabel"))
+  {}
 
-  ShowerPandoraSlidingFitTrackFinder::ShowerPandoraSlidingFitTrackFinder(const fhicl::ParameterSet& pset):
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fVerbose(pset.get<int>("Verbose")),
-    fSlidingFitHalfWindow(pset.get<float> ("SlidingFitHalfWindow")),
-    fMinTrajectoryPoints(pset.get<float> ("MinTrajectoryPoints")),
-    fInitialTrackOutputLabel(pset.get<std::string>("InitialTrackOutputLabel")),
-    fInitialTrackLengthOutputLabel(pset.get<std::string>("InitialTrackLengthOutputLabel")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel")),
-    fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel")),
-    fInitialTrackHitsInputLabel(pset.get<std::string>("InitialTrackHitsInputLabel"))
+  void
+  ShowerPandoraSlidingFitTrackFinder::InitialiseProducers()
   {
+
+    InitialiseProduct<std::vector<recob::Track>>(fInitialTrackOutputLabel);
+    InitialiseProduct<art::Assns<recob::Shower, recob::Track>>("ShowerTrackAssn");
+    InitialiseProduct<art::Assns<recob::Track, recob::Hit>>("ShowerTrackHitAssn");
   }
-
-  void ShowerPandoraSlidingFitTrackFinder::InitialiseProducers(){
-
-    InitialiseProduct<std::vector<recob::Track> >(fInitialTrackOutputLabel);
-    InitialiseProduct<art::Assns<recob::Shower, recob::Track > >("ShowerTrackAssn");
-    InitialiseProduct<art::Assns<recob::Track, recob::Hit > >("ShowerTrackHitAssn");
-
-  }
-
 
   //This whole idea is stolen from PandoraTrackCreationModule so credit goes to the Pandora guys.
-  int ShowerPandoraSlidingFitTrackFinder::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder
-      ){
+  int
+  ShowerPandoraSlidingFitTrackFinder::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
     //This is all based on the shower vertex being known. If it is not lets not do the track
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerPandoraSlidingFitTrackFinder") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerPandoraSlidingFitTrackFinder")
+          << "Start position not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerPandoraSlidingFitTrackFinder") << "Direction not set, returning "<< std::endl;
+        mf::LogError("ShowerPandoraSlidingFitTrackFinder")
+          << "Direction not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerPandoraSlidingFitTrackFinder") << "Initial Spacepoints not set, returning "<< std::endl;
+        mf::LogError("ShowerPandoraSlidingFitTrackFinder")
+          << "Initial Spacepoints not set, returning " << std::endl;
       return 1;
     }
 
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,ShowerStartPosition);
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, ShowerStartPosition);
 
-    TVector3 ShowerDirection     = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerDirectionInputLabel,ShowerDirection);
+    TVector3 ShowerDirection = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerDirectionInputLabel, ShowerDirection);
 
-    std::vector<art::Ptr<recob::SpacePoint> > spacepoints;
-    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel,spacepoints);
+    std::vector<art::Ptr<recob::SpacePoint>> spacepoints;
+    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel, spacepoints);
 
     // The track fitter tries to create a traj point from each spacepoint so if we don't have enough
     // spacepoints we will not get enough traj points, so let's not even try
-    if (spacepoints.size() < fMinTrajectoryPoints){
+    if (spacepoints.size() < fMinTrajectoryPoints) {
       if (fVerbose)
-        mf::LogWarning("ShowerPandoraSlidingFitTrackFinder") << "Insufficient space points points to build track: " << spacepoints.size();
+        mf::LogWarning("ShowerPandoraSlidingFitTrackFinder")
+          << "Insufficient space points points to build track: " << spacepoints.size();
       return 1;
     }
 
     const unsigned int nWirePlanes(fGeom->MaxPlanes());
 
     if (nWirePlanes > 3)
-      throw cet::exception("LArPandoraTrackCreation") << " LArPandoraTrackCreation::produce --- More than three wire planes present ";
+      throw cet::exception("LArPandoraTrackCreation")
+        << " LArPandoraTrackCreation::produce --- More than three wire planes present ";
 
     if ((0 == fGeom->Ncryostats()) || (0 == fGeom->NTPC(0)))
-      throw cet::exception("LArPandoraTrackCreation") << " LArPandoraTrackCreation::produce --- unable to access first tpc in first cryostat ";
+      throw cet::exception("LArPandoraTrackCreation")
+        << " LArPandoraTrackCreation::produce --- unable to access first tpc in first cryostat ";
 
     std::unordered_set<geo::_plane_proj> planeSet;
     for (unsigned int iPlane = 0; iPlane < nWirePlanes; ++iPlane)
-      (void) planeSet.insert(fGeom->TPC(0, 0).Plane(iPlane).View());
+      (void)planeSet.insert(fGeom->TPC(0, 0).Plane(iPlane).View());
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.  For single phase we expect
     // three views, U, V and either W or Y, for dual phase we expect two views, W and Y.
     const bool isDualPhase(fGeom->MaxPlanes() == 2);
 
     if (nWirePlanes != planeSet.size())
-      throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- geometry description for wire plane(s) missing ";
+      throw cet::exception("LArPandoraTrackCreation")
+        << " LArPandoraGeometry::LoadGeometry --- geometry description for wire plane(s) missing ";
 
     if (isDualPhase && (!planeSet.count(geo::kW) || !planeSet.count(geo::kY)))
-      throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- dual phase scenario; expect to find w and y views ";
+      throw cet::exception("LArPandoraTrackCreation")
+        << " LArPandoraGeometry::LoadGeometry --- dual phase scenario; expect to find w and y "
+           "views ";
 
-    if (!isDualPhase && (!planeSet.count(geo::kU) || !planeSet.count(geo::kV) || (planeSet.count(geo::kW) && planeSet.count(geo::kY))))
-      throw cet::exception("LArPandoraTrackCreation") << " LArPandoraGeometry::LoadGeometry --- single phase scenatio; expect to find u and v views; if there is one further view, it must be w or y ";
+    if (!isDualPhase && (!planeSet.count(geo::kU) || !planeSet.count(geo::kV) ||
+                         (planeSet.count(geo::kW) && planeSet.count(geo::kY))))
+      throw cet::exception("LArPandoraTrackCreation")
+        << " LArPandoraGeometry::LoadGeometry --- single phase scenatio; expect to find u and v "
+           "views; if there is one further view, it must be w or y ";
 
     const bool useYPlane((nWirePlanes > 2) && planeSet.count(geo::kY));
 
@@ -144,104 +157,123 @@ namespace ShowerRecoTools{
     // planes, which are inherently induction only, are mapped to induction planes in the single phase geometry.
     const float wirePitchU(fGeom->WirePitch((isDualPhase ? geo::kW : geo::kU)));
     const float wirePitchV(fGeom->WirePitch((isDualPhase ? geo::kY : geo::kV)));
-    const float wirePitchW((nWirePlanes < 3) ? 0.5f * (wirePitchU + wirePitchV) : (useYPlane) ? fGeom->WirePitch(geo::kY) :
-        fGeom->WirePitch(geo::kW));
+    const float wirePitchW((nWirePlanes < 3) ?
+                             0.5f * (wirePitchU + wirePitchV) :
+                             (useYPlane) ? fGeom->WirePitch(geo::kY) : fGeom->WirePitch(geo::kW));
 
-
-    const pandora::CartesianVector vertexPosition(ShowerStartPosition.X(), ShowerStartPosition.Y(),
-        ShowerStartPosition.Z());
+    const pandora::CartesianVector vertexPosition(
+      ShowerStartPosition.X(), ShowerStartPosition.Y(), ShowerStartPosition.Z());
 
     pandora::CartesianPointVector cartesianPointVector;
     for (const art::Ptr<recob::SpacePoint> spacePoint : spacepoints)
-      cartesianPointVector.emplace_back(pandora::CartesianVector(spacePoint->XYZ()[0],
-            spacePoint->XYZ()[1], spacePoint->XYZ()[2]));
+      cartesianPointVector.emplace_back(
+        pandora::CartesianVector(spacePoint->XYZ()[0], spacePoint->XYZ()[1], spacePoint->XYZ()[2]));
 
     lar_content::LArTrackStateVector trackStateVector;
     pandora::IntVector indexVector;
-    try{
-      lar_content::LArPfoHelper::GetSlidingFitTrajectory(cartesianPointVector, vertexPosition,
-          fSlidingFitHalfWindow, wirePitchW, trackStateVector, &indexVector);
+    try {
+      lar_content::LArPfoHelper::GetSlidingFitTrajectory(cartesianPointVector,
+                                                         vertexPosition,
+                                                         fSlidingFitHalfWindow,
+                                                         wirePitchW,
+                                                         trackStateVector,
+                                                         &indexVector);
     }
-    catch (const pandora::StatusCodeException &){
+    catch (const pandora::StatusCodeException&) {
       if (fVerbose)
-        mf::LogWarning("ShowerPandoraSlidingFitTrackFinder") << "Unable to extract sliding fit trajectory" << std::endl;
+        mf::LogWarning("ShowerPandoraSlidingFitTrackFinder")
+          << "Unable to extract sliding fit trajectory" << std::endl;
       return 1;
     }
-    if (trackStateVector.size() < fMinTrajectoryPoints){
+    if (trackStateVector.size() < fMinTrajectoryPoints) {
       if (fVerbose)
-        mf::LogWarning("ShowerPandoraSlidingFitTrackFinder") << "Insufficient input trajectory points to build track: " << trackStateVector.size();
+        mf::LogWarning("ShowerPandoraSlidingFitTrackFinder")
+          << "Insufficient input trajectory points to build track: " << trackStateVector.size();
       return 1;
     }
 
     if (trackStateVector.empty())
-      throw cet::exception("ShowerPandoraSlidingFitTrackFinder") << "BuildTrack - No input trajectory points provided " << std::endl;
+      throw cet::exception("ShowerPandoraSlidingFitTrackFinder")
+        << "BuildTrack - No input trajectory points provided " << std::endl;
 
     recob::tracking::Positions_t xyz;
     recob::tracking::Momenta_t pxpypz;
     recob::TrackTrajectory::Flags_t flags;
 
-    for (const lar_content::LArTrackState &trackState : trackStateVector)
-    {
+    for (const lar_content::LArTrackState& trackState : trackStateVector) {
       xyz.emplace_back(recob::tracking::Point_t(trackState.GetPosition().GetX(),
-            trackState.GetPosition().GetY(), trackState.GetPosition().GetZ()));
+                                                trackState.GetPosition().GetY(),
+                                                trackState.GetPosition().GetZ()));
       pxpypz.emplace_back(recob::tracking::Vector_t(trackState.GetDirection().GetX(),
-            trackState.GetDirection().GetY(), trackState.GetDirection().GetZ()));
+                                                    trackState.GetDirection().GetY(),
+                                                    trackState.GetDirection().GetZ()));
 
       // Set flag NoPoint if point has bogus coordinates, otherwise use clean flag set
-      if (std::fabs(trackState.GetPosition().GetX()-util::kBogusF)<std::numeric_limits<float>::epsilon() &&
-          std::fabs(trackState.GetPosition().GetY()-util::kBogusF)<std::numeric_limits<float>::epsilon() &&
-          std::fabs(trackState.GetPosition().GetZ()-util::kBogusF)<std::numeric_limits<float>::epsilon())
-      {
+      if (std::fabs(trackState.GetPosition().GetX() - util::kBogusF) <
+            std::numeric_limits<float>::epsilon() &&
+          std::fabs(trackState.GetPosition().GetY() - util::kBogusF) <
+            std::numeric_limits<float>::epsilon() &&
+          std::fabs(trackState.GetPosition().GetZ() - util::kBogusF) <
+            std::numeric_limits<float>::epsilon()) {
         flags.emplace_back(recob::TrajectoryPointFlags(recob::TrajectoryPointFlags::InvalidHitIndex,
-              recob::TrajectoryPointFlagTraits::NoPoint));
-      } else {
+                                                       recob::TrajectoryPointFlagTraits::NoPoint));
+      }
+      else {
         flags.emplace_back(recob::TrajectoryPointFlags());
       }
     }
 
     // note from gc: eventually we should produce a TrackTrajectory, not a Track with empty covariance matrix and bogus chi2, etc.
-    recob::Track InitialTrack  =  recob::Track(recob::TrackTrajectory(std::move(xyz),std::move(pxpypz), std::move(flags), false),
-        util::kBogusI, util::kBogusF, util::kBogusI, recob::tracking::SMatrixSym55(),
-        recob::tracking::SMatrixSym55(), pfparticle.key());
+    recob::Track InitialTrack = recob::Track(
+      recob::TrackTrajectory(std::move(xyz), std::move(pxpypz), std::move(flags), false),
+      util::kBogusI,
+      util::kBogusF,
+      util::kBogusI,
+      recob::tracking::SMatrixSym55(),
+      recob::tracking::SMatrixSym55(),
+      pfparticle.key());
 
-    ShowerEleHolder.SetElement(InitialTrack,fInitialTrackOutputLabel);
+    ShowerEleHolder.SetElement(InitialTrack, fInitialTrackOutputLabel);
 
     TVector3 Start = {InitialTrack.Start().X(), InitialTrack.Start().Y(), InitialTrack.Start().Z()};
-    TVector3 End   = {InitialTrack.End().X(), InitialTrack.End().Y(),InitialTrack.End().Z()};
-    float tracklength = (Start-End).Mag();
+    TVector3 End = {InitialTrack.End().X(), InitialTrack.End().Y(), InitialTrack.End().Z()};
+    float tracklength = (Start - End).Mag();
 
-    ShowerEleHolder.SetElement(tracklength,fInitialTrackLengthOutputLabel);
+    ShowerEleHolder.SetElement(tracklength, fInitialTrackLengthOutputLabel);
 
     return 0;
   }
 
-
-  int ShowerPandoraSlidingFitTrackFinder::AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder
-      ){
+  int
+  ShowerPandoraSlidingFitTrackFinder::AddAssociations(
+    const art::Ptr<recob::PFParticle>& pfpPtr,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //Check the track has been set
-    if(!ShowerEleHolder.CheckElement(fInitialTrackOutputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackOutputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerPandoraSlidingFitTrackFinderAddAssn") << "Track not set so the assocation can not be made  "<< std::endl;
+        mf::LogError("ShowerPandoraSlidingFitTrackFinderAddAssn")
+          << "Track not set so the assocation can not be made  " << std::endl;
       return 1;
     }
 
     //Get the size of the ptr as it is.
     int trackptrsize = GetVectorPtrSize(fInitialTrackOutputLabel);
 
-    const art::Ptr<recob::Track> trackptr = GetProducedElementPtr<recob::Track>(fInitialTrackOutputLabel,
-        ShowerEleHolder,trackptrsize-1);
-    const art::Ptr<recob::Shower> showerptr = GetProducedElementPtr<recob::Shower>("shower",
-        ShowerEleHolder);
+    const art::Ptr<recob::Track> trackptr = GetProducedElementPtr<recob::Track>(
+      fInitialTrackOutputLabel, ShowerEleHolder, trackptrsize - 1);
+    const art::Ptr<recob::Shower> showerptr =
+      GetProducedElementPtr<recob::Shower>("shower", ShowerEleHolder);
 
-    AddSingle<art::Assns<recob::Shower, recob::Track> >(showerptr,trackptr,"ShowerTrackAssn");
+    AddSingle<art::Assns<recob::Shower, recob::Track>>(showerptr, trackptr, "ShowerTrackAssn");
 
-    std::vector<art::Ptr<recob::Hit> > TrackHits;
-    ShowerEleHolder.GetElement(fInitialTrackHitsInputLabel,TrackHits);
+    std::vector<art::Ptr<recob::Hit>> TrackHits;
+    ShowerEleHolder.GetElement(fInitialTrackHitsInputLabel, TrackHits);
 
-    for(auto const& TrackHit: TrackHits){
-      AddSingle<art::Assns<recob::Track, recob::Hit> >(trackptr,TrackHit,"ShowerTrackHitAssn");
+    for (auto const& TrackHit : TrackHits) {
+      AddSingle<art::Assns<recob::Track, recob::Hit>>(trackptr, TrackHit, "ShowerTrackHitAssn");
     }
 
     return 0;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerSkeletonTool_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerSkeletonTool_tool.cc
@@ -13,46 +13,46 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerSkeletonTool : public IShowerTool {
 
-  class ShowerSkeletonTool: public IShowerTool {
+  public:
+    ShowerSkeletonTool(const fhicl::ParameterSet& pset);
 
-    public:
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerSkeletonTool(const fhicl::ParameterSet& pset);
+  private:
+    //Function to add the assoctions
+    int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                        art::Event& Event,
+                        reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      //Function to add the assoctions
-      int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder) override;
-
-      // Stuff you will probably need that inherits from the module
-      art::InputTag              fPFParticleLabel;
-      int                        fVerbose;
+    // Stuff you will probably need that inherits from the module
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
   };
 
+  ShowerSkeletonTool::ShowerSkeletonTool(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+  {}
 
-  ShowerSkeletonTool::ShowerSkeletonTool(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose"))
+  int
+  ShowerSkeletonTool::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                       art::Event& Event,
+                                       reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int ShowerSkeletonTool::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
     return 0;
   }
 
-  int ShowerSkeletonTool::AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder
-      ){
+  int
+  ShowerSkeletonTool::AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                                      art::Event& Event,
+                                      reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
     return 0;
   }
 }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackColinearTrajPointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackColinearTrajPointDirection_tool.cc
@@ -14,74 +14,74 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerTrackColinearTrajPointDirection : IShowerTool {
 
-  class ShowerTrackColinearTrajPointDirection:IShowerTool {
+  public:
+    ShowerTrackColinearTrajPointDirection(const fhicl::ParameterSet& pset);
 
-    public:
+    //Calculate the direction from the inital track.
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerTrackColinearTrajPointDirection(const fhicl::ParameterSet& pset);
+  private:
+    //fcl
+    int fVerbose;
+    bool fUsePandoraVertex; //Direction from point defined as
+    //(Position of traj point - Vertex) rather than
+    //(Position of traj point - Track Start Point).
+    bool fAllowDynamicSliding; //Rather than evualte the angle from the start use
+    //the previous trajectory point position.
+    bool fUsePositionInfo; //Don't use the DirectionAtPoint rather than
+    //definition above.
+    //((Position of traj point + 1)-(Position of traj point)
+    bool fUseStartPos; //Rather the using the angles between the directions
+    //from start position to the trajectory points
+    //use the angle between the the points themselves
+    float fAngleCut;
 
-      //Calculate the direction from the inital track.
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      //fcl
-      int   fVerbose;
-      bool  fUsePandoraVertex;    //Direction from point defined as
-      //(Position of traj point - Vertex) rather than
-      //(Position of traj point - Track Start Point).
-      bool  fAllowDynamicSliding; //Rather than evualte the angle from the start use
-      //the previous trajectory point position.
-      bool  fUsePositionInfo;     //Don't use the DirectionAtPoint rather than
-      //definition above.
-      //((Position of traj point + 1)-(Position of traj point)
-      bool  fUseStartPos;         //Rather the using the angles between the directions
-      //from start position to the trajectory points
-      //use the angle between the the points themselves
-      float fAngleCut;
-
-      std::string fInitialTrackInputLabel;
-      std::string fShowerStartPositionInputLabel;
-      std::string fShowerDirectionOutputLabel;
+    std::string fInitialTrackInputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionOutputLabel;
   };
 
+  ShowerTrackColinearTrajPointDirection::ShowerTrackColinearTrajPointDirection(
+    const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fUsePandoraVertex(pset.get<bool>("UsePandoraVertex"))
+    , fAllowDynamicSliding(pset.get<bool>("AllowDynamicSliding"))
+    , fUsePositionInfo(pset.get<bool>("UsePositionInfo"))
+    , fUseStartPos(pset.get<bool>("UseStartPos"))
+    , fAngleCut(pset.get<float>("AngleCut"))
+    , fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
 
-  ShowerTrackColinearTrajPointDirection::ShowerTrackColinearTrajPointDirection(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fVerbose(pset.get<int>("Verbose")),
-    fUsePandoraVertex(pset.get<bool>("UsePandoraVertex")),
-    fAllowDynamicSliding(pset.get<bool>("AllowDynamicSliding")),
-    fUsePositionInfo(pset.get<bool>("UsePositionInfo")),
-    fUseStartPos(pset.get<bool>("UseStartPos")),
-    fAngleCut(pset.get<float>("AngleCut")),
-    fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  {}
 
+  int
+  ShowerTrackColinearTrajPointDirection::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int ShowerTrackColinearTrajPointDirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     //Check the Track has been defined
-    if(!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)) {
       if (fVerbose)
         mf::LogError("ShowerTrackColinearTrajPointDirection")
-          << "Initial track not set"<< std::endl;
+          << "Initial track not set" << std::endl;
       return 1;
     }
     recob::Track InitialTrack;
-    ShowerEleHolder.GetElement(fInitialTrackInputLabel,InitialTrack);
+    ShowerEleHolder.GetElement(fInitialTrackInputLabel, InitialTrack);
 
     //Smartly choose the which trajectory point to look at by ignoring the smush of hits at the vertex.
-    if(InitialTrack.NumberTrajectoryPoints() == 1){
+    if (InitialTrack.NumberTrajectoryPoints() == 1) {
       if (fVerbose)
         mf::LogError("ShowerTrackColinearTrajPointDirection")
-          << "Not Enough trajectory points."<< std::endl;
+          << "Not Enough trajectory points." << std::endl;
       return 1;
     }
 
@@ -89,208 +89,234 @@ namespace ShowerRecoTools {
     int trajpoint = 0;
     geo::Vector_t Direction_vec;
 
-    if(fUsePositionInfo){
+    if (fUsePositionInfo) {
       //Get the start position.
       geo::Point_t StartPosition;
 
-      if(fUsePandoraVertex){
+      if (fUsePandoraVertex) {
         //Check the Track has been defined
-        if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+        if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
           if (fVerbose)
             mf::LogError("ShowerTrackColinearTrajPointDirection")
-              << "Shower start position not set"<< std::endl;
+              << "Shower start position not set" << std::endl;
           return 1;
         }
-        TVector3 StartPosition_vec = {-999,-999,-999};
-        ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,StartPosition_vec);
-        StartPosition.SetCoordinates(StartPosition_vec.X(),StartPosition_vec.Y(),StartPosition_vec.Z());
+        TVector3 StartPosition_vec = {-999, -999, -999};
+        ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPosition_vec);
+        StartPosition.SetCoordinates(
+          StartPosition_vec.X(), StartPosition_vec.Y(), StartPosition_vec.Z());
       }
-      else{
+      else {
         StartPosition = InitialTrack.Start();
       }
 
       //Loop over the trajectory points and find two corresponding trajectory points where the angle between themselves (or themsleves and the start position) is less the fMinAngle.
-      for(unsigned int traj=0; traj<InitialTrack.NumberTrajectoryPoints()-2; ++traj){
+      for (unsigned int traj = 0; traj < InitialTrack.NumberTrajectoryPoints() - 2; ++traj) {
         ++trajpoint;
 
         //ignore bogus info.
         auto trajflags = InitialTrack.FlagsAtPoint(trajpoint);
-        if(trajflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
-
+        if (trajflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
         bool bail = false;
 
         //ignore bogus info.
         auto flags = InitialTrack.FlagsAtPoint(traj);
-        if(flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
+        if (flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
         //find the next non bogus traj point.
-        int nexttraj = traj+1;
+        int nexttraj = traj + 1;
         auto nextflags = InitialTrack.FlagsAtPoint(nexttraj);
-        while(nextflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)){
-          if(nexttraj == (int)InitialTrack.NumberTrajectoryPoints()-2){bail = true;break;}
+        while (nextflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) {
+          if (nexttraj == (int)InitialTrack.NumberTrajectoryPoints() - 2) {
+            bail = true;
+            break;
+          }
           ++nexttraj;
           nextflags = InitialTrack.FlagsAtPoint(nexttraj);
         }
 
         //find the next next non bogus traj point.
-        int nextnexttraj = nexttraj+1;
+        int nextnexttraj = nexttraj + 1;
         auto nextnextflags = InitialTrack.FlagsAtPoint(nextnexttraj);
-        while(nextnextflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)){
-          if(nexttraj == (int)InitialTrack.NumberTrajectoryPoints()-1){bail = true;break;}
+        while (nextnextflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) {
+          if (nexttraj == (int)InitialTrack.NumberTrajectoryPoints() - 1) {
+            bail = true;
+            break;
+          }
           ++nextnexttraj;
           nextnextflags = InitialTrack.FlagsAtPoint(nextnexttraj);
         }
 
-        if(bail){
+        if (bail) {
           if (fVerbose)
-            mf::LogError("ShowerTrackColinearTrajPointDirection") << "Trajectory point not set as rest of the traj points are bogus."<< std::endl;
+            mf::LogError("ShowerTrackColinearTrajPointDirection")
+              << "Trajectory point not set as rest of the traj points are bogus." << std::endl;
           break;
         }
 
         //Get the directions.
-        geo::Vector_t TrajPosition_vec      = InitialTrack.LocationAtPoint(traj) - StartPosition ;
+        geo::Vector_t TrajPosition_vec = InitialTrack.LocationAtPoint(traj) - StartPosition;
         geo::Vector_t NextTrajPosition_vec;
         geo::Vector_t NextNextTrajPosition_vec;
-        if(fUseStartPos){
-          NextTrajPosition_vec  = InitialTrack.LocationAtPoint(nexttraj) - StartPosition;
-          NextNextTrajPosition_vec  = InitialTrack.LocationAtPoint(nextnexttraj) - StartPosition;
+        if (fUseStartPos) {
+          NextTrajPosition_vec = InitialTrack.LocationAtPoint(nexttraj) - StartPosition;
+          NextNextTrajPosition_vec = InitialTrack.LocationAtPoint(nextnexttraj) - StartPosition;
         }
-        else{
-          NextTrajPosition_vec  = InitialTrack.LocationAtPoint(nexttraj)  - InitialTrack.LocationAtPoint(traj);
-          NextNextTrajPosition_vec  = InitialTrack.LocationAtPoint(nextnexttraj) - InitialTrack.LocationAtPoint(traj+1);
+        else {
+          NextTrajPosition_vec =
+            InitialTrack.LocationAtPoint(nexttraj) - InitialTrack.LocationAtPoint(traj);
+          NextNextTrajPosition_vec =
+            InitialTrack.LocationAtPoint(nextnexttraj) - InitialTrack.LocationAtPoint(traj + 1);
         }
 
         //Get the directions.
-        TVector3 TrajPosition = {TrajPosition_vec.X(), TrajPosition_vec.Y(),TrajPosition_vec.Z()};
-        TVector3 NextTrajPosition = {NextTrajPosition_vec.X(), NextTrajPosition_vec.Y(),NextTrajPosition_vec.Z()};
-        TVector3 NextNextTrajPosition = {NextNextTrajPosition_vec.X(), NextNextTrajPosition_vec.Y(),NextNextTrajPosition_vec.Z()};
+        TVector3 TrajPosition = {TrajPosition_vec.X(), TrajPosition_vec.Y(), TrajPosition_vec.Z()};
+        TVector3 NextTrajPosition = {
+          NextTrajPosition_vec.X(), NextTrajPosition_vec.Y(), NextTrajPosition_vec.Z()};
+        TVector3 NextNextTrajPosition = {
+          NextNextTrajPosition_vec.X(), NextNextTrajPosition_vec.Y(), NextNextTrajPosition_vec.Z()};
 
         //Might still be bogus and we can't use the start point
-        if(TrajPosition.Mag() == 0){continue;}
-        if(NextTrajPosition.Mag() == 0){continue;}
-        if(NextNextTrajPosition.Mag() == 0){continue;}
+        if (TrajPosition.Mag() == 0) { continue; }
+        if (NextTrajPosition.Mag() == 0) { continue; }
+        if (NextNextTrajPosition.Mag() == 0) { continue; }
 
         //Check to see if the angle between the directions is small enough.
-        if(TrajPosition.Angle(NextTrajPosition) < fAngleCut && TrajPosition.Angle(NextNextTrajPosition) <fAngleCut){break;}
+        if (TrajPosition.Angle(NextTrajPosition) < fAngleCut &&
+            TrajPosition.Angle(NextNextTrajPosition) < fAngleCut) {
+          break;
+        }
 
         //Move the start position onwords.
-        if(fAllowDynamicSliding){
-          StartPosition = {InitialTrack.LocationAtPoint(traj).X(), InitialTrack.LocationAtPoint(traj).Y(), InitialTrack.LocationAtPoint(traj).Z()};
+        if (fAllowDynamicSliding) {
+          StartPosition = {InitialTrack.LocationAtPoint(traj).X(),
+                           InitialTrack.LocationAtPoint(traj).Y(),
+                           InitialTrack.LocationAtPoint(traj).Z()};
         }
       }
 
-      geo::Point_t  TrajPosition   = InitialTrack.LocationAtPoint(trajpoint);
-      Direction_vec  = (TrajPosition - StartPosition).Unit();
+      geo::Point_t TrajPosition = InitialTrack.LocationAtPoint(trajpoint);
+      Direction_vec = (TrajPosition - StartPosition).Unit();
     }
-    else{
+    else {
       //Loop over the trajectory points and find two corresponding trajectory points where the angle between themselves (or themsleves and the start position) is less the fMinAngle.
-      for(unsigned int traj=0; traj<InitialTrack.NumberTrajectoryPoints()-2; ++traj){
+      for (unsigned int traj = 0; traj < InitialTrack.NumberTrajectoryPoints() - 2; ++traj) {
         ++trajpoint;
 
         //ignore bogus info.
         auto trajflags = InitialTrack.FlagsAtPoint(trajpoint);
-        if(trajflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
-
+        if (trajflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
         //ignore bogus info.
         auto flags = InitialTrack.FlagsAtPoint(traj);
-        if(flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
+        if (flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
         bool bail = false;
 
         geo::Vector_t TrajDirection_vec;
 
         //Get the next non bogus trajectory points
-        if(fUseStartPos){
+        if (fUseStartPos) {
           int prevtraj = 0;
           auto prevflags = InitialTrack.FlagsAtPoint(prevtraj);
-          while(prevflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)){
-            if(prevtraj == (int)InitialTrack.NumberTrajectoryPoints()-2){bail = true;break;}
+          while (prevflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) {
+            if (prevtraj == (int)InitialTrack.NumberTrajectoryPoints() - 2) {
+              bail = true;
+              break;
+            }
             ++prevtraj;
             prevflags = InitialTrack.FlagsAtPoint(prevtraj);
           }
-          TrajDirection_vec         = InitialTrack.DirectionAtPoint(prevtraj);
+          TrajDirection_vec = InitialTrack.DirectionAtPoint(prevtraj);
         }
-        else if(fAllowDynamicSliding && traj!=0){
-          int prevtraj = traj-1;
+        else if (fAllowDynamicSliding && traj != 0) {
+          int prevtraj = traj - 1;
           auto prevflags = InitialTrack.FlagsAtPoint(prevtraj);
-          while(prevflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)){
-            if(prevtraj == 0){bail = true;break;}
+          while (prevflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) {
+            if (prevtraj == 0) {
+              bail = true;
+              break;
+            }
             --prevtraj;
             prevflags = InitialTrack.FlagsAtPoint(prevtraj);
           }
-          TrajDirection_vec         = InitialTrack.DirectionAtPoint(prevtraj);
+          TrajDirection_vec = InitialTrack.DirectionAtPoint(prevtraj);
         }
-        else{
-          TrajDirection_vec         = InitialTrack.DirectionAtPoint(traj);
+        else {
+          TrajDirection_vec = InitialTrack.DirectionAtPoint(traj);
         }
 
         //find the next non bogus traj point.
-        int nexttraj = traj+1;
+        int nexttraj = traj + 1;
         auto nextflags = InitialTrack.FlagsAtPoint(nexttraj);
-        while(nextflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)){
-          if(nexttraj == (int)InitialTrack.NumberTrajectoryPoints()-2){bail = true;break;}
+        while (nextflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) {
+          if (nexttraj == (int)InitialTrack.NumberTrajectoryPoints() - 2) {
+            bail = true;
+            break;
+          }
           ++nexttraj;
           nextflags = InitialTrack.FlagsAtPoint(nexttraj);
         }
 
         //find the next next non bogus traj point.
-        int nextnexttraj = nexttraj+1;
+        int nextnexttraj = nexttraj + 1;
         auto nextnextflags = InitialTrack.FlagsAtPoint(nextnexttraj);
-        while(nextnextflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)){
-          if(nexttraj == (int)InitialTrack.NumberTrajectoryPoints()-1){bail = true;break;}
+        while (nextnextflags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) {
+          if (nexttraj == (int)InitialTrack.NumberTrajectoryPoints() - 1) {
+            bail = true;
+            break;
+          }
           ++nextnexttraj;
           nextnextflags = InitialTrack.FlagsAtPoint(nextnexttraj);
         }
 
-        if(bail){
+        if (bail) {
           if (fVerbose)
             mf::LogError("ShowerTrackColinearTrajPointDirection")
-              << "Trajectory point not set as rest of the traj points are bogus."<< std::endl;
+              << "Trajectory point not set as rest of the traj points are bogus." << std::endl;
           break;
         }
 
         //Get the directions.
-        geo::Vector_t NextTrajDirection_vec     = InitialTrack.DirectionAtPoint(nexttraj);
+        geo::Vector_t NextTrajDirection_vec = InitialTrack.DirectionAtPoint(nexttraj);
         geo::Vector_t NextNextTrajDirection_vec = InitialTrack.DirectionAtPoint(nextnexttraj);
 
-        TVector3 TrajDirection = {TrajDirection_vec.X(), TrajDirection_vec.Y(),TrajDirection_vec.Z()};
-        TVector3 NextTrajDirection = {NextTrajDirection_vec.X(), NextTrajDirection_vec.Y(),NextTrajDirection_vec.Z()};
-        TVector3 NextNextTrajDirection = {NextNextTrajDirection_vec.X(), NextNextTrajDirection_vec.Y(),NextNextTrajDirection_vec.Z()};
+        TVector3 TrajDirection = {
+          TrajDirection_vec.X(), TrajDirection_vec.Y(), TrajDirection_vec.Z()};
+        TVector3 NextTrajDirection = {
+          NextTrajDirection_vec.X(), NextTrajDirection_vec.Y(), NextTrajDirection_vec.Z()};
+        TVector3 NextNextTrajDirection = {NextNextTrajDirection_vec.X(),
+                                          NextNextTrajDirection_vec.Y(),
+                                          NextNextTrajDirection_vec.Z()};
 
         //Might still be bogus and we can't use the start point
-        if(TrajDirection.Mag() == 0){continue;}
-        if(NextTrajDirection.Mag() == 0){continue;}
-        if(NextNextTrajDirection.Mag() == 0){continue;}
+        if (TrajDirection.Mag() == 0) { continue; }
+        if (NextTrajDirection.Mag() == 0) { continue; }
+        if (NextNextTrajDirection.Mag() == 0) { continue; }
 
         //See if the angle is small enough.
-        if(TrajDirection.Angle(NextTrajDirection) < fAngleCut && TrajDirection.Angle(NextNextTrajDirection) <fAngleCut){
+        if (TrajDirection.Angle(NextTrajDirection) < fAngleCut &&
+            TrajDirection.Angle(NextNextTrajDirection) < fAngleCut) {
           break;
         }
       }
-      Direction_vec  = InitialTrack.DirectionAtPoint(trajpoint).Unit();
+      Direction_vec = InitialTrack.DirectionAtPoint(trajpoint).Unit();
     }
 
-    if(trajpoint == (int) InitialTrack.NumberTrajectoryPoints() -3){
+    if (trajpoint == (int)InitialTrack.NumberTrajectoryPoints() - 3) {
       if (fVerbose)
-        mf::LogError("ShowerSmartTrackTrajectoryPointDirectio") <<
-          "Trajectory point not set."<< std::endl;
+        mf::LogError("ShowerSmartTrackTrajectoryPointDirectio")
+          << "Trajectory point not set." << std::endl;
       return 1;
     }
 
     //Set the direction.
-    TVector3 Direction = {Direction_vec.X(), Direction_vec.Y(),Direction_vec.Z()};
-    TVector3 DirectionErr = {-999,-999,-999};
-    ShowerEleHolder.SetElement(Direction,DirectionErr,fShowerDirectionOutputLabel);
+    TVector3 Direction = {Direction_vec.X(), Direction_vec.Y(), Direction_vec.Z()};
+    TVector3 DirectionErr = {-999, -999, -999};
+    ShowerEleHolder.SetElement(Direction, DirectionErr, fShowerDirectionOutputLabel);
     return 0;
   }
 }
 
-
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrackColinearTrajPointDirection)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackDirection_tool.cc
@@ -14,226 +14,220 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerTrackDirection : IShowerTool {
 
-  class ShowerTrackDirection:IShowerTool {
+  public:
+    ShowerTrackDirection(const fhicl::ParameterSet& pset);
 
-    public:
+    //Find Track Direction using initial track.
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerTrackDirection(const fhicl::ParameterSet& pset);
-
-      //Find Track Direction using initial track.
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      //fcl
-      int  fVerbose;
-      bool fUsePandoraVertex; //Direction from point defined as
-      //(Position of traj point - Vertex) rather than
-      //(Position of traj point - Track Start Point).
-      bool fUsePositionInfo;  //Don't use the directionAtPoint rather
-      //than definition above.
-      //i.e((Position of traj point + 1) - (Position of traj point)
-
+  private:
+    //fcl
+    int fVerbose;
+    bool fUsePandoraVertex; //Direction from point defined as
+    //(Position of traj point - Vertex) rather than
+    //(Position of traj point - Track Start Point).
+    bool fUsePositionInfo; //Don't use the directionAtPoint rather
+                           //than definition above.
+                           //i.e((Position of traj point + 1) - (Position of traj point)
   };
 
-
   ShowerTrackDirection::ShowerTrackDirection(const fhicl::ParameterSet& pset)
-    :IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fVerbose(pset.get<int>("Verbose")),
-    fUsePandoraVertex(pset.get<bool>("UsePandoraVertex")),
-    fUsePositionInfo(pset.get<bool>("UsePositionInfo"))
-  {
-  }
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fUsePandoraVertex(pset.get<bool>("UsePandoraVertex"))
+    , fUsePositionInfo(pset.get<bool>("UsePositionInfo"))
+  {}
 
-  int ShowerTrackDirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
+  int
+  ShowerTrackDirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                         art::Event& Event,
+                                         reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //Check the Track has been defined
-    if(!ShowerEleHolder.CheckElement("InitialTrack")){
-      if (fVerbose)
-        mf::LogError("ShowerTrackDirection") << "Initial track not set"<< std::endl;
+    if (!ShowerEleHolder.CheckElement("InitialTrack")) {
+      if (fVerbose) mf::LogError("ShowerTrackDirection") << "Initial track not set" << std::endl;
       return 0;
     }
 
     //Check the start position is set.
-    if(fUsePandoraVertex && !ShowerEleHolder.CheckElement("ShowerStartPosition")){
+    if (fUsePandoraVertex && !ShowerEleHolder.CheckElement("ShowerStartPosition")) {
       if (fVerbose)
-        mf::LogError("ShowerTrackDirection") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerTrackDirection") << "Start position not set, returning " << std::endl;
       return 0;
     }
 
     //Get the track
     recob::Track InitialTrack;
-    ShowerEleHolder.GetElement("InitialTrack",InitialTrack);
+    ShowerEleHolder.GetElement("InitialTrack", InitialTrack);
 
-    if(fUsePositionInfo){
+    if (fUsePositionInfo) {
       geo::Point_t StartPosition;
-      if(fUsePandoraVertex){
-        TVector3 StartPosition_vec = {-999,-999,-999};
-        ShowerEleHolder.GetElement("ShowerStartPosition",StartPosition_vec);
-        StartPosition.SetCoordinates(StartPosition_vec.X(),StartPosition_vec.Y(),StartPosition_vec.Z());
+      if (fUsePandoraVertex) {
+        TVector3 StartPosition_vec = {-999, -999, -999};
+        ShowerEleHolder.GetElement("ShowerStartPosition", StartPosition_vec);
+        StartPosition.SetCoordinates(
+          StartPosition_vec.X(), StartPosition_vec.Y(), StartPosition_vec.Z());
       }
-      else{
+      else {
         StartPosition = InitialTrack.Start();
       }
 
       //Calculate the mean direction and the the standard deviation
-      float sumX=0, sumX2=0;
-      float sumY=0, sumY2=0;
-      float sumZ=0, sumZ2=0;
-      for(unsigned int traj=0; traj< InitialTrack.NumberTrajectoryPoints(); ++traj){
+      float sumX = 0, sumX2 = 0;
+      float sumY = 0, sumY2 = 0;
+      float sumZ = 0, sumZ2 = 0;
+      for (unsigned int traj = 0; traj < InitialTrack.NumberTrajectoryPoints(); ++traj) {
 
         //Ignore bogus flags.
         auto flags = InitialTrack.FlagsAtPoint(traj);
-        if(flags.isSet(recob::TrajectoryPointFlags::InvalidHitIndex)
-            || flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
+        if (flags.isSet(recob::TrajectoryPointFlags::InvalidHitIndex) ||
+            flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) {
+          continue;
+        }
 
         //Get the direction to the trajectory position.
         geo::Vector_t TrajPosition = (InitialTrack.LocationAtPoint(traj) - StartPosition).Unit();
-        sumX += TrajPosition.X(); sumX2 += TrajPosition.X()*TrajPosition.X();
-        sumY += TrajPosition.Y(); sumY2 += TrajPosition.Y()*TrajPosition.Y();
-        sumZ += TrajPosition.Z(); sumZ2 += TrajPosition.Z()*TrajPosition.Z();
+        sumX += TrajPosition.X();
+        sumX2 += TrajPosition.X() * TrajPosition.X();
+        sumY += TrajPosition.Y();
+        sumY2 += TrajPosition.Y() * TrajPosition.Y();
+        sumZ += TrajPosition.Z();
+        sumZ2 += TrajPosition.Z() * TrajPosition.Z();
       }
 
-      float NumTraj =  InitialTrack.NumberTrajectoryPoints();
-      geo::Vector_t Mean = {sumX/NumTraj,sumY/NumTraj,sumZ/NumTraj};
+      float NumTraj = InitialTrack.NumberTrajectoryPoints();
+      geo::Vector_t Mean = {sumX / NumTraj, sumY / NumTraj, sumZ / NumTraj};
       Mean = Mean.Unit();
 
       float RMSX = 999;
       float RMSY = 999;
       float RMSZ = 999;
-      if(sumX2/NumTraj - ((sumX/NumTraj)*((sumX/NumTraj))) > 0){
-        RMSX = std::sqrt(sumX2/NumTraj - ((sumX/NumTraj)*((sumX/NumTraj))));
+      if (sumX2 / NumTraj - ((sumX / NumTraj) * ((sumX / NumTraj))) > 0) {
+        RMSX = std::sqrt(sumX2 / NumTraj - ((sumX / NumTraj) * ((sumX / NumTraj))));
       }
-      if(sumY2/NumTraj - ((sumY/NumTraj)*((sumY/NumTraj))) > 0){
-        RMSY = std::sqrt(sumY2/NumTraj - ((sumY/NumTraj)*((sumY/NumTraj))));
+      if (sumY2 / NumTraj - ((sumY / NumTraj) * ((sumY / NumTraj))) > 0) {
+        RMSY = std::sqrt(sumY2 / NumTraj - ((sumY / NumTraj) * ((sumY / NumTraj))));
       }
-      if(sumZ2/NumTraj - ((sumZ/NumTraj)*((sumZ/NumTraj))) > 0){
-        RMSZ = std::sqrt(sumZ2/NumTraj - ((sumZ/NumTraj)*((sumZ/NumTraj))));
+      if (sumZ2 / NumTraj - ((sumZ / NumTraj) * ((sumZ / NumTraj))) > 0) {
+        RMSZ = std::sqrt(sumZ2 / NumTraj - ((sumZ / NumTraj) * ((sumZ / NumTraj))));
       }
 
-      TVector3 Direction_Mean = {0,0,0};
+      TVector3 Direction_Mean = {0, 0, 0};
       int N = 0;
       //Remove trajectory points from the mean that are not with one sigma.
-      for(unsigned int traj=0; traj< InitialTrack.NumberTrajectoryPoints(); ++traj){
+      for (unsigned int traj = 0; traj < InitialTrack.NumberTrajectoryPoints(); ++traj) {
 
         //Ignore bogus flags.
         auto flags = InitialTrack.FlagsAtPoint(traj);
-        if(flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
+        if (flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
         //Get the direction of the trajectory point.
         geo::Point_t TrajPosition = InitialTrack.LocationAtPoint(traj);
-        geo::Vector_t Direction   = (TrajPosition - StartPosition).Unit();
+        geo::Vector_t Direction = (TrajPosition - StartPosition).Unit();
 
         //Remove points not within 1RMS.
-        if((std::abs((Direction-Mean).X()) < 1*RMSX) &&
-            (std::abs((Direction-Mean).Y()) < 1*RMSY) &&
-            (std::abs((Direction-Mean).Z()) < 1*RMSZ)){
-          TVector3 Direction_vec = {Direction.X(),Direction.Y(),Direction.Z()};
-          if(Direction_vec.Mag() == 0){continue;}
+        if ((std::abs((Direction - Mean).X()) < 1 * RMSX) &&
+            (std::abs((Direction - Mean).Y()) < 1 * RMSY) &&
+            (std::abs((Direction - Mean).Z()) < 1 * RMSZ)) {
+          TVector3 Direction_vec = {Direction.X(), Direction.Y(), Direction.Z()};
+          if (Direction_vec.Mag() == 0) { continue; }
           Direction_Mean += Direction_vec;
           ++N;
         }
       }
 
-
       //Take the mean value
-      if(N > 0){
-        TVector3 Direction    = Direction_Mean.Unit();
-        TVector3 DirectionErr = {RMSX,RMSY,RMSZ};
-        ShowerEleHolder.SetElement(Direction,DirectionErr,"ShowerDirection");
+      if (N > 0) {
+        TVector3 Direction = Direction_Mean.Unit();
+        TVector3 DirectionErr = {RMSX, RMSY, RMSZ};
+        ShowerEleHolder.SetElement(Direction, DirectionErr, "ShowerDirection");
       }
-      else{
+      else {
         if (fVerbose)
-          mf::LogError("ShowerTrackDirection") << "None of the points are within 1 sigma"<< std::endl;
+          mf::LogError("ShowerTrackDirection")
+            << "None of the points are within 1 sigma" << std::endl;
         return 1;
       }
 
       return 0;
     }
-    else{ // if(fUsePositionInfo)
+    else { // if(fUsePositionInfo)
 
-      float sumX=0, sumX2=0;
-      float sumY=0, sumY2=0;
-      float sumZ=0, sumZ2=0;
-      for(unsigned int traj=0; traj< InitialTrack.NumberTrajectoryPoints(); ++traj){
+      float sumX = 0, sumX2 = 0;
+      float sumY = 0, sumY2 = 0;
+      float sumZ = 0, sumZ2 = 0;
+      for (unsigned int traj = 0; traj < InitialTrack.NumberTrajectoryPoints(); ++traj) {
 
         //Ignore bogus points
         auto flags = InitialTrack.FlagsAtPoint(traj);
-        if(flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
+        if (flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
         //Get the direction.
-        geo::Vector_t  Direction = InitialTrack.DirectionAtPoint(traj);
-        sumX += Direction.X(); sumX2 += Direction.X()*Direction.X();
-        sumY += Direction.Y(); sumY2 += Direction.Y()*Direction.Y();
-        sumZ += Direction.Z(); sumZ2 += Direction.Z()*Direction.Z();
+        geo::Vector_t Direction = InitialTrack.DirectionAtPoint(traj);
+        sumX += Direction.X();
+        sumX2 += Direction.X() * Direction.X();
+        sumY += Direction.Y();
+        sumY2 += Direction.Y() * Direction.Y();
+        sumZ += Direction.Z();
+        sumZ2 += Direction.Z() * Direction.Z();
       }
 
-      float NumTraj =  InitialTrack.NumberTrajectoryPoints();
-      geo::Vector_t Mean = {sumX/NumTraj,sumY/NumTraj,sumZ/NumTraj};
+      float NumTraj = InitialTrack.NumberTrajectoryPoints();
+      geo::Vector_t Mean = {sumX / NumTraj, sumY / NumTraj, sumZ / NumTraj};
       Mean = Mean.Unit();
 
       float RMSX = 999;
       float RMSY = 999;
       float RMSZ = 999;
-      if(sumX2/NumTraj - ((sumX/NumTraj)*((sumX/NumTraj))) > 0){
-        RMSX = std::sqrt(sumX2/NumTraj - ((sumX/NumTraj)*((sumX/NumTraj))));
+      if (sumX2 / NumTraj - ((sumX / NumTraj) * ((sumX / NumTraj))) > 0) {
+        RMSX = std::sqrt(sumX2 / NumTraj - ((sumX / NumTraj) * ((sumX / NumTraj))));
       }
-      if(sumY2/NumTraj - ((sumY/NumTraj)*((sumY/NumTraj))) > 0){
-        RMSY = std::sqrt(sumY2/NumTraj - ((sumY/NumTraj)*((sumY/NumTraj))));
+      if (sumY2 / NumTraj - ((sumY / NumTraj) * ((sumY / NumTraj))) > 0) {
+        RMSY = std::sqrt(sumY2 / NumTraj - ((sumY / NumTraj) * ((sumY / NumTraj))));
       }
-      if(sumZ2/NumTraj - ((sumZ/NumTraj)*((sumZ/NumTraj))) > 0){
-        RMSZ = std::sqrt(sumZ2/NumTraj - ((sumZ/NumTraj)*((sumZ/NumTraj))));
+      if (sumZ2 / NumTraj - ((sumZ / NumTraj) * ((sumZ / NumTraj))) > 0) {
+        RMSZ = std::sqrt(sumZ2 / NumTraj - ((sumZ / NumTraj) * ((sumZ / NumTraj))));
       }
 
       //Remove trajectory points from the mean that are not with one sigma.
       float N = 0.;
-      TVector3 Direction_Mean = {0,0,0};
-      for(unsigned int traj=0; traj<InitialTrack.NumberTrajectoryPoints(); ++traj){
+      TVector3 Direction_Mean = {0, 0, 0};
+      for (unsigned int traj = 0; traj < InitialTrack.NumberTrajectoryPoints(); ++traj) {
 
         auto flags = InitialTrack.FlagsAtPoint(traj);
-        if(flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
-
+        if (flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
         geo::Vector_t Direction = InitialTrack.DirectionAtPoint(traj).Unit();
-        if((std::abs((Direction-Mean).X()) < 1*RMSX) &&
-            (std::abs((Direction-Mean).Y()) < 1*RMSY) &&
-            (std::abs((Direction-Mean).Z()) < 1*RMSZ)){
-          TVector3 Direction_vec = {Direction.X(),Direction.Y(),Direction.Z()};
-          if(Direction_vec.Mag() == 0){continue;}
+        if ((std::abs((Direction - Mean).X()) < 1 * RMSX) &&
+            (std::abs((Direction - Mean).Y()) < 1 * RMSY) &&
+            (std::abs((Direction - Mean).Z()) < 1 * RMSZ)) {
+          TVector3 Direction_vec = {Direction.X(), Direction.Y(), Direction.Z()};
+          if (Direction_vec.Mag() == 0) { continue; }
           Direction_Mean += Direction_vec;
           ++N;
         }
       }
 
       //Take the mean value
-      if(N>0){
+      if (N > 0) {
         TVector3 Direction = Direction_Mean.Unit();
-        TVector3 DirectionErr = {RMSX,RMSY,RMSZ};
-        ShowerEleHolder.SetElement(Direction,DirectionErr,"ShowerDirection");
+        TVector3 DirectionErr = {RMSX, RMSY, RMSZ};
+        ShowerEleHolder.SetElement(Direction, DirectionErr, "ShowerDirection");
       }
-      else{
+      else {
         if (fVerbose)
-          mf::LogError("ShowerTrackDirection") << "None of the points are within 1 sigma"<< std::endl;
+          mf::LogError("ShowerTrackDirection")
+            << "None of the points are within 1 sigma" << std::endl;
         return 1;
       }
-
     }
     return 0;
   }
 }
 
-
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrackDirection)
-
-
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
@@ -14,165 +14,162 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerTrackHitDirection : IShowerTool {
 
-  class ShowerTrackHitDirection:IShowerTool {
+  public:
+    ShowerTrackHitDirection(const fhicl::ParameterSet& pset);
 
-    public:
+    //Calculate the shower direction from the initial track hits.
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerTrackHitDirection(const fhicl::ParameterSet& pset);
+  private:
+    //fcl
+    int fVerbose;
+    bool fUsePandoraVertex; //Direction from point defined as (Position of Hit - Vertex)
+    //rather than (Position of Hit - Track Start Point)
+    art::InputTag fHitModuleLabel;
+    art::InputTag fPFParticleLabel;
 
-      //Calculate the shower direction from the initial track hits.
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      //fcl
-      int  fVerbose;
-      bool fUsePandoraVertex; //Direction from point defined as (Position of Hit - Vertex)
-      //rather than (Position of Hit - Track Start Point)
-      art::InputTag fHitModuleLabel;
-      art::InputTag fPFParticleLabel;
-
-      std::string fInitialTrackHitsInputLabel;
-      std::string fShowerStartPositionInputLabel;
-      std::string fInitialTrackInputLabel;
-      std::string fShowerDirectionOutputLabel;
+    std::string fInitialTrackHitsInputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fInitialTrackInputLabel;
+    std::string fShowerDirectionOutputLabel;
   };
 
-
   ShowerTrackHitDirection::ShowerTrackHitDirection(const fhicl::ParameterSet& pset)
-    :  IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fVerbose(pset.get<int>("Verbose")),
-    fUsePandoraVertex(pset.get<bool>         ("UsePandoraVertex")),
-    fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fInitialTrackHitsInputLabel(pset.get<std::string>("InitialTrackHitsInputLabel")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel")),
-    fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
-  {
-  }
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fUsePandoraVertex(pset.get<bool>("UsePandoraVertex"))
+    , fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fInitialTrackHitsInputLabel(pset.get<std::string>("InitialTrackHitsInputLabel"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  {}
 
-  int ShowerTrackHitDirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
+  int
+  ShowerTrackHitDirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                            art::Event& Event,
+                                            reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //Check the Track Hits has been defined
-    if(!ShowerEleHolder.CheckElement(fInitialTrackHitsInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackHitsInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackHitDirection") << "Initial track hits not set"<< std::endl;
+        mf::LogError("ShowerTrackHitDirection") << "Initial track hits not set" << std::endl;
       return 0;
     }
 
     //Check the start position is set.
-    if(fUsePandoraVertex && !ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (fUsePandoraVertex && !ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackHitDirection") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerTrackHitDirection")
+          << "Start position not set, returning " << std::endl;
       return 0;
     }
 
     //Get the start poistion
-    TVector3 StartPosition = {-999,-999,-99};
-    if(fUsePandoraVertex){
-      ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,StartPosition);
+    TVector3 StartPosition = {-999, -999, -99};
+    if (fUsePandoraVertex) {
+      ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPosition);
     }
-    else{
+    else {
       //Check the Tracks has been defined
-      if(!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)){
+      if (!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)) {
         if (fVerbose)
-          mf::LogError("ShowerTrackHitDirection") << "Initial track not set"<< std::endl;
+          mf::LogError("ShowerTrackHitDirection") << "Initial track not set" << std::endl;
         return 0;
       }
       recob::Track InitialTrack;
-      ShowerEleHolder.GetElement(fInitialTrackInputLabel,InitialTrack);
+      ShowerEleHolder.GetElement(fInitialTrackInputLabel, InitialTrack);
       geo::Point_t Start_point = InitialTrack.Start();
-      StartPosition = {Start_point.X(),Start_point.Y(),Start_point.Z()};
+      StartPosition = {Start_point.X(), Start_point.Y(), Start_point.Z()};
     }
 
-
     //Get the spacepoints associated to hits
-    auto const hitHandle = Event.getValidHandle<std::vector<recob::Hit> >(fHitModuleLabel);
+    auto const hitHandle = Event.getValidHandle<std::vector<recob::Hit>>(fHitModuleLabel);
 
     //Get the spacepoint handle. We need to do this in 3D.
-    const art::FindManyP<recob::SpacePoint>& fmsp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>(
-        hitHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::SpacePoint>& fmsp =
+      ShowerEleHolder.GetFindManyP<recob::SpacePoint>(hitHandle, Event, fPFParticleLabel);
 
     //Get the initial track hits.
-    std::vector<art::Ptr<recob::Hit> > InitialTrackHits;
-    ShowerEleHolder.GetElement(fInitialTrackHitsInputLabel,InitialTrackHits);
-
+    std::vector<art::Ptr<recob::Hit>> InitialTrackHits;
+    ShowerEleHolder.GetElement(fInitialTrackHitsInputLabel, InitialTrackHits);
 
     //Calculate the mean direction and the the standard deviation
-    float sumX=0, sumX2=0;
-    float sumY=0, sumY2=0;
-    float sumZ=0, sumZ2=0;
+    float sumX = 0, sumX2 = 0;
+    float sumY = 0, sumY2 = 0;
+    float sumZ = 0, sumZ2 = 0;
 
     //Get the spacepoints associated to the track hit
-    std::vector<art::Ptr<recob::SpacePoint > > intitaltrack_sp;
-    for(auto const hit: InitialTrackHits){
-      std::vector<art::Ptr<recob::SpacePoint > > sps = fmsp.at(hit.key());
-      for(auto const sp: sps){
+    std::vector<art::Ptr<recob::SpacePoint>> intitaltrack_sp;
+    for (auto const hit : InitialTrackHits) {
+      std::vector<art::Ptr<recob::SpacePoint>> sps = fmsp.at(hit.key());
+      for (auto const sp : sps) {
         intitaltrack_sp.push_back(sp);
 
         //Get the direction relative to the start positon
         TVector3 pos = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - StartPosition;
-        if(pos.Mag() == 0){continue;}
+        if (pos.Mag() == 0) { continue; }
 
-        sumX = pos.X(); sumX2 += pos.X()*pos.X();
-        sumY = pos.Y(); sumY2 += pos.Y()*pos.Y();
-        sumZ = pos.Z(); sumZ2 += pos.Z()*pos.Z();
+        sumX = pos.X();
+        sumX2 += pos.X() * pos.X();
+        sumY = pos.Y();
+        sumY2 += pos.Y() * pos.Y();
+        sumZ = pos.Z();
+        sumZ2 += pos.Z() * pos.Z();
       }
     }
 
     float NumSps = intitaltrack_sp.size();
-    TVector3 Mean = {sumX/NumSps,sumY/NumSps,sumZ/NumSps};
+    TVector3 Mean = {sumX / NumSps, sumY / NumSps, sumZ / NumSps};
     Mean = Mean.Unit();
 
     float RMSX = 999;
     float RMSY = 999;
     float RMSZ = 999;
-    if(sumX2/NumSps - ((sumX/NumSps)*((sumX/NumSps))) > 0){
-      RMSX = std::sqrt(sumX2/NumSps - ((sumX/NumSps)*((sumX/NumSps))));
+    if (sumX2 / NumSps - ((sumX / NumSps) * ((sumX / NumSps))) > 0) {
+      RMSX = std::sqrt(sumX2 / NumSps - ((sumX / NumSps) * ((sumX / NumSps))));
     }
-    if(sumY2/NumSps - ((sumY/NumSps)*((sumY/NumSps))) > 0){
-      RMSY = std::sqrt(sumY2/NumSps - ((sumY/NumSps)*((sumY/NumSps))));
+    if (sumY2 / NumSps - ((sumY / NumSps) * ((sumY / NumSps))) > 0) {
+      RMSY = std::sqrt(sumY2 / NumSps - ((sumY / NumSps) * ((sumY / NumSps))));
     }
-    if(sumZ2/NumSps - ((sumZ/NumSps)*((sumZ/NumSps))) > 0){
-      RMSZ = std::sqrt(sumZ2/NumSps - ((sumZ/NumSps)*((sumZ/NumSps))));
+    if (sumZ2 / NumSps - ((sumZ / NumSps) * ((sumZ / NumSps))) > 0) {
+      RMSZ = std::sqrt(sumZ2 / NumSps - ((sumZ / NumSps) * ((sumZ / NumSps))));
     }
-
 
     //Loop over the spacepoints and remove ones the relative direction is not within one sigma.
-    TVector3 Direction_Mean = {0,0,0};
+    TVector3 Direction_Mean = {0, 0, 0};
     int N = 0;
-    for(auto const sp: intitaltrack_sp){
-      TVector3 Direction = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - StartPosition;
-      if((std::abs((Direction-Mean).X()) < 1*RMSX) &&
-          (std::abs((Direction-Mean).Y())< 1*RMSY) &&
-          (std::abs((Direction-Mean).Z()) < 1*RMSZ)){
-        if(Direction.Mag() == 0){continue;}
+    for (auto const sp : intitaltrack_sp) {
+      TVector3 Direction =
+        IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - StartPosition;
+      if ((std::abs((Direction - Mean).X()) < 1 * RMSX) &&
+          (std::abs((Direction - Mean).Y()) < 1 * RMSY) &&
+          (std::abs((Direction - Mean).Z()) < 1 * RMSZ)) {
+        if (Direction.Mag() == 0) { continue; }
         ++N;
         Direction_Mean += Direction;
       }
     }
 
-    if(N>0){
+    if (N > 0) {
       //Take the mean value
       TVector3 Direction = Direction_Mean.Unit();
-      ShowerEleHolder.SetElement(Direction,fShowerDirectionOutputLabel);
+      ShowerEleHolder.SetElement(Direction, fShowerDirectionOutputLabel);
     }
-    else{
+    else {
       if (fVerbose)
-        mf::LogError("ShowerTrackHitDirection") << "None of the points are within 1 sigma"<< std::endl;
+        mf::LogError("ShowerTrackHitDirection")
+          << "None of the points are within 1 sigma" << std::endl;
       return 1;
     }
     return 0;
   }
 }
 
-
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrackHitDirection)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackPCADirection_tool.cc
@@ -17,86 +17,85 @@
 
 namespace ShowerRecoTools {
 
-  class ShowerTrackPCADirection:IShowerTool {
+  class ShowerTrackPCADirection : IShowerTool {
 
-    public:
+  public:
+    ShowerTrackPCADirection(const fhicl::ParameterSet& pset);
 
-      ShowerTrackPCADirection(const fhicl::ParameterSet& pset);
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
+  private:
+    TVector3 ShowerPCAVector(const detinfo::DetectorClocksData& clockData,
+                             const detinfo::DetectorPropertiesData& detProp,
+                             std::vector<art::Ptr<recob::SpacePoint>>& spacePoints_pfp,
+                             const art::FindManyP<recob::Hit>& fmh,
+                             TVector3& ShowerCentre);
 
-    private:
+    //fcl
+    art::InputTag fPFParticleLabel;
+    art::InputTag fHitModuleLabel;
+    int fVerbose;
+    bool fChargeWeighted;       //Should we charge weight the PCA.
+    unsigned int fMinPCAPoints; //Number of spacepoints needed to do the analysis.
 
-      TVector3 ShowerPCAVector(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          std::vector<art::Ptr<recob::SpacePoint> >& spacePoints_pfp,
-          const art::FindManyP<recob::Hit>& fmh,
-          TVector3& ShowerCentre);
-
-      //fcl
-      art::InputTag fPFParticleLabel;
-      art::InputTag fHitModuleLabel;
-      int           fVerbose;
-      bool          fChargeWeighted;  //Should we charge weight the PCA.
-      unsigned int  fMinPCAPoints;    //Number of spacepoints needed to do the analysis.
-
-      std::string fShowerStartPositionInputLabel;
-      std::string fInitialTrackSpacePointsInputLabel;
-      std::string fShowerDirectionOutputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fInitialTrackSpacePointsInputLabel;
+    std::string fShowerDirectionOutputLabel;
   };
 
-
   ShowerTrackPCADirection::ShowerTrackPCADirection(const fhicl::ParameterSet& pset)
-    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel")),
-    fVerbose(pset.get<int>                 ("Verbose")),
-    fChargeWeighted(pset.get<bool>         ("ChargeWeighted")),
-    fMinPCAPoints (pset.get<unsigned int> ("MinPCAPoints")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel")),
-    fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fHitModuleLabel(pset.get<art::InputTag>("HitModuleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fChargeWeighted(pset.get<bool>("ChargeWeighted"))
+    , fMinPCAPoints(pset.get<unsigned int>("MinPCAPoints"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  {}
+
+  int
+  ShowerTrackPCADirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                            art::Event& Event,
+                                            reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
 
-  int ShowerTrackPCADirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
-
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackPCA") << "Start Position not set. Stopping" << std::endl;;
+        mf::LogError("ShowerTrackPCA") << "Start Position not set. Stopping" << std::endl;
+      ;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackPCA") << "TrackSpacePoints not set, returning "<< std::endl;
+        mf::LogError("ShowerTrackPCA") << "TrackSpacePoints not set, returning " << std::endl;
       return 1;
     }
 
     //Get the spacepoints handle and the hit assoication
-    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
+    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
 
-    const art::FindManyP<recob::Hit>& fmh = ShowerEleHolder.GetFindManyP<recob::Hit>(
-        spHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Hit>& fmh =
+      ShowerEleHolder.GetFindManyP<recob::Hit>(spHandle, Event, fPFParticleLabel);
 
-    std::vector<art::Ptr<recob::SpacePoint> > trackSpacePoints;
-    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel,trackSpacePoints);
-
+    std::vector<art::Ptr<recob::SpacePoint>> trackSpacePoints;
+    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel, trackSpacePoints);
 
     //We cannot progress with no spacepoints.
-    if(trackSpacePoints.size() < fMinPCAPoints){
+    if (trackSpacePoints.size() < fMinPCAPoints) {
       if (fVerbose)
-        mf::LogError("ShowerTrackPCA") << "Not enough spacepoints for PCA, returning "<< std::endl;
+        mf::LogError("ShowerTrackPCA") << "Not enough spacepoints for PCA, returning " << std::endl;
       return 1;
     }
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
     //Find the PCA vector
     TVector3 trackCentre;
@@ -104,44 +103,46 @@ namespace ShowerRecoTools {
 
     //Get the General direction as the vector between the start position and the centre
     TVector3 StartPositionVec = {-999, -999, -999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,StartPositionVec);
-    TVector3 GeneralDir       = (trackCentre - StartPositionVec).Unit();
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPositionVec);
+    TVector3 GeneralDir = (trackCentre - StartPositionVec).Unit();
 
     //Dot product
     double DotProduct = Eigenvector.Dot(GeneralDir);
 
     //If the dotproduct is negative the Direction needs Flipping
-    if(DotProduct < 0){
-      Eigenvector[0] = - Eigenvector[0];
-      Eigenvector[1] = - Eigenvector[1];
-      Eigenvector[2] = - Eigenvector[2];
+    if (DotProduct < 0) {
+      Eigenvector[0] = -Eigenvector[0];
+      Eigenvector[1] = -Eigenvector[1];
+      Eigenvector[2] = -Eigenvector[2];
     }
 
-    TVector3 EigenvectorErr = {-999,-999,-999};
+    TVector3 EigenvectorErr = {-999, -999, -999};
 
-    ShowerEleHolder.SetElement(Eigenvector,EigenvectorErr,fShowerDirectionOutputLabel);
+    ShowerEleHolder.SetElement(Eigenvector, EigenvectorErr, fShowerDirectionOutputLabel);
 
     return 0;
   }
 
-
   //Function to calculate the shower direction using a charge weight 3D PCA calculation.
-  TVector3 ShowerTrackPCADirection::ShowerPCAVector(const detinfo::DetectorClocksData& clockData,
-          const detinfo::DetectorPropertiesData& detProp,
-          std::vector<art::Ptr<recob::SpacePoint> >& sps,
-          const art::FindManyP<recob::Hit>& fmh, TVector3& ShowerCentre){
+  TVector3
+  ShowerTrackPCADirection::ShowerPCAVector(const detinfo::DetectorClocksData& clockData,
+                                           const detinfo::DetectorPropertiesData& detProp,
+                                           std::vector<art::Ptr<recob::SpacePoint>>& sps,
+                                           const art::FindManyP<recob::Hit>& fmh,
+                                           TVector3& ShowerCentre)
+  {
 
     //Initialise the the PCA.
-    TPrincipal *pca = new TPrincipal(3,"");
+    TPrincipal* pca = new TPrincipal(3, "");
 
     float TotalCharge = 0;
 
     //Get the Shower Centre
-    ShowerCentre = IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, sps, fmh, TotalCharge);
-
+    ShowerCentre =
+      IShowerTool::GetLArPandoraShowerAlg().ShowerCentre(clockData, detProp, sps, fmh, TotalCharge);
 
     //Normalise the spacepoints, charge weight and add to the PCA.
-    for(auto& sp: sps){
+    for (auto& sp : sps) {
 
       TVector3 sp_position = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp);
 
@@ -150,25 +151,25 @@ namespace ShowerRecoTools {
       //Normalise the spacepoint position.
       sp_position = sp_position - ShowerCentre;
 
-      if(fChargeWeighted){
+      if (fChargeWeighted) {
 
         //Get the charge.
-        float Charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(sp,fmh);
+        float Charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(sp, fmh);
 
         //Get the time of the spacepoint
-        float Time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(sp,fmh);
+        float Time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(sp, fmh);
 
         //Correct for the lifetime at the moment.
-        Charge *= std::exp((sampling_rate(clockData)* Time ) / (detProp.ElectronLifetime()*1e3));
+        Charge *= std::exp((sampling_rate(clockData) * Time) / (detProp.ElectronLifetime() * 1e3));
 
         //Charge Weight
-        wht *= std::sqrt(Charge/TotalCharge);
+        wht *= std::sqrt(Charge / TotalCharge);
       }
 
       double sp_coord[3];
-      sp_coord[0] = sp_position.X()*wht;
-      sp_coord[1] = sp_position.Y()*wht;
-      sp_coord[2] = sp_position.Z()*wht;
+      sp_coord[0] = sp_position.X() * wht;
+      sp_coord[1] = sp_position.Y() * wht;
+      sp_coord[2] = sp_position.Z() * wht;
 
       //Add to the PCA
       pca->AddRow(sp_coord);
@@ -180,7 +181,7 @@ namespace ShowerRecoTools {
     //Get the Eigenvectors.
     const TMatrixD* Eigenvectors = pca->GetEigenVectors();
 
-    TVector3 Eigenvector = { (*Eigenvectors)[0][0], (*Eigenvectors)[1][0], (*Eigenvectors)[2][0] };
+    TVector3 Eigenvector = {(*Eigenvectors)[0][0], (*Eigenvectors)[1][0], (*Eigenvectors)[2][0]};
 
     delete pca;
 
@@ -189,4 +190,3 @@ namespace ShowerRecoTools {
 }
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrackPCADirection)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
@@ -14,152 +14,149 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerTrackSpacePointDirection : IShowerTool {
 
-  class ShowerTrackSpacePointDirection:IShowerTool {
+  public:
+    ShowerTrackSpacePointDirection(const fhicl::ParameterSet& pset);
 
-    public:
+    //Calculate the direction using the initial track spacepoints
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerTrackSpacePointDirection(const fhicl::ParameterSet& pset);
+  private:
+    //fcl
+    int fVerbose;
+    bool fUsePandoraVertex; //Direction from point defined as
+    //(Position of SP - Vertex) rather than
+    //(Position of SP - Track Start Point).
 
-      //Calculate the direction using the initial track spacepoints
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      //fcl
-      int  fVerbose;
-      bool fUsePandoraVertex; //Direction from point defined as
-      //(Position of SP - Vertex) rather than
-      //(Position of SP - Track Start Point).
-
-      std::string fInitialTrackSpacePointsInputLabel;
-      std::string fShowerStartPositionInputLabel;
-      std::string fInitialTrackInputLabel;
-      std::string fShowerDirectionOutputLabel;
-
+    std::string fInitialTrackSpacePointsInputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fInitialTrackInputLabel;
+    std::string fShowerDirectionOutputLabel;
   };
 
-
   ShowerTrackSpacePointDirection::ShowerTrackSpacePointDirection(const fhicl::ParameterSet& pset)
-    :IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fVerbose(pset.get<int>("Verbose")),
-    fUsePandoraVertex(pset.get<bool>("UsePandoraVertex")),
-    fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel")),
-    fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
-  {
-  }
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fUsePandoraVertex(pset.get<bool>("UsePandoraVertex"))
+    , fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  {}
 
-  int ShowerTrackSpacePointDirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
+  int
+  ShowerTrackSpacePointDirection::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //Check the Track Hits has been defined
-    if(!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackSpacePointDirection") << "Initial track spacepoints not set"<< std::endl;
+        mf::LogError("ShowerTrackSpacePointDirection")
+          << "Initial track spacepoints not set" << std::endl;
       return 0;
     }
 
     //Check the start position is set.
-    if(fUsePandoraVertex && !ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (fUsePandoraVertex && !ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
         mf::LogError("ShowerTrackSpacePointDirection")
-          << "Start position not set, returning "<< std::endl;
+          << "Start position not set, returning " << std::endl;
       return 0;
     }
 
     //Get the start poistion
-    TVector3 StartPosition = {-999,-999,-999};
-    if(fUsePandoraVertex){
-      ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,StartPosition);
+    TVector3 StartPosition = {-999, -999, -999};
+    if (fUsePandoraVertex) {
+      ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPosition);
     }
-    else{
+    else {
       //Check the Tracks has been defined
-      if(!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)){
+      if (!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)) {
         if (fVerbose)
-          mf::LogError("ShowerTrackSpacePointDirection")
-            << "Initial track not set"<< std::endl;
+          mf::LogError("ShowerTrackSpacePointDirection") << "Initial track not set" << std::endl;
         return 0;
       }
       recob::Track InitialTrack;
-      ShowerEleHolder.GetElement(fInitialTrackInputLabel,InitialTrack);
+      ShowerEleHolder.GetElement(fInitialTrackInputLabel, InitialTrack);
       geo::Point_t Start_point = InitialTrack.Start();
-      StartPosition = {Start_point.X(),Start_point.Y(),Start_point.Z()};
+      StartPosition = {Start_point.X(), Start_point.Y(), Start_point.Z()};
     }
 
     //Get the initial track hits.
-    std::vector<art::Ptr<recob::SpacePoint> > intitaltrack_sp;
-    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel,intitaltrack_sp);
+    std::vector<art::Ptr<recob::SpacePoint>> intitaltrack_sp;
+    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel, intitaltrack_sp);
 
     //Calculate the mean direction and the the standard deviation
-    float sumX=0, sumX2=0;
-    float sumY=0, sumY2=0;
-    float sumZ=0, sumZ2=0;
+    float sumX = 0, sumX2 = 0;
+    float sumY = 0, sumY2 = 0;
+    float sumZ = 0, sumZ2 = 0;
 
     //Get the spacepoints associated to the track hit
-    for(auto const& sp: intitaltrack_sp){
+    for (auto const& sp : intitaltrack_sp) {
 
       //Get the direction relative to the start positon
       TVector3 pos = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - StartPosition;
-      if(pos.Mag() == 0){continue;}
+      if (pos.Mag() == 0) { continue; }
 
-      sumX = pos.X(); sumX2 += pos.X()*pos.X();
-      sumY = pos.Y(); sumY2 += pos.Y()*pos.Y();
-      sumZ = pos.Z(); sumZ2 += pos.Z()*pos.Z();
+      sumX = pos.X();
+      sumX2 += pos.X() * pos.X();
+      sumY = pos.Y();
+      sumY2 += pos.Y() * pos.Y();
+      sumZ = pos.Z();
+      sumZ2 += pos.Z() * pos.Z();
     }
 
     float NumSps = intitaltrack_sp.size();
-    TVector3 Mean = {sumX/NumSps,sumY/NumSps,sumZ/NumSps};
+    TVector3 Mean = {sumX / NumSps, sumY / NumSps, sumZ / NumSps};
     Mean = Mean.Unit();
 
     float RMSX = 999;
     float RMSY = 999;
     float RMSZ = 999;
-    if(sumX2/NumSps - ((sumX/NumSps)*((sumX/NumSps))) > 0){
-      RMSX = std::sqrt(sumX2/NumSps - ((sumX/NumSps)*((sumX/NumSps))));
+    if (sumX2 / NumSps - ((sumX / NumSps) * ((sumX / NumSps))) > 0) {
+      RMSX = std::sqrt(sumX2 / NumSps - ((sumX / NumSps) * ((sumX / NumSps))));
     }
-    if(sumY2/NumSps - ((sumY/NumSps)*((sumY/NumSps))) > 0){
-      RMSY = std::sqrt(sumY2/NumSps - ((sumY/NumSps)*((sumY/NumSps))));
+    if (sumY2 / NumSps - ((sumY / NumSps) * ((sumY / NumSps))) > 0) {
+      RMSY = std::sqrt(sumY2 / NumSps - ((sumY / NumSps) * ((sumY / NumSps))));
     }
-    if(sumZ2/NumSps - ((sumZ/NumSps)*((sumZ/NumSps))) > 0){
-      RMSZ = std::sqrt(sumZ2/NumSps - ((sumZ/NumSps)*((sumZ/NumSps))));
+    if (sumZ2 / NumSps - ((sumZ / NumSps) * ((sumZ / NumSps))) > 0) {
+      RMSZ = std::sqrt(sumZ2 / NumSps - ((sumZ / NumSps) * ((sumZ / NumSps))));
     }
-
 
     //Loop over the spacepoints and remove ones the relative direction is not within one sigma.
-    TVector3 Direction_Mean = {0,0,0};
+    TVector3 Direction_Mean = {0, 0, 0};
     int N = 0;
-    for(auto const sp: intitaltrack_sp){
-      TVector3 Direction = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - StartPosition;
-      if((std::abs((Direction-Mean).X()) < 1*RMSX) &&
-          (std::abs((Direction-Mean).Y())< 1*RMSY) &&
-          (std::abs((Direction-Mean).Z()) < 1*RMSZ)){
-        if(Direction.Mag() == 0){continue;}
+    for (auto const sp : intitaltrack_sp) {
+      TVector3 Direction =
+        IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp) - StartPosition;
+      if ((std::abs((Direction - Mean).X()) < 1 * RMSX) &&
+          (std::abs((Direction - Mean).Y()) < 1 * RMSY) &&
+          (std::abs((Direction - Mean).Z()) < 1 * RMSZ)) {
+        if (Direction.Mag() == 0) { continue; }
         ++N;
         Direction_Mean += Direction;
       }
     }
 
-    if(N>0){
+    if (N > 0) {
       //Take the mean value
       TVector3 Direction = Direction_Mean.Unit();
-      ShowerEleHolder.SetElement(Direction,fShowerDirectionOutputLabel);
+      ShowerEleHolder.SetElement(Direction, fShowerDirectionOutputLabel);
     }
-    else{
+    else {
       if (fVerbose)
         mf::LogError("ShowerTrackSpacePointDirection")
-          << "None of the points are within 1 sigma"<< std::endl;
+          << "None of the points are within 1 sigma" << std::endl;
       return 1;
     }
     return 0;
   }
 }
 
-
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrackSpacePointDirection)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackStartPosition_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackStartPosition_tool.cc
@@ -10,65 +10,58 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "lardataobj/RecoBase/Track.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace ShowerRecoTools {
 
+  class ShowerTrackStartPosition : public IShowerTool {
 
-  class ShowerTrackStartPosition: public IShowerTool {
+  public:
+    ShowerTrackStartPosition(const fhicl::ParameterSet& pset);
 
-    public:
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerTrackStartPosition(const fhicl::ParameterSet& pset);
-
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      int         fVerbose;
-      std::string fInitialTrackInputLabel;
-      std::string fShowerStartPositionOutputLabel;
-
+  private:
+    int fVerbose;
+    std::string fInitialTrackInputLabel;
+    std::string fShowerStartPositionOutputLabel;
   };
 
+  ShowerTrackStartPosition::ShowerTrackStartPosition(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel"))
+    , fShowerStartPositionOutputLabel(pset.get<std::string>("ShowerStartPositionOutputLabel"))
+  {}
 
-  ShowerTrackStartPosition::ShowerTrackStartPosition(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fVerbose(pset.get<int>("Verbose")),
-    fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel")),
-    fShowerStartPositionOutputLabel(pset.get<std::string>("ShowerStartPositionOutputLabel"))
+  int
+  ShowerTrackStartPosition::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                             art::Event& Event,
+                                             reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int ShowerTrackStartPosition::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     //Check the Track has been defined
-    if(!ShowerEleHolder.CheckElement("InitialTrack")){
+    if (!ShowerEleHolder.CheckElement("InitialTrack")) {
       if (fVerbose)
-        mf::LogError("ShowerTrackStartPosition")
-          << "Initial track not set"<< std::endl;
+        mf::LogError("ShowerTrackStartPosition") << "Initial track not set" << std::endl;
       return 1;
     }
     recob::Track InitialTrack;
-    ShowerEleHolder.GetElement(fInitialTrackInputLabel,InitialTrack);
-
+    ShowerEleHolder.GetElement(fInitialTrackInputLabel, InitialTrack);
 
     //Set the shower start position as the
-    TVector3 StartPositionErr = {-999,-999,-999};
+    TVector3 StartPositionErr = {-999, -999, -999};
 
-    geo::Point_t  TrajPosition_vec   = InitialTrack.LocationAtPoint(0);
-    TVector3 TrajPosition = {TrajPosition_vec.X(), TrajPosition_vec.Y(),TrajPosition_vec.Z()};
-    ShowerEleHolder.SetElement(TrajPosition,StartPositionErr,fShowerStartPositionOutputLabel);
+    geo::Point_t TrajPosition_vec = InitialTrack.LocationAtPoint(0);
+    TVector3 TrajPosition = {TrajPosition_vec.X(), TrajPosition_vec.Y(), TrajPosition_vec.Z()};
+    ShowerEleHolder.SetElement(TrajPosition, StartPositionErr, fShowerStartPositionOutputLabel);
 
     return 0;
   }
 }
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrackStartPosition)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackTrajPointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackTrajPointDirection_tool.cc
@@ -14,113 +14,110 @@
 
 namespace ShowerRecoTools {
 
+  class ShowerTrackTrajPointDirection : IShowerTool {
 
-  class ShowerTrackTrajPointDirection:IShowerTool {
+  public:
+    ShowerTrackTrajPointDirection(const fhicl::ParameterSet& pset);
 
-    public:
+    //Calculate the direction from the inital track
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerTrackTrajPointDirection(const fhicl::ParameterSet& pset);
+  private:
+    //fcl
+    int fVerbose;
+    bool fUsePandoraVertex; //Direction from point defined as
+    //(Position of traj point - Vertex) rather than
+    //(Position of traj point - Track Start Point).
+    bool fUsePositonInfo; //Don't use the direction At point rather than definition
+    //above.
+    //((Position of traj point + 1) - (Position of traj point).
+    int fTrajPoint; //Trajectory point to get the direction from.
 
-      //Calculate the direction from the inital track
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      //fcl
-      int  fVerbose;
-      bool fUsePandoraVertex; //Direction from point defined as
-      //(Position of traj point - Vertex) rather than
-      //(Position of traj point - Track Start Point).
-      bool fUsePositonInfo;   //Don't use the direction At point rather than definition
-      //above.
-      //((Position of traj point + 1) - (Position of traj point).
-      int  fTrajPoint;        //Trajectory point to get the direction from.
-
-      std::string fInitialTrackInputLabel;
-      std::string fShowerStartPositionInputLabel;
-      std::string fShowerDirectionOutputLabel;
+    std::string fInitialTrackInputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionOutputLabel;
   };
 
+  ShowerTrackTrajPointDirection::ShowerTrackTrajPointDirection(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fUsePandoraVertex(pset.get<bool>("UsePandoraVertex"))
+    , fUsePositonInfo(pset.get<bool>("UsePositonInfo"))
+    , fTrajPoint(pset.get<int>("TrajPoint"))
+    , fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  {}
 
-  ShowerTrackTrajPointDirection::ShowerTrackTrajPointDirection(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fVerbose(pset.get<int>("Verbose")),
-    fUsePandoraVertex(pset.get<bool>("UsePandoraVertex")),
-    fUsePositonInfo(pset.get<bool>("UsePositonInfo")),
-    fTrajPoint(pset.get<int>("TrajPoint")),
-    fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+  int
+  ShowerTrackTrajPointDirection::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
-
-  int ShowerTrackTrajPointDirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
 
     //Check the Track has been defined
-    if(!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackTrajPointDirection") << "Initial track not set"<< std::endl;
+        mf::LogError("ShowerTrackTrajPointDirection") << "Initial track not set" << std::endl;
       return 1;
     }
     recob::Track InitialTrack;
-    ShowerEleHolder.GetElement(fInitialTrackInputLabel,InitialTrack);
+    ShowerEleHolder.GetElement(fInitialTrackInputLabel, InitialTrack);
 
-    if((int)InitialTrack.NumberTrajectoryPoints()-1 < fTrajPoint){
+    if ((int)InitialTrack.NumberTrajectoryPoints() - 1 < fTrajPoint) {
       if (fVerbose)
-        mf::LogError("ShowerTrackTrajPointDirection") << "Less that fTrajPoint trajectory points, bailing."<< std::endl;
-      fTrajPoint = InitialTrack.NumberTrajectoryPoints()-1;
+        mf::LogError("ShowerTrackTrajPointDirection")
+          << "Less that fTrajPoint trajectory points, bailing." << std::endl;
+      fTrajPoint = InitialTrack.NumberTrajectoryPoints() - 1;
     }
 
     //ignore bogus info.
     auto flags = InitialTrack.FlagsAtPoint(fTrajPoint);
-    if(flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-    {
+    if (flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackTrajPointDirection") << "Bogus trajectory point bailing."<< std::endl;
+        mf::LogError("ShowerTrackTrajPointDirection")
+          << "Bogus trajectory point bailing." << std::endl;
       return 1;
     }
 
-
     geo::Vector_t Direction_vec;
     //Get the difference between the point and the start position.
-    if(fUsePositonInfo){
+    if (fUsePositonInfo) {
       //Get the start position.
       geo::Point_t StartPosition;
-      if(fUsePandoraVertex){
+      if (fUsePandoraVertex) {
         //Check the Track has been defined
-        if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+        if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
           if (fVerbose)
-            mf::LogError("ShowerTrackTrajPointDirection") << "Shower start position not set"<< std::endl;
+            mf::LogError("ShowerTrackTrajPointDirection")
+              << "Shower start position not set" << std::endl;
           return 1;
         }
-        TVector3 StartPosition_vec = {-999,-999,-999};
-        ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,StartPosition_vec);
-        StartPosition.SetCoordinates(StartPosition_vec.X(),StartPosition_vec.Y(),StartPosition_vec.Z());
+        TVector3 StartPosition_vec = {-999, -999, -999};
+        ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPosition_vec);
+        StartPosition.SetCoordinates(
+          StartPosition_vec.X(), StartPosition_vec.Y(), StartPosition_vec.Z());
       }
-      else{
+      else {
         StartPosition = InitialTrack.Start();
       }
       //Get the specific trajectory point and look and and the direction from the start position
-      geo::Point_t  TrajPosition = InitialTrack.LocationAtPoint(fTrajPoint);
-      Direction_vec  = (TrajPosition - StartPosition).Unit();
+      geo::Point_t TrajPosition = InitialTrack.LocationAtPoint(fTrajPoint);
+      Direction_vec = (TrajPosition - StartPosition).Unit();
     }
-    else{
+    else {
       //Use the direction of the trajection at tat point;
       Direction_vec = InitialTrack.DirectionAtPoint(fTrajPoint);
     }
 
-    TVector3 Direction = {Direction_vec.X(), Direction_vec.Y(),Direction_vec.Z()};
-    TVector3 DirectionErr = {-999,-999,-999};
-    ShowerEleHolder.SetElement(Direction,DirectionErr,fShowerDirectionOutputLabel);
+    TVector3 Direction = {Direction_vec.X(), Direction_vec.Y(), Direction_vec.Z()};
+    TVector3 DirectionErr = {-999, -999, -999};
+    ShowerEleHolder.SetElement(Direction, DirectionErr, fShowerDirectionOutputLabel);
     return 0;
   }
 }
 
-
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrackTrajPointDirection)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackTrajToSpacePoint_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackTrajToSpacePoint_tool.cc
@@ -10,125 +10,121 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
-#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "lardataobj/RecoBase/Track.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 
 namespace ShowerRecoTools {
 
+  class ShowerTrackTrajToSpacePoint : public IShowerTool {
 
-  class ShowerTrackTrajToSpacePoint: public IShowerTool {
+  public:
+    ShowerTrackTrajToSpacePoint(const fhicl::ParameterSet& pset);
 
-    public:
+    //Match trajectory points to the spacepoints
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      ShowerTrackTrajToSpacePoint(const fhicl::ParameterSet& pset);
+  private:
+    float fMaxDist; //Max distance that a spacepoint can be from a trajectory
+    //point to be matched
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
 
-      //Match trajectory points to the spacepoints
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
-
-    private:
-
-      float fMaxDist; //Max distance that a spacepoint can be from a trajectory
-      //point to be matched
-      art::InputTag fPFParticleLabel;
-      int fVerbose;
-
-      std::string fInitialTrackSpacePointsOutputLabel;
-      std::string fInitialTrackHitsOutputLabel;
-      std::string fInitialTrackInputTag;
-      std::string fShowerStartPositionInputTag;
-      std::string fInitialTrackSpacePointsInputTag;
-
+    std::string fInitialTrackSpacePointsOutputLabel;
+    std::string fInitialTrackHitsOutputLabel;
+    std::string fInitialTrackInputTag;
+    std::string fShowerStartPositionInputTag;
+    std::string fInitialTrackSpacePointsInputTag;
   };
 
-
   ShowerTrackTrajToSpacePoint::ShowerTrackTrajToSpacePoint(const fhicl::ParameterSet& pset)
-    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fMaxDist(pset.get<float>("MaxDist")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fInitialTrackSpacePointsOutputLabel(pset.get<std::string>("InitialTrackSpacePointsOutputLabel")),
-    fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel")),
-    fInitialTrackInputTag(pset.get<std::string>("InitialTrackInputTag")),
-    fShowerStartPositionInputTag(pset.get<std::string>("ShowerStartPositionInputTag")),
-    fInitialTrackSpacePointsInputTag(pset.get<std::string>("InitialTrackSpacePointsInputTag"))
-  {
-  }
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fMaxDist(pset.get<float>("MaxDist"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fInitialTrackSpacePointsOutputLabel(
+        pset.get<std::string>("InitialTrackSpacePointsOutputLabel"))
+    , fInitialTrackHitsOutputLabel(pset.get<std::string>("InitialTrackHitsOutputLabel"))
+    , fInitialTrackInputTag(pset.get<std::string>("InitialTrackInputTag"))
+    , fShowerStartPositionInputTag(pset.get<std::string>("ShowerStartPositionInputTag"))
+    , fInitialTrackSpacePointsInputTag(pset.get<std::string>("InitialTrackSpacePointsInputTag"))
+  {}
 
-  int ShowerTrackTrajToSpacePoint::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
+  int
+  ShowerTrackTrajToSpacePoint::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                                art::Event& Event,
+                                                reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
     //Check the Track has been defined
-    if(!ShowerEleHolder.CheckElement(fInitialTrackInputTag)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackInputTag)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackTrajToSpacePoint") << "Initial track not set"<< std::endl;
+        mf::LogError("ShowerTrackTrajToSpacePoint") << "Initial track not set" << std::endl;
       return 0;
     }
 
     //Check the start position is set.
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputTag)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputTag)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackTrajToSpacePoint") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerTrackTrajToSpacePoint")
+          << "Start position not set, returning " << std::endl;
       return 0;
     }
 
-
     //Check the Track Hits has been defined
-    if(!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputTag)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputTag)) {
       if (fVerbose)
-        mf::LogError("ShowerTrackTrajToSpacePoint") << "Initial track spacepoints not set"<< std::endl;
+        mf::LogError("ShowerTrackTrajToSpacePoint")
+          << "Initial track spacepoints not set" << std::endl;
       return 0;
     }
 
     //Get the start poistion
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputTag,ShowerStartPosition);
-
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputTag, ShowerStartPosition);
 
     //Get the initial track hits.
-    std::vector<art::Ptr<recob::SpacePoint> > intitaltrack_sp;
-    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputTag,intitaltrack_sp);
+    std::vector<art::Ptr<recob::SpacePoint>> intitaltrack_sp;
+    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputTag, intitaltrack_sp);
 
     //Get the track
     recob::Track InitialTrack;
-    ShowerEleHolder.GetElement(fInitialTrackInputTag,InitialTrack);
+    ShowerEleHolder.GetElement(fInitialTrackInputTag, InitialTrack);
 
-    std::vector<art::Ptr<recob::SpacePoint> > new_intitaltrack_sp;
+    std::vector<art::Ptr<recob::SpacePoint>> new_intitaltrack_sp;
     //Loop over the trajectory points
-    for(unsigned int traj=0; traj< InitialTrack.NumberTrajectoryPoints(); ++traj){
+    for (unsigned int traj = 0; traj < InitialTrack.NumberTrajectoryPoints(); ++traj) {
 
       //ignore bogus info.
       auto flags = InitialTrack.FlagsAtPoint(traj);
-      if(flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-      {continue;}
+      if (flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
       geo::Point_t TrajPositionPoint = InitialTrack.LocationAtPoint(traj);
-      TVector3 TrajPosition = {TrajPositionPoint.X(),TrajPositionPoint.Y(),TrajPositionPoint.Z()};
+      TVector3 TrajPosition = {TrajPositionPoint.X(), TrajPositionPoint.Y(), TrajPositionPoint.Z()};
 
       geo::Point_t TrajPositionStartPoint = InitialTrack.LocationAtPoint(0);
-      TVector3 TrajPositionStart = {TrajPositionStartPoint.X(),TrajPositionStartPoint.Y(),TrajPositionStartPoint.Z()};
-
+      TVector3 TrajPositionStart = {
+        TrajPositionStartPoint.X(), TrajPositionStartPoint.Y(), TrajPositionStartPoint.Z()};
 
       //Ignore values with 0 mag from the start position
-      if((TrajPosition - TrajPositionStart).Mag() == 0){continue;}
-      if((TrajPosition - ShowerStartPosition).Mag() == 0){continue;}
+      if ((TrajPosition - TrajPositionStart).Mag() == 0) { continue; }
+      if ((TrajPosition - ShowerStartPosition).Mag() == 0) { continue; }
 
       float MinDist = 9999;
       unsigned int index = 999;
-      for(unsigned int sp=0; sp<intitaltrack_sp.size();++sp){
+      for (unsigned int sp = 0; sp < intitaltrack_sp.size(); ++sp) {
         //Find the spacepoint closest to the trajectory point.
         art::Ptr<recob::SpacePoint> spacepoint = intitaltrack_sp[sp];
-        TVector3 pos = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(spacepoint) - TrajPosition;
-        if(pos.Mag() < MinDist && pos.Mag()< fMaxDist){
+        TVector3 pos =
+          IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(spacepoint) - TrajPosition;
+        if (pos.Mag() < MinDist && pos.Mag() < fMaxDist) {
           MinDist = pos.Mag();
           index = sp;
         }
       }
 
-      if(index == 999){continue;}
+      if (index == 999) { continue; }
       //Add the spacepoint to the track spacepoints.
       new_intitaltrack_sp.push_back(intitaltrack_sp[index]);
 
@@ -136,24 +132,24 @@ namespace ShowerRecoTools {
       intitaltrack_sp.erase(intitaltrack_sp.begin() + index);
     }
 
-
     // Get the spacepoints
-    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
+    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
 
     // Get the hits associated with the space points
-    const art::FindOneP<recob::Hit>& fohsp = ShowerEleHolder.GetFindOneP<recob::Hit>(spHandle, Event, fPFParticleLabel);
+    const art::FindOneP<recob::Hit>& fohsp =
+      ShowerEleHolder.GetFindOneP<recob::Hit>(spHandle, Event, fPFParticleLabel);
 
     //Save the corresponding hits
-    std::vector<art::Ptr<recob::Hit> > trackHits;
-    for(auto const& spacePoint: new_intitaltrack_sp){
+    std::vector<art::Ptr<recob::Hit>> trackHits;
+    for (auto const& spacePoint : new_intitaltrack_sp) {
       //Get the hits
       const art::Ptr<recob::Hit> hit = fohsp.at(spacePoint.key());
       trackHits.push_back(hit);
     }
 
     //Save the spacepoints.
-    ShowerEleHolder.SetElement(new_intitaltrack_sp,fInitialTrackSpacePointsOutputLabel);
-    ShowerEleHolder.SetElement(trackHits,fInitialTrackHitsOutputLabel);
+    ShowerEleHolder.SetElement(new_intitaltrack_sp, fInitialTrackSpacePointsOutputLabel);
+    ShowerEleHolder.SetElement(trackHits, fInitialTrackHitsOutputLabel);
 
     return 0;
   }
@@ -161,4 +157,3 @@ namespace ShowerRecoTools {
 }
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrackTrajToSpacePoint)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -13,179 +13,181 @@
 #include "art/Utilities/ToolMacros.h"
 
 //LArSoft Includes
+#include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/RecoBase/Track.h"
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "larreco/Calorimetry/CalorimetryAlg.h"
-#include "lardataobj/RecoBase/Track.h"
-#include "lardataobj/AnalysisBase/T0.h"
 
-namespace ShowerRecoTools{
+namespace ShowerRecoTools {
 
-  class ShowerTrajPointdEdx:IShowerTool {
+  class ShowerTrajPointdEdx : IShowerTool {
 
-    public:
+  public:
+    ShowerTrajPointdEdx(const fhicl::ParameterSet& pset);
 
-      ShowerTrajPointdEdx(const fhicl::ParameterSet& pset);
+    //Physics Function. Calculate the dEdx.
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Physics Function. Calculate the dEdx.
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+    void FinddEdxLength(std::vector<double>& dEdx_vec, std::vector<double>& dEdx_val);
 
-      void FinddEdxLength(std::vector<double>& dEdx_vec, std::vector<double>& dEdx_val);
+  private:
+    //Servcies and Algorithms
+    art::ServiceHandle<geo::Geometry> fGeom;
+    calo::CalorimetryAlg fCalorimetryAlg;
 
-    private:
+    //fcl parameters
+    float fMinAngleToWire; //Minimum angle between the wire direction and the shower
+    //direction for the spacepoint to be used. Default means
+    //the cut has no effect. In radians.
+    float fShapingTime; //Shaping time of the ASIC defualt so we don't cut on track
+    //going too much into the plane. In Microseconds
+    float fMinDistCutOff; //Distance in wires a hit has to be from the start position
+    //to be used
+    float fMaxDist, MaxDist; //Distance in wires a that a trajectory point can be from a
+    //spacepoint to match to it.
+    float fdEdxTrackLength,
+      dEdxTrackLength; //Max Distance a spacepoint can be away from the start of the
+    //track. In cm
+    float fdEdxCut;
+    bool fUseMedian;        //Use the median value as the dEdx rather than the mean.
+    bool fCutStartPosition; //Remove hits using MinDistCutOff from the vertex as well.
 
-      //Servcies and Algorithms
-      art::ServiceHandle<geo::Geometry> fGeom;
-      calo::CalorimetryAlg fCalorimetryAlg;
+    bool fT0Correct;       // Whether to look for a T0 associated to the PFP
+    bool fSCECorrectPitch; // Whether to correct the "squeezing" of pitch, requires corrected input
+    bool
+      fSCECorrectEField; // Whether to use the local electric field, from SpaceChargeService, in recombination calc.
+    bool
+      fSCEInputCorrected; // Whether the input has already been corrected for spatial SCE distortions
 
-      //fcl parameters
-      float fMinAngleToWire;  //Minimum angle between the wire direction and the shower
-      //direction for the spacepoint to be used. Default means
-      //the cut has no effect. In radians.
-      float fShapingTime;     //Shaping time of the ASIC defualt so we don't cut on track
-      //going too much into the plane. In Microseconds
-      float fMinDistCutOff;   //Distance in wires a hit has to be from the start position
-      //to be used
-      float fMaxDist,MaxDist;         //Distance in wires a that a trajectory point can be from a
-      //spacepoint to match to it.
-      float fdEdxTrackLength,dEdxTrackLength; //Max Distance a spacepoint can be away from the start of the
-      //track. In cm
-      float fdEdxCut;
-      bool fUseMedian;        //Use the median value as the dEdx rather than the mean.
-      bool fCutStartPosition; //Remove hits using MinDistCutOff from the vertex as well.
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
 
-      bool fT0Correct;        // Whether to look for a T0 associated to the PFP
-      bool fSCECorrectPitch;  // Whether to correct the "squeezing" of pitch, requires corrected input
-      bool fSCECorrectEField; // Whether to use the local electric field, from SpaceChargeService, in recombination calc.
-      bool fSCEInputCorrected; // Whether the input has already been corrected for spatial SCE distortions
-
-      art::InputTag fPFParticleLabel;
-      int           fVerbose;
-
-      std::string fShowerStartPositionInputLabel;
-      std::string fInitialTrackSpacePointsInputLabel;
-      std::string fInitialTrackInputLabel;
-      std::string fShowerdEdxOutputLabel;
-      std::string fShowerBestPlaneOutputLabel;
-      std::string fShowerdEdxVecOutputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fInitialTrackSpacePointsInputLabel;
+    std::string fInitialTrackInputLabel;
+    std::string fShowerdEdxOutputLabel;
+    std::string fShowerBestPlaneOutputLabel;
+    std::string fShowerdEdxVecOutputLabel;
   };
 
-
-  ShowerTrajPointdEdx::ShowerTrajPointdEdx(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fCalorimetryAlg(pset.get<fhicl::ParameterSet>("CalorimetryAlg")),
-    fMinAngleToWire(pset.get<float>("MinAngleToWire")),
-    fShapingTime(pset.get<float>("ShapingTime")),
-    fMinDistCutOff(pset.get<float>("MinDistCutOff")),
-    fMaxDist(pset.get<float>("MaxDist")),
-    fdEdxTrackLength(pset.get<float>("dEdxTrackLength")),
-    fdEdxCut(pset.get<float>("dEdxCut")),
-    fUseMedian(pset.get<bool>("UseMedian")),
-    fCutStartPosition(pset.get<bool>("CutStartPosition")),
-    fT0Correct(pset.get<bool>("T0Correct")),
-    fSCECorrectPitch(pset.get<bool>("SCECorrectPitch")),
-    fSCECorrectEField(pset.get<bool>("SCECorrectEField")),
-    fSCEInputCorrected(pset.get<bool>("SCEInputCorrected")),
-    fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel")),
-    fVerbose(pset.get<int>("Verbose")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel")),
-    fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel")),
-    fShowerdEdxOutputLabel(pset.get<std::string>("ShowerdEdxOutputLabel")),
-    fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel")),
-    fShowerdEdxVecOutputLabel(pset.get<std::string>("ShowerdEdxVecOutputLabel"))
+  ShowerTrajPointdEdx::ShowerTrajPointdEdx(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fCalorimetryAlg(pset.get<fhicl::ParameterSet>("CalorimetryAlg"))
+    , fMinAngleToWire(pset.get<float>("MinAngleToWire"))
+    , fShapingTime(pset.get<float>("ShapingTime"))
+    , fMinDistCutOff(pset.get<float>("MinDistCutOff"))
+    , fMaxDist(pset.get<float>("MaxDist"))
+    , fdEdxTrackLength(pset.get<float>("dEdxTrackLength"))
+    , fdEdxCut(pset.get<float>("dEdxCut"))
+    , fUseMedian(pset.get<bool>("UseMedian"))
+    , fCutStartPosition(pset.get<bool>("CutStartPosition"))
+    , fT0Correct(pset.get<bool>("T0Correct"))
+    , fSCECorrectPitch(pset.get<bool>("SCECorrectPitch"))
+    , fSCECorrectEField(pset.get<bool>("SCECorrectEField"))
+    , fSCEInputCorrected(pset.get<bool>("SCEInputCorrected"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fInitialTrackSpacePointsInputLabel(pset.get<std::string>("InitialTrackSpacePointsInputLabel"))
+    , fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel"))
+    , fShowerdEdxOutputLabel(pset.get<std::string>("ShowerdEdxOutputLabel"))
+    , fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel"))
+    , fShowerdEdxVecOutputLabel(pset.get<std::string>("ShowerdEdxVecOutputLabel"))
   {
     if ((fSCECorrectPitch || fSCECorrectEField) && !fSCEInputCorrected) {
-      throw cet::exception("ShowerTrajPointdEdx") << "Can only correct for SCE if input is already corrected"
-        << std::endl;
+      throw cet::exception("ShowerTrajPointdEdx")
+        << "Can only correct for SCE if input is already corrected" << std::endl;
     }
   }
 
-  int ShowerTrajPointdEdx::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event,
-      reco::shower::ShowerElementHolder& ShowerEleHolder){
+  int
+  ShowerTrajPointdEdx::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                        art::Event& Event,
+                                        reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
 
-    MaxDist         = fMaxDist;
+    MaxDist = fMaxDist;
     dEdxTrackLength = fdEdxTrackLength;
 
     // Shower dEdx calculation
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerTrajPointdEdx") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerTrajPointdEdx") << "Start position not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackSpacePointsInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerTrajPointdEdx") << "Initial Track Spacepoints is not set returning"<< std::endl;
+        mf::LogError("ShowerTrajPointdEdx")
+          << "Initial Track Spacepoints is not set returning" << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)){
-      if (fVerbose)
-        mf::LogError("ShowerTrajPointdEdx") << "Initial Track is not set"<< std::endl;
+    if (!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)) {
+      if (fVerbose) mf::LogError("ShowerTrajPointdEdx") << "Initial Track is not set" << std::endl;
       return 1;
     }
 
     //Get the initial track hits
-    std::vector<art::Ptr<recob::SpacePoint> > tracksps;
-    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel,tracksps);
+    std::vector<art::Ptr<recob::SpacePoint>> tracksps;
+    ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel, tracksps);
 
-    if(tracksps.empty()){
+    if (tracksps.empty()) {
       if (fVerbose)
         mf::LogWarning("ShowerTrajPointdEdx") << "no spacepointsin the initial track" << std::endl;
       return 0;
     }
 
-
     // Get the spacepoints
-    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint> >(fPFParticleLabel);
+    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
 
     // Get the hits associated with the space points
-    const art::FindManyP<recob::Hit>& fmsp = ShowerEleHolder.GetFindManyP<recob::Hit>(
-        spHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::Hit>& fmsp =
+      ShowerEleHolder.GetFindManyP<recob::Hit>(spHandle, Event, fPFParticleLabel);
 
     //Only consider hits in the same tpcs as the vertex.
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,ShowerStartPosition);
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, ShowerStartPosition);
     geo::TPCID vtxTPC = fGeom->FindTPCAtPosition(ShowerStartPosition);
 
     //Get the initial track
     recob::Track InitialTrack;
-    ShowerEleHolder.GetElement(fInitialTrackInputLabel,InitialTrack);
+    ShowerEleHolder.GetElement(fInitialTrackInputLabel, InitialTrack);
 
     double pfpT0Time(0); // If no T0 found, assume the particle happened at trigger time (0)
-    if (fT0Correct){
-      auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle> >(fPFParticleLabel);
-      const art::FindManyP<anab::T0>& fmpfpt0 = ShowerEleHolder.GetFindManyP<anab::T0>(
-          pfpHandle, Event, fPFParticleLabel);
-      std::vector<art::Ptr<anab::T0> > pfpT0Vec = fmpfpt0.at(pfparticle.key());
-      if (pfpT0Vec.size()==1) {
-        pfpT0Time = pfpT0Vec.front()->Time();
-      }
+    if (fT0Correct) {
+      auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
+      const art::FindManyP<anab::T0>& fmpfpt0 =
+        ShowerEleHolder.GetFindManyP<anab::T0>(pfpHandle, Event, fPFParticleLabel);
+      std::vector<art::Ptr<anab::T0>> pfpT0Vec = fmpfpt0.at(pfparticle.key());
+      if (pfpT0Vec.size() == 1) { pfpT0Time = pfpT0Vec.front()->Time(); }
     }
 
     //Don't care that I could use a vector.
-    std::map<int,std::vector<double > > dEdx_vec;
-    std::map<int,std::vector<double> >  dEdx_vecErr;
-    std::map<int,int> num_hits;
+    std::map<int, std::vector<double>> dEdx_vec;
+    std::map<int, std::vector<double>> dEdx_vecErr;
+    std::map<int, int> num_hits;
 
-    for(geo::PlaneID plane_id: fGeom->IteratePlaneIDs()){
+    for (geo::PlaneID plane_id : fGeom->IteratePlaneIDs()) {
       dEdx_vec[plane_id.Plane] = {};
       dEdx_vecErr[plane_id.Plane] = {};
       num_hits[plane_id.Plane] = 0;
     }
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
     //Loop over the spacepoints
-    for(auto const sp: tracksps){
+    for (auto const sp : tracksps) {
 
       //Get the associated hit
-      std::vector<art::Ptr<recob::Hit> > hits = fmsp.at(sp.key());
-      if(hits.empty()){
+      std::vector<art::Ptr<recob::Hit>> hits = fmsp.at(sp.key());
+      if (hits.empty()) {
         if (fVerbose)
-          mf::LogWarning("ShowerTrajPointdEdx") << "no hit for the spacepoint. This suggest the find many is wrong."<< std::endl;
+          mf::LogWarning("ShowerTrajPointdEdx")
+            << "no hit for the spacepoint. This suggest the find many is wrong." << std::endl;
         continue;
       }
       const art::Ptr<recob::Hit> hit = hits[0];
@@ -194,128 +196,124 @@ namespace ShowerRecoTools{
       //Only consider hits in the same tpc
       geo::PlaneID planeid = hit->WireID();
       geo::TPCID TPC = planeid.asTPCID();
-      if (TPC !=vtxTPC){continue;}
+      if (TPC != vtxTPC) { continue; }
 
       //Ignore spacepoints within a few wires of the vertex.
       const TVector3 pos = IShowerTool::GetLArPandoraShowerAlg().SpacePointPosition(sp);
       double dist_from_start = (pos - ShowerStartPosition).Mag();
 
-      if(fCutStartPosition){
-        if(dist_from_start < fMinDistCutOff*wirepitch){continue;}
+      if (fCutStartPosition) {
+        if (dist_from_start < fMinDistCutOff * wirepitch) { continue; }
 
-        if(dist_from_start > dEdxTrackLength){continue;}
+        if (dist_from_start > dEdxTrackLength) { continue; }
       }
 
       //Find the closest trajectory point of the track. These should be in order if the user has used ShowerTrackTrajToSpacePoint_tool but the sake of gernicness I'll get the cloest sp.
       unsigned int index = 999;
       double MinDist = 999;
-      for(unsigned int traj=0; traj< InitialTrack.NumberTrajectoryPoints(); ++traj){
+      for (unsigned int traj = 0; traj < InitialTrack.NumberTrajectoryPoints(); ++traj) {
 
         geo::Point_t TrajPositionPoint = InitialTrack.LocationAtPoint(traj);
-        TVector3 TrajPosition = {TrajPositionPoint.X(),TrajPositionPoint.Y(),TrajPositionPoint.Z()};
-
+        TVector3 TrajPosition = {
+          TrajPositionPoint.X(), TrajPositionPoint.Y(), TrajPositionPoint.Z()};
 
         //ignore bogus info.
         auto flags = InitialTrack.FlagsAtPoint(traj);
-        if(flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint))
-        {continue;}
+        if (flags.isSet(recob::TrajectoryPointFlagTraits::NoPoint)) { continue; }
 
         const TVector3 dist = pos - TrajPosition;
 
-        if(dist.Mag() < MinDist && dist.Mag()< MaxDist*wirepitch){
+        if (dist.Mag() < MinDist && dist.Mag() < MaxDist * wirepitch) {
           MinDist = dist.Mag();
           index = traj;
         }
       }
 
       //If there is no matching trajectory point then bail.
-      if(index == 999){continue;}
+      if (index == 999) { continue; }
 
       geo::Point_t TrajPositionPoint = InitialTrack.LocationAtPoint(index);
-      TVector3 TrajPosition = {TrajPositionPoint.X(),TrajPositionPoint.Y(),TrajPositionPoint.Z()};
+      TVector3 TrajPosition = {TrajPositionPoint.X(), TrajPositionPoint.Y(), TrajPositionPoint.Z()};
 
       geo::Point_t TrajPositionStartPoint = InitialTrack.LocationAtPoint(0);
-      TVector3 TrajPositionStart = {TrajPositionStartPoint.X(),TrajPositionStartPoint.Y(),TrajPositionStartPoint.Z()};
+      TVector3 TrajPositionStart = {
+        TrajPositionStartPoint.X(), TrajPositionStartPoint.Y(), TrajPositionStartPoint.Z()};
 
       //Ignore values with 0 mag from the start position
-      if((TrajPosition - TrajPositionStart).Mag() == 0){continue;}
-      if((TrajPosition - ShowerStartPosition).Mag() == 0){continue;}
+      if ((TrajPosition - TrajPositionStart).Mag() == 0) { continue; }
+      if ((TrajPosition - ShowerStartPosition).Mag() == 0) { continue; }
 
-      if((TrajPosition-TrajPositionStart).Mag() < fMinDistCutOff*wirepitch){continue;}
-
+      if ((TrajPosition - TrajPositionStart).Mag() < fMinDistCutOff * wirepitch) { continue; }
 
       //Get the direction of the trajectory point
       geo::Vector_t TrajDirection_vec = InitialTrack.DirectionAtPoint(index);
-      TVector3 TrajDirection = {TrajDirection_vec.X(),TrajDirection_vec.Y(),TrajDirection_vec.Z()};
+      TVector3 TrajDirection = {
+        TrajDirection_vec.X(), TrajDirection_vec.Y(), TrajDirection_vec.Z()};
 
       //If the direction is in the same direction as the wires within some tolerance the hit finding struggles. Let remove these.
       // Note that we project in the YZ plane to make sure we are not cutting on
       // the angle into the wire planes, that should be done by the shaping time cut
-      TVector3 TrajDirectionYZ = {0,TrajDirection_vec.Y(),TrajDirection_vec.Z()};
+      TVector3 TrajDirectionYZ = {0, TrajDirection_vec.Y(), TrajDirection_vec.Z()};
       TVector3 PlaneDirection = fGeom->Plane(planeid).GetIncreasingWireDirection();
 
-      if(std::abs((TMath::Pi()/2 - TrajDirectionYZ.Angle(PlaneDirection))) < fMinAngleToWire){
-        if (fVerbose)
-          mf::LogWarning("ShowerTrajPointdEdx")
-            << "remove from angle cut" << std::endl;
+      if (std::abs((TMath::Pi() / 2 - TrajDirectionYZ.Angle(PlaneDirection))) < fMinAngleToWire) {
+        if (fVerbose) mf::LogWarning("ShowerTrajPointdEdx") << "remove from angle cut" << std::endl;
         continue;
       }
 
       //If the direction is too much into the wire plane then the shaping amplifer cuts the charge. Lets remove these events.
       double velocity = detProp.DriftVelocity(detProp.Efield(), detProp.Temperature());
-      double distance_in_x = TrajDirection.X()*(wirepitch/TrajDirection.Dot(PlaneDirection));
-      double time_taken = std::abs(distance_in_x/velocity);
+      double distance_in_x = TrajDirection.X() * (wirepitch / TrajDirection.Dot(PlaneDirection));
+      double time_taken = std::abs(distance_in_x / velocity);
 
       //Shaping time doesn't seem to exist in a global place so add it as a fcl.
-      if(fShapingTime < time_taken){
-        if (fVerbose)
-          mf::LogWarning("ShowerTrajPointdEdx")
-            << "move for shaping time" << std::endl;
+      if (fShapingTime < time_taken) {
+        if (fVerbose) mf::LogWarning("ShowerTrajPointdEdx") << "move for shaping time" << std::endl;
         continue;
       }
 
-      if((TrajPosition-TrajPositionStart).Mag() > dEdxTrackLength){continue;}
+      if ((TrajPosition - TrajPositionStart).Mag() > dEdxTrackLength) { continue; }
 
       //Iterate the number of hits on the plane
       ++num_hits[planeid.Plane];
 
       //If we still exist then we can be used in the calculation. Calculate the 3D pitch
-      double trackpitch = (TrajDirection*(wirepitch/TrajDirection.Dot(PlaneDirection))).Mag();
+      double trackpitch = (TrajDirection * (wirepitch / TrajDirection.Dot(PlaneDirection))).Mag();
 
-      if (fSCECorrectPitch){
-        trackpitch = IShowerTool::GetLArPandoraShowerAlg().SCECorrectPitch(trackpitch, pos,
-            TrajDirection.Unit(), hit->WireID().TPC);
+      if (fSCECorrectPitch) {
+        trackpitch = IShowerTool::GetLArPandoraShowerAlg().SCECorrectPitch(
+          trackpitch, pos, TrajDirection.Unit(), hit->WireID().TPC);
       }
 
       //Calculate the dQdx
-      double dQdx = hit->Integral()/trackpitch;
+      double dQdx = hit->Integral() / trackpitch;
 
       //Calculate the dEdx
       double localEField = detProp.Efield();
-      if (fSCECorrectEField){
+      if (fSCECorrectEField) {
         localEField = IShowerTool::GetLArPandoraShowerAlg().SCECorrectEField(localEField, pos);
       }
-      double dEdx = fCalorimetryAlg.dEdx_AREA(clockData, detProp, dQdx, hit->PeakTime(), planeid.Plane, pfpT0Time, localEField);
+      double dEdx = fCalorimetryAlg.dEdx_AREA(
+        clockData, detProp, dQdx, hit->PeakTime(), planeid.Plane, pfpT0Time, localEField);
 
       //Add the value to the dEdx
       dEdx_vec[planeid.Plane].push_back(dEdx);
     }
 
     //Choose max hits based on hitnum
-    int max_hits   = 0;
+    int max_hits = 0;
     int best_plane = -std::numeric_limits<int>::max();
-    for(auto const& [plane, numHits] : num_hits){
-      if (fVerbose>2)
-        std::cout << "Plane: " << plane << " with size: " << numHits << std::endl;
-      if(numHits > max_hits){
+    for (auto const& [plane, numHits] : num_hits) {
+      if (fVerbose > 2) std::cout << "Plane: " << plane << " with size: " << numHits << std::endl;
+      if (numHits > max_hits) {
         best_plane = plane;
-        max_hits   = numHits;
+        max_hits = numHits;
       }
     }
 
-    if (best_plane < 0){
+    if (best_plane < 0) {
       if (fVerbose)
-        mf::LogError("ShowerTrajPointdEdx") << "No hits in any plane, returning "<< std::endl;
+        mf::LogError("ShowerTrajPointdEdx") << "No hits in any plane, returning " << std::endl;
       return 1;
     }
 
@@ -324,47 +322,47 @@ namespace ShowerRecoTools{
     //If there is a sudden jump particle has probably split
     //If there is very large dEdx we have either calculated it wrong (probably) or the Electron is coming to end.
     //Assumes hits are ordered!
-    std::map<int,std::vector<double > > dEdx_vec_cut;
-    for(geo::PlaneID plane_id: fGeom->IteratePlaneIDs()){
+    std::map<int, std::vector<double>> dEdx_vec_cut;
+    for (geo::PlaneID plane_id : fGeom->IteratePlaneIDs()) {
       dEdx_vec_cut[plane_id.Plane] = {};
     }
 
-    for(auto& dEdx_plane: dEdx_vec){
+    for (auto& dEdx_plane : dEdx_vec) {
       FinddEdxLength(dEdx_plane.second, dEdx_vec_cut[dEdx_plane.first]);
     }
 
     //Never have the stats to do a landau fit and get the most probable value. User decides if they want the median value or the mean.
     std::vector<double> dEdx_val;
     std::vector<double> dEdx_valErr;
-    for(auto const& dEdx_plane: dEdx_vec_cut){
+    for (auto const& dEdx_plane : dEdx_vec_cut) {
 
-      if((dEdx_plane.second).empty()){
+      if ((dEdx_plane.second).empty()) {
         dEdx_val.push_back(-999);
         dEdx_valErr.push_back(-999);
         continue;
       }
 
-      if(fUseMedian){
+      if (fUseMedian) {
         dEdx_val.push_back(TMath::Median((dEdx_plane.second).size(), &(dEdx_plane.second)[0]));
       }
-      else{
+      else {
         //Else calculate the mean value.
         double dEdx_mean = 0;
-        for(auto const& dEdx: dEdx_plane.second){
-          if(dEdx > 10 || dEdx < 0){continue;}
+        for (auto const& dEdx : dEdx_plane.second) {
+          if (dEdx > 10 || dEdx < 0) { continue; }
           dEdx_mean += dEdx;
         }
-        dEdx_val.push_back(dEdx_mean/(float)(dEdx_plane.second).size());
+        dEdx_val.push_back(dEdx_mean / (float)(dEdx_plane.second).size());
       }
     }
 
-    if (fVerbose>1){
+    if (fVerbose > 1) {
       std::cout << "#Best Plane: " << best_plane << std::endl;
-      for(unsigned int plane=0; plane<dEdx_vec.size(); plane++){
-        std::cout << "#Plane: " << plane<< " #" << std::endl;
+      for (unsigned int plane = 0; plane < dEdx_vec.size(); plane++) {
+        std::cout << "#Plane: " << plane << " #" << std::endl;
         std::cout << "#Median: " << dEdx_val[plane] << " #" << std::endl;
-        if (fVerbose>2){
-          for(auto const& dEdx: dEdx_vec_cut[plane]){
+        if (fVerbose > 2) {
+          for (auto const& dEdx : dEdx_vec_cut[plane]) {
             std::cout << "dEdx: " << dEdx << std::endl;
           }
         }
@@ -372,23 +370,24 @@ namespace ShowerRecoTools{
     }
 
     //Need to sort out errors sensibly.
-    ShowerEleHolder.SetElement(dEdx_val,dEdx_valErr,fShowerdEdxOutputLabel);
-    ShowerEleHolder.SetElement(best_plane,fShowerBestPlaneOutputLabel);
-    ShowerEleHolder.SetElement(dEdx_vec_cut,fShowerdEdxVecOutputLabel);
+    ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
+    ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+    ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
     return 0;
   }
 
-
-  void ShowerTrajPointdEdx::FinddEdxLength(std::vector<double>& dEdx_vec, std::vector<double>& dEdx_val){
+  void
+  ShowerTrajPointdEdx::FinddEdxLength(std::vector<double>& dEdx_vec, std::vector<double>& dEdx_val)
+  {
 
     //As default do not apply this cut.
-    if(fdEdxCut > 10){
+    if (fdEdxCut > 10) {
       dEdx_val = dEdx_vec;
       return;
     }
 
     //Can only do this with 4 hits.
-    if(dEdx_vec.size() < 4){
+    if (dEdx_vec.size() < 4) {
       dEdx_val = dEdx_vec;
       return;
     }
@@ -397,17 +396,16 @@ namespace ShowerRecoTools{
 
     //See if we are in the upper bound or upper bound defined by the cut.
     int upperbound_int = 0;
-    if(dEdx_vec[0] > fdEdxCut){++upperbound_int;}
-    if(dEdx_vec[1] > fdEdxCut){++upperbound_int;}
-    if(dEdx_vec[2] > fdEdxCut){++upperbound_int;}
-    if(upperbound_int > 1){upperbound = true;}
-
+    if (dEdx_vec[0] > fdEdxCut) { ++upperbound_int; }
+    if (dEdx_vec[1] > fdEdxCut) { ++upperbound_int; }
+    if (dEdx_vec[2] > fdEdxCut) { ++upperbound_int; }
+    if (upperbound_int > 1) { upperbound = true; }
 
     dEdx_val.push_back(dEdx_vec[0]);
     dEdx_val.push_back(dEdx_vec[1]);
     dEdx_val.push_back(dEdx_vec[2]);
 
-    for(unsigned int dEdx_iter=2; dEdx_iter<dEdx_vec.size(); ++dEdx_iter){
+    for (unsigned int dEdx_iter = 2; dEdx_iter < dEdx_vec.size(); ++dEdx_iter) {
 
       //The Function of dEdx as a function of E is flat above ~10 MeV.
       //We are looking for a jump up (or down) above the ladau width in the dEx
@@ -416,27 +414,26 @@ namespace ShowerRecoTools{
       double dEdx = dEdx_vec[dEdx_iter];
 
       //We are really poo at physics and so attempt to find the pair production
-      if(upperbound){
-        if(dEdx > fdEdxCut){
+      if (upperbound) {
+        if (dEdx > fdEdxCut) {
           dEdx_val.push_back(dEdx);
-          if (fVerbose>1)
-            std::cout << "Adding dEdx: "<< dEdx<< std::endl;
+          if (fVerbose > 1) std::cout << "Adding dEdx: " << dEdx << std::endl;
           continue;
         }
-        else{
+        else {
           //Maybe its a landau fluctation lets try again.
-          if(dEdx_iter < dEdx_vec.size()-1){
-            if(dEdx_vec[dEdx_iter+1] > fdEdxCut){
-              if (fVerbose>1)
-                std::cout << "Next dEdx hit is good removing hit"<< dEdx<< std::endl;
+          if (dEdx_iter < dEdx_vec.size() - 1) {
+            if (dEdx_vec[dEdx_iter + 1] > fdEdxCut) {
+              if (fVerbose > 1)
+                std::cout << "Next dEdx hit is good removing hit" << dEdx << std::endl;
               continue;
             }
           }
           //I'll let one more value
-          if(dEdx_iter<dEdx_vec.size()-2){
-            if(dEdx_vec[dEdx_iter+2] > fdEdxCut){
-              if (fVerbose>1)
-                std::cout << "Next Next dEdx hit is good removing hit"<< dEdx<< std::endl;
+          if (dEdx_iter < dEdx_vec.size() - 2) {
+            if (dEdx_vec[dEdx_iter + 2] > fdEdxCut) {
+              if (fVerbose > 1)
+                std::cout << "Next Next dEdx hit is good removing hit" << dEdx << std::endl;
               continue;
             }
           }
@@ -444,27 +441,26 @@ namespace ShowerRecoTools{
           break;
         }
       }
-      else{
-        if(dEdx < fdEdxCut){
+      else {
+        if (dEdx < fdEdxCut) {
           dEdx_val.push_back(dEdx);
-          if (fVerbose>1)
-            std::cout << "Adding dEdx: "<< dEdx<< std::endl;
+          if (fVerbose > 1) std::cout << "Adding dEdx: " << dEdx << std::endl;
           continue;
         }
-        else{
+        else {
           //Maybe its a landau fluctation lets try again.
-          if(dEdx_iter < dEdx_vec.size()-1){
-            if(dEdx_vec[dEdx_iter+1] > fdEdxCut){
-              if (fVerbose>1)
-                std::cout << "Next dEdx hit is good removing hit "<< dEdx<< std::endl;
+          if (dEdx_iter < dEdx_vec.size() - 1) {
+            if (dEdx_vec[dEdx_iter + 1] > fdEdxCut) {
+              if (fVerbose > 1)
+                std::cout << "Next dEdx hit is good removing hit " << dEdx << std::endl;
               continue;
             }
           }
           //I'll let one more value
-          if(dEdx_iter < dEdx_vec.size()-2){
-            if(dEdx_vec[dEdx_iter+2] > fdEdxCut){
-              if (fVerbose>1)
-                std::cout << "Next Next dEdx hit is good removing hit "<< dEdx<< std::endl;
+          if (dEdx_iter < dEdx_vec.size() - 2) {
+            if (dEdx_vec[dEdx_iter + 2] > fdEdxCut) {
+              if (fVerbose > 1)
+                std::cout << "Next Next dEdx hit is good removing hit " << dEdx << std::endl;
               continue;
             }
           }
@@ -479,4 +475,3 @@ namespace ShowerRecoTools{
 }
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerTrajPointdEdx)
-

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerUnidirectiondEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerUnidirectiondEdx_tool.cc
@@ -14,156 +14,155 @@
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "larreco/Calorimetry/CalorimetryAlg.h"
 
-namespace ShowerRecoTools{
+namespace ShowerRecoTools {
 
-  class ShowerUnidirectiondEdx:IShowerTool {
+  class ShowerUnidirectiondEdx : IShowerTool {
 
-    public:
+  public:
+    ShowerUnidirectiondEdx(const fhicl::ParameterSet& pset);
 
-      ShowerUnidirectiondEdx(const fhicl::ParameterSet& pset);
+    //Generic Direction Finder
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
-      //Generic Direction Finder
-      int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-          art::Event& Event,
-          reco::shower::ShowerElementHolder& ShowerEleHolder
-          ) override;
+  private:
+    //Define the services and algorithms
+    art::ServiceHandle<geo::Geometry> fGeom;
+    calo::CalorimetryAlg fCalorimetryAlg;
 
-    private:
-
-      //Define the services and algorithms
-      art::ServiceHandle<geo::Geometry> fGeom;
-      calo::CalorimetryAlg              fCalorimetryAlg;
-
-      //fcl parameters.
-      int    fVerbose;
-      double fdEdxTrackLength,dEdxTrackLength; //Max length from a hit can be to the start point in cm.
-      bool   fMaxHitPlane;     //Set the best planes as the one with the most hits
-      bool   fMissFirstPoint;  //Do not use any hits from the first wire.
-      std::string fShowerStartPositionInputLabel;
-      std::string fInitialTrackHitsInputLabel;
-      std::string fShowerDirectionInputLabel;
-      std::string fShowerdEdxOutputLabel;
-      std::string fShowerBestPlaneOutputLabel;
+    //fcl parameters.
+    int fVerbose;
+    double fdEdxTrackLength,
+      dEdxTrackLength;    //Max length from a hit can be to the start point in cm.
+    bool fMaxHitPlane;    //Set the best planes as the one with the most hits
+    bool fMissFirstPoint; //Do not use any hits from the first wire.
+    std::string fShowerStartPositionInputLabel;
+    std::string fInitialTrackHitsInputLabel;
+    std::string fShowerDirectionInputLabel;
+    std::string fShowerdEdxOutputLabel;
+    std::string fShowerBestPlaneOutputLabel;
   };
 
+  ShowerUnidirectiondEdx::ShowerUnidirectiondEdx(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fCalorimetryAlg(pset.get<fhicl::ParameterSet>("CalorimetryAlg"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fdEdxTrackLength(pset.get<float>("dEdxTrackLength"))
+    , fMaxHitPlane(pset.get<bool>("MaxHitPlane"))
+    , fMissFirstPoint(pset.get<bool>("MissFirstPoint"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fInitialTrackHitsInputLabel(pset.get<std::string>("InitialTrackHitsInputLabel"))
+    , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+    , fShowerdEdxOutputLabel(pset.get<std::string>("ShowerdEdxOutputLabel"))
+    , fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel"))
+  {}
 
-  ShowerUnidirectiondEdx::ShowerUnidirectiondEdx(const fhicl::ParameterSet& pset) :
-    IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools")),
-    fCalorimetryAlg(pset.get<fhicl::ParameterSet>("CalorimetryAlg")),
-    fVerbose(pset.get<int>("Verbose")),
-    fdEdxTrackLength(pset.get<float>("dEdxTrackLength")),
-    fMaxHitPlane(pset.get<bool>("MaxHitPlane")),
-    fMissFirstPoint(pset.get<bool>("MissFirstPoint")),
-    fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel")),
-    fInitialTrackHitsInputLabel(pset.get<std::string>("InitialTrackHitsInputLabel")),
-    fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel")),
-    fShowerdEdxOutputLabel(pset.get<std::string>("ShowerdEdxOutputLabel")),
-    fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel"))
+  int
+  ShowerUnidirectiondEdx::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                                           art::Event& Event,
+                                           reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-  }
 
-  int ShowerUnidirectiondEdx::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
-      art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder){
-
-    dEdxTrackLength=fdEdxTrackLength;
+    dEdxTrackLength = fdEdxTrackLength;
 
     // Shower dEdx calculation
-    if(!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerUnidirectiondEdx") << "Start position not set, returning "<< std::endl;
+        mf::LogError("ShowerUnidirectiondEdx") << "Start position not set, returning " << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fInitialTrackHitsInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fInitialTrackHitsInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerUnidirectiondEdx") << "Initial Track Hits not set returning"<< std::endl;
+        mf::LogError("ShowerUnidirectiondEdx")
+          << "Initial Track Hits not set returning" << std::endl;
       return 1;
     }
-    if(!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)){
+    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerUnidirectiondEdx") << "Shower Direction not set"<< std::endl;
+        mf::LogError("ShowerUnidirectiondEdx") << "Shower Direction not set" << std::endl;
       return 1;
     }
 
     //Get the initial track hits
-    std::vector<art::Ptr<recob::Hit> > trackhits;
-    ShowerEleHolder.GetElement(fInitialTrackHitsInputLabel,trackhits);
+    std::vector<art::Ptr<recob::Hit>> trackhits;
+    ShowerEleHolder.GetElement(fInitialTrackHitsInputLabel, trackhits);
 
-    if(trackhits.empty()){
+    if (trackhits.empty()) {
       if (fVerbose)
         mf::LogWarning("ShowerUnidirectiondEdx") << "Not Hits in the initial track" << std::endl;
       return 0;
     }
 
-    TVector3 ShowerStartPosition = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel,ShowerStartPosition);
+    TVector3 ShowerStartPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, ShowerStartPosition);
 
-    TVector3 showerDir = {-999,-999,-999};
-    ShowerEleHolder.GetElement(fShowerDirectionInputLabel,showerDir);
+    TVector3 showerDir = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerDirectionInputLabel, showerDir);
 
     geo::TPCID vtxTPC = fGeom->FindTPCAtPosition(ShowerStartPosition);
 
     // Split the track hits per plane
     std::vector<double> dEdxVec;
-    std::vector<std::vector<art::Ptr<recob::Hit> > > trackHits;
+    std::vector<std::vector<art::Ptr<recob::Hit>>> trackHits;
     unsigned int numPlanes = fGeom->Nplanes();
     trackHits.resize(numPlanes);
 
     // Loop over the track hits and split into planes
-    for (unsigned int hitIt=0; hitIt<trackhits.size(); ++hitIt) {
+    for (unsigned int hitIt = 0; hitIt < trackhits.size(); ++hitIt) {
       art::Ptr<recob::Hit> hit = trackhits.at(hitIt);
       geo::PlaneID hitWire = hit->WireID();
       geo::TPCID TPC = hitWire.asTPCID();
 
       //only get hits from the same TPC as the vertex
-      if (TPC==vtxTPC){
-        (trackHits.at(hitWire.Plane)).push_back(hit);
-      }
+      if (TPC == vtxTPC) { (trackHits.at(hitWire.Plane)).push_back(hit); }
     }
 
     int bestHitsPlane = 0;
     int bestPlaneHits = 0;
-    int bestPlane     = -999;
-    double minPitch   = 999;
+    int bestPlane = -999;
+    double minPitch = 999;
 
-    auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-    auto const detProp   = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
+    auto const clockData =
+      art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+    auto const detProp =
+      art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockData);
 
-    for (unsigned int plane=0; plane<numPlanes; ++plane) {
-      std::vector<art::Ptr<recob::Hit> > trackPlaneHits = trackHits.at(plane);
+    for (unsigned int plane = 0; plane < numPlanes; ++plane) {
+      std::vector<art::Ptr<recob::Hit>> trackPlaneHits = trackHits.at(plane);
 
-      if (trackPlaneHits.size()){
+      if (trackPlaneHits.size()) {
 
         double dEdx = -999;
-        double totQ  = 0;
-        double avgT  = 0;
+        double totQ = 0;
+        double avgT = 0;
         double pitch = 0;
-
 
         //Calculate the pitch
         double wirepitch = fGeom->WirePitch(trackPlaneHits.at(0)->WireID().planeID());
         double angleToVert = fGeom->WireAngleToVertical(fGeom->Plane(plane).View(),
-            trackPlaneHits[0]->WireID().planeID()) - 0.5*TMath::Pi();
-        double cosgamma = std::abs(std::sin(angleToVert)*showerDir.Y()+std::cos(angleToVert)*showerDir.Z());
+                                                        trackPlaneHits[0]->WireID().planeID()) -
+                             0.5 * TMath::Pi();
+        double cosgamma =
+          std::abs(std::sin(angleToVert) * showerDir.Y() + std::cos(angleToVert) * showerDir.Z());
 
-        pitch = wirepitch/cosgamma;
+        pitch = wirepitch / cosgamma;
 
-        if (pitch){ // Check the pitch is calculated correctly
+        if (pitch) { // Check the pitch is calculated correctly
           int nhits = 0;
           std::vector<float> vQ;
 
           //Get the first wire
           int w0 = trackPlaneHits.at(0)->WireID().Wire;
 
-          for (auto const& hit: trackPlaneHits){
+          for (auto const& hit : trackPlaneHits) {
 
             // Get the wire for each hit
             int w1 = hit->WireID().Wire;
-            if (fMissFirstPoint && w0==w1){
-              continue;
-            }
+            if (fMissFirstPoint && w0 == w1) { continue; }
 
             //Ignore hits that are too far away.
-            if (std::abs((w1-w0)*pitch)<dEdxTrackLength){
+            if (std::abs((w1 - w0) * pitch) < dEdxTrackLength) {
               vQ.push_back(hit->Integral());
               totQ += hit->Integral();
               avgT += hit->PeakTime();
@@ -173,62 +172,60 @@ namespace ShowerRecoTools{
 
           if (totQ) {
             // Check if the pitch is the smallest yet (best plane)
-            if (pitch<minPitch){
-              minPitch  = pitch;
+            if (pitch < minPitch) {
+              minPitch = pitch;
               bestPlane = plane;
             }
 
             //Get the median and calculate the dEdx using the algorithm.
-            double dQdx = TMath::Median(vQ.size(), &vQ[0])/pitch;
-            dEdx = fCalorimetryAlg.dEdx_AREA(clockData, detProp, dQdx, avgT/nhits, trackPlaneHits.at(0)->WireID().Plane);
+            double dQdx = TMath::Median(vQ.size(), &vQ[0]) / pitch;
+            dEdx = fCalorimetryAlg.dEdx_AREA(
+              clockData, detProp, dQdx, avgT / nhits, trackPlaneHits.at(0)->WireID().Plane);
 
-            if (isinf(dEdx)) {
-              dEdx=-999;
-            };
+            if (isinf(dEdx)) { dEdx = -999; };
 
-            if (nhits > bestPlaneHits || ((nhits==bestPlaneHits) && (pitch<minPitch))){
+            if (nhits > bestPlaneHits || ((nhits == bestPlaneHits) && (pitch < minPitch))) {
               bestHitsPlane = plane;
               bestPlaneHits = nhits;
             }
           }
           dEdxVec.push_back(dEdx);
         }
-        else{
-          throw cet::exception("ShowerUnidirectiondEdx") << "pitch is 0. I can't think how it is 0? Stopping so I can tell you" << std::endl;
+        else {
+          throw cet::exception("ShowerUnidirectiondEdx")
+            << "pitch is 0. I can't think how it is 0? Stopping so I can tell you" << std::endl;
         }
-      }else { // if not (trackPlaneHits.size())
+      }
+      else { // if not (trackPlaneHits.size())
         dEdxVec.push_back(-999);
       }
       trackPlaneHits.clear();
     } //end loop over planes
 
     //TODO
-    std::vector<double> dEdxVecErr = {-999,-999,-999};
+    std::vector<double> dEdxVecErr = {-999, -999, -999};
 
-    ShowerEleHolder.SetElement(dEdxVec,dEdxVecErr,fShowerdEdxOutputLabel);
+    ShowerEleHolder.SetElement(dEdxVec, dEdxVecErr, fShowerdEdxOutputLabel);
 
     //Set The best plane
-    if (fMaxHitPlane){
-      bestPlane=bestHitsPlane;
-    }
+    if (fMaxHitPlane) { bestPlane = bestHitsPlane; }
 
-    if (bestPlane==-999){
+    if (bestPlane == -999) {
       throw cet::exception("ShowerUnidirectiondEdx") << "No best plane set";
-    } else {
-      ShowerEleHolder.SetElement(bestPlane,fShowerBestPlaneOutputLabel);
+    }
+    else {
+      ShowerEleHolder.SetElement(bestPlane, fShowerBestPlaneOutputLabel);
     }
 
-    if (fVerbose>1){
+    if (fVerbose > 1) {
       std::cout << "Best Plane: " << bestPlane << std::endl;
-      for(unsigned int plane=0; plane<dEdxVec.size(); plane++){
-        std::cout << "Plane: " << plane<< " with dEdx: " << dEdxVec[plane] << std::endl;
+      for (unsigned int plane = 0; plane < dEdxVec.size(); plane++) {
+        std::cout << "Plane: " << plane << " with dEdx: " << dEdxVec[plane] << std::endl;
       }
     }
 
     return 0;
-
   }
 }
 
 DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerUnidirectiondEdx)
-

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -134,7 +134,8 @@ namespace lar_pandora {
   LArPandora::beginJob()
   {
     LArDriftVolumeList driftVolumeList;
-    LArPandoraGeometry::LoadGeometry(driftVolumeList, m_driftVolumeMap, m_inputSettings.m_useActiveBoundingBox);
+    LArPandoraGeometry::LoadGeometry(
+      driftVolumeList, m_driftVolumeMap, m_inputSettings.m_useActiveBoundingBox);
 
     this->CreatePandoraInstances();
 

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -67,6 +67,7 @@ namespace lar_pandora {
   {
     m_inputSettings.m_useHitWidths = pset.get<bool>("UseHitWidths", true);
     m_inputSettings.m_useBirksCorrection = pset.get<bool>("UseBirksCorrection", false);
+    m_inputSettings.m_useActiveBoundingBox = pset.get<bool>("UseActiveBoundingBox", false);
     m_inputSettings.m_uidOffset = pset.get<int>("UidOffset", 100000000);
     m_inputSettings.m_dx_cm = pset.get<double>("DefaultHitWidth", 0.5);
     m_inputSettings.m_int_cm = pset.get<double>("InteractionLength", 84.);
@@ -133,7 +134,7 @@ namespace lar_pandora {
   LArPandora::beginJob()
   {
     LArDriftVolumeList driftVolumeList;
-    LArPandoraGeometry::LoadGeometry(driftVolumeList, m_driftVolumeMap);
+    LArPandoraGeometry::LoadGeometry(driftVolumeList, m_driftVolumeMap, m_inputSettings.m_useActiveBoundingBox);
 
     this->CreatePandoraInstances();
 
@@ -150,7 +151,7 @@ namespace lar_pandora {
     // If using global drift volume approach, pass details of gaps between daughter volumes to the pandora instance
     if (m_enableDetectorGaps) {
       LArDetectorGapList listOfGaps;
-      LArPandoraGeometry::LoadDetectorGaps(listOfGaps);
+      LArPandoraGeometry::LoadDetectorGaps(listOfGaps, m_inputSettings.m_useActiveBoundingBox);
       LArPandoraInput::CreatePandoraDetectorGaps(m_inputSettings, driftVolumeList, listOfGaps);
     }
 

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -421,19 +421,19 @@ namespace lar_pandora {
           if (dThetaU > maxDeltaTheta || dThetaV > maxDeltaTheta || dThetaW > maxDeltaTheta)
             continue;
 
-          double dminx2 = theTpc2.ActiveBoundingBox().MinX();
-          double dmaxx2 = theTpc2.ActiveBoundingBox().MaxX();
+          const float driftMinX2(theTpc2.ActiveBoundingBox().MinX());
+          const float driftMaxX2(theTpc2.ActiveBoundingBox().MaxX());
 
-          const double min2(0.5 * (dminx2 + dmaxx2) - 0.25 * std::fabs(dmaxx2 - dminx2));
-          const double max2(0.5 * (dminx2 + dmaxx2) + 0.25 * std::fabs(dmaxx2 - dminx2));
+          const double min2(0.5 * (driftMinX2 + driftMaxX2) -
+                            0.25 * std::fabs(driftMaxX2 - driftMinX2));
+          const double max2(0.5 * (driftMinX2 + driftMaxX2) +
+                            0.25 * std::fabs(driftMaxX2 - driftMinX2));
 
           if ((min2 > max1) || (min1 > max2)) continue;
 
           cstatList.insert(itpc2);
           tpcList.insert(itpc2);
 
-          const float driftMinX2(theTpc2.ActiveBoundingBox().MinX());
-          const float driftMaxX2(theTpc2.ActiveBoundingBox().MaxX());
           const float driftMinY2(theTpc2.ActiveBoundingBox().MinY());
           const float driftMaxY2(theTpc2.ActiveBoundingBox().MaxY());
           const float driftMinZ2(theTpc2.ActiveBoundingBox().MinZ());

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -352,19 +352,17 @@ namespace lar_pandora {
             (std::fabs(0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kY, itpc1, icstat))) :
             (0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat)));
 
-        double localCoord1[3] = {0., 0., 0.};
-        double worldCoord1[3] = {0., 0., 0.};
-        theTpc1.LocalToWorld(localCoord1, worldCoord1);
+        float driftMinX(theTpc1.ActiveBoundingBox().MinX());
+	float driftMaxX(theTpc1.ActiveBoundingBox().MaxX());
+        float driftMinY(theTpc1.ActiveBoundingBox().MinY());
+        float driftMaxY(theTpc1.ActiveBoundingBox().MaxY());
+        float driftMinZ(theTpc1.ActiveBoundingBox().MinZ());
+        float driftMaxZ(theTpc1.ActiveBoundingBox().MaxZ());
 
-        const double min1(worldCoord1[0] - 0.5 * theTpc1.ActiveHalfWidth());
-        const double max1(worldCoord1[0] + 0.5 * theTpc1.ActiveHalfWidth());
-
-        float driftMinX(worldCoord1[0] - theTpc1.ActiveHalfWidth());
-        float driftMaxX(worldCoord1[0] + theTpc1.ActiveHalfWidth());
-        float driftMinY(worldCoord1[1] - theTpc1.ActiveHalfHeight());
-        float driftMaxY(worldCoord1[1] + theTpc1.ActiveHalfHeight());
-        float driftMinZ(worldCoord1[2] - 0.5f * theTpc1.ActiveLength());
-        float driftMaxZ(worldCoord1[2] + 0.5f * theTpc1.ActiveLength());
+	// NOTE: This update is attempting to make the min/max used here and for "tpc2" compatible with 
+	//       the changes to driftMin/driftMax. Am not certain this is strictly necessary.
+	const double min1( 0.5*(driftMinX+driftMaxX) - 0.25*std::fabs(driftMaxX-driftMinX) );
+	const double max1( 0.5*(driftMinX+driftMaxX) + 0.25*std::fabs(driftMaxX-driftMinX) );
 
         const bool isPositiveDrift(theTpc1.DriftDirection() == geo::kPosX);
 
@@ -406,24 +404,23 @@ namespace lar_pandora {
           if (dThetaU > maxDeltaTheta || dThetaV > maxDeltaTheta || dThetaW > maxDeltaTheta)
             continue;
 
-          double localCoord2[3] = {0., 0., 0.};
-          double worldCoord2[3] = {0., 0., 0.};
-          theTpc2.LocalToWorld(localCoord2, worldCoord2);
+	  double dminx2 = theTpc2.ActiveBoundingBox().MinX();
+	  double dmaxx2 = theTpc2.ActiveBoundingBox().MaxX();
 
-          const double min2(worldCoord2[0] - 0.5 * theTpc2.ActiveHalfWidth());
-          const double max2(worldCoord2[0] + 0.5 * theTpc2.ActiveHalfWidth());
+          const double min2( 0.5*(dminx2+dmaxx2) - 0.25*std::fabs(dmaxx2-dminx2) );
+          const double max2( 0.5*(dminx2+dmaxx2) + 0.25*std::fabs(dmaxx2-dminx2) );
 
           if ((min2 > max1) || (min1 > max2)) continue;
 
           cstatList.insert(itpc2);
           tpcList.insert(itpc2);
 
-          const float driftMinX2(worldCoord2[0] - theTpc2.ActiveHalfWidth());
-          const float driftMaxX2(worldCoord2[0] + theTpc2.ActiveHalfWidth());
-          const float driftMinY2(worldCoord2[1] - theTpc2.ActiveHalfHeight());
-          const float driftMaxY2(worldCoord2[1] + theTpc2.ActiveHalfHeight());
-          const float driftMinZ2(worldCoord2[2] - 0.5f * theTpc2.ActiveLength());
-          const float driftMaxZ2(worldCoord2[2] + 0.5f * theTpc2.ActiveLength());
+	  const float driftMinX2(theTpc2.ActiveBoundingBox().MinX());
+	  const float driftMaxX2(theTpc2.ActiveBoundingBox().MaxX());
+	  const float driftMinY2(theTpc2.ActiveBoundingBox().MinY());
+	  const float driftMaxY2(theTpc2.ActiveBoundingBox().MaxY());
+	  const float driftMinZ2(theTpc2.ActiveBoundingBox().MinZ());
+	  const float driftMaxZ2(theTpc2.ActiveBoundingBox().MaxZ());
 
           driftMinX = std::min(driftMinX, driftMinX2);
           driftMaxX = std::max(driftMaxX, driftMaxX2);

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -87,22 +87,22 @@ namespace lar_pandora {
         else if (!isDualPhase)
           listOfGaps.emplace_back(LArDetectorGap(X1, Y1, Z1, X2, Y2, Z2));
       }
-      if (isDualPhase)
-      {
-        for (LArDaughterDriftVolumeList::const_iterator iterDghtr1 = driftVolume1.GetTpcVolumeList().begin(),
-             iterDghtrEnd1 = driftVolume1.GetTpcVolumeList().end();
-             iterDghtr1 != iterDghtrEnd1; 
+      if (isDualPhase) {
+        for (LArDaughterDriftVolumeList::const_iterator
+               iterDghtr1 = driftVolume1.GetTpcVolumeList().begin(),
+               iterDghtrEnd1 = driftVolume1.GetTpcVolumeList().end();
+             iterDghtr1 != iterDghtrEnd1;
              ++iterDghtr1) {
-          const LArDaughterDriftVolume &tpcVolume1(*iterDghtr1);
+          const LArDaughterDriftVolume& tpcVolume1(*iterDghtr1);
 
-          for (LArDaughterDriftVolumeList::const_iterator iterDghtr2 = iterDghtr1,
-               iterDghtrEnd2 = driftVolume1.GetTpcVolumeList().end();
+          for (LArDaughterDriftVolumeList::const_iterator
+                 iterDghtr2 = iterDghtr1,
+                 iterDghtrEnd2 = driftVolume1.GetTpcVolumeList().end();
                iterDghtr2 != iterDghtrEnd2;
                ++iterDghtr2) {
-            const LArDaughterDriftVolume &tpcVolume2(*iterDghtr2);
+            const LArDaughterDriftVolume& tpcVolume2(*iterDghtr2);
 
-            if (tpcVolume1.GetTpc() == tpcVolume2.GetTpc())
-              continue;
+            if (tpcVolume1.GetTpc() == tpcVolume2.GetTpc()) continue;
 
             const float maxDisplacement(LArDetectorGap::GetMaxGapSize());
 
@@ -115,10 +115,12 @@ namespace lar_pandora {
             const float gapY(deltaY - widthY);
             const float gapZ(deltaZ - widthZ);
 
-            const float X1((tpcVolume1.GetCenterX() < tpcVolume2.GetCenterX()) ? (tpcVolume1.GetCenterX() + 0.5f * tpcVolume1.GetWidthX()) :
-                           (tpcVolume2.GetCenterX() + 0.5f * tpcVolume2.GetWidthX()));
-            const float X2((tpcVolume1.GetCenterX() > tpcVolume2.GetCenterX()) ? (tpcVolume1.GetCenterX() - 0.5f * tpcVolume1.GetWidthX()) :
-                           (tpcVolume2.GetCenterX() - 0.5f * tpcVolume2.GetWidthX()));
+            const float X1((tpcVolume1.GetCenterX() < tpcVolume2.GetCenterX()) ?
+                             (tpcVolume1.GetCenterX() + 0.5f * tpcVolume1.GetWidthX()) :
+                             (tpcVolume2.GetCenterX() + 0.5f * tpcVolume2.GetWidthX()));
+            const float X2((tpcVolume1.GetCenterX() > tpcVolume2.GetCenterX()) ?
+                             (tpcVolume1.GetCenterX() - 0.5f * tpcVolume1.GetWidthX()) :
+                             (tpcVolume2.GetCenterX() - 0.5f * tpcVolume2.GetWidthX()));
             const float Y1(std::min((tpcVolume1.GetCenterY() - 0.5f * tpcVolume1.GetWidthY()),
                                     (tpcVolume2.GetCenterY() - 0.5f * tpcVolume2.GetWidthY())));
             const float Y2(std::max((tpcVolume1.GetCenterY() + 0.5f * tpcVolume1.GetWidthY()),
@@ -129,7 +131,8 @@ namespace lar_pandora {
                                     (tpcVolume2.GetCenterZ() + 0.5f * tpcVolume2.GetWidthZ())));
 
             if (std::fabs(gapY) > maxDisplacement || std::fabs(gapZ) > maxDisplacement)
-              listOfGaps.emplace_back(LArDetectorGap(X1, Y1 + widthY, Z1 + widthZ, X2, Y2 - widthY, Z2 - widthZ));
+              listOfGaps.emplace_back(
+                LArDetectorGap(X1, Y1 + widthY, Z1 + widthZ, X2, Y2 - widthY, Z2 - widthZ));
           }
         }
       }
@@ -183,29 +186,42 @@ namespace lar_pandora {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  unsigned int LArPandoraGeometry::GetDaughterVolumeID(const LArDriftVolumeMap &driftVolumeMap, const unsigned int cstat, const unsigned int tpc)
+  unsigned int
+  LArPandoraGeometry::GetDaughterVolumeID(const LArDriftVolumeMap& driftVolumeMap,
+                                          const unsigned int cstat,
+                                          const unsigned int tpc)
   {
     if (driftVolumeMap.empty())
-      throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- detector geometry map is empty";
+      throw cet::exception("LArPandora")
+        << " LArPandoraGeometry::GetDaughterVolumeID --- detector geometry map is empty";
 
-    LArDriftVolumeMap::const_iterator iter = driftVolumeMap.find(LArPandoraGeometry::GetTpcID(cstat, tpc));
+    LArDriftVolumeMap::const_iterator iter =
+      driftVolumeMap.find(LArPandoraGeometry::GetTpcID(cstat, tpc));
 
     if (driftVolumeMap.end() == iter)
-      throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- found a TPC volume that doesn't belong to a drift volume";
+      throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- found a "
+                                            "TPC volume that doesn't belong to a drift volume";
 
-    for (LArDaughterDriftVolumeList::const_iterator iterDghtr = iter->second.GetTpcVolumeList().begin(),
-         iterDghtrEnd = iter->second.GetTpcVolumeList().end(); 
-         iterDghtr != iterDghtrEnd; ++iterDghtr) {
-      const LArDaughterDriftVolume &daughterVolume(*iterDghtr);
+    for (LArDaughterDriftVolumeList::const_iterator
+           iterDghtr = iter->second.GetTpcVolumeList().begin(),
+           iterDghtrEnd = iter->second.GetTpcVolumeList().end();
+         iterDghtr != iterDghtrEnd;
+         ++iterDghtr) {
+      const LArDaughterDriftVolume& daughterVolume(*iterDghtr);
       if (cstat == daughterVolume.GetCryostat() && tpc == daughterVolume.GetTpc())
         return std::distance(iter->second.GetTpcVolumeList().begin(), iterDghtr);
     }
-    throw cet::exception("LArPandora") << " LArPandoraGeometry::GetDaughterVolumeID --- found a daughter volume that doesn't belong to the drift volume ";
+    throw cet::exception("LArPandora")
+      << " LArPandoraGeometry::GetDaughterVolumeID --- found a daughter volume that doesn't belong "
+         "to the drift volume ";
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  geo::View_t LArPandoraGeometry::GetGlobalView(const unsigned int cstat, const unsigned int tpc, const geo::View_t hit_View)
+  geo::View_t
+  LArPandoraGeometry::GetGlobalView(const unsigned int cstat,
+                                    const unsigned int tpc,
+                                    const geo::View_t hit_View)
   {
     const bool switchUV(LArPandoraGeometry::ShouldSwitchUV(cstat, tpc));
 
@@ -353,16 +369,16 @@ namespace lar_pandora {
             (0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat)));
 
         float driftMinX(theTpc1.ActiveBoundingBox().MinX());
-	float driftMaxX(theTpc1.ActiveBoundingBox().MaxX());
+        float driftMaxX(theTpc1.ActiveBoundingBox().MaxX());
         float driftMinY(theTpc1.ActiveBoundingBox().MinY());
         float driftMaxY(theTpc1.ActiveBoundingBox().MaxY());
         float driftMinZ(theTpc1.ActiveBoundingBox().MinZ());
         float driftMaxZ(theTpc1.ActiveBoundingBox().MaxZ());
 
-	// NOTE: This update is attempting to make the min/max used here and for "tpc2" compatible with 
-	//       the changes to driftMin/driftMax. Am not certain this is strictly necessary.
-	const double min1( 0.5*(driftMinX+driftMaxX) - 0.25*std::fabs(driftMaxX-driftMinX) );
-	const double max1( 0.5*(driftMinX+driftMaxX) + 0.25*std::fabs(driftMaxX-driftMinX) );
+        // NOTE: This update is attempting to make the min/max used here and for "tpc2" compatible with
+        //       the changes to driftMin/driftMax. Am not certain this is strictly necessary.
+        const double min1(0.5 * (driftMinX + driftMaxX) - 0.25 * std::fabs(driftMaxX - driftMinX));
+        const double max1(0.5 * (driftMinX + driftMaxX) + 0.25 * std::fabs(driftMaxX - driftMinX));
 
         const bool isPositiveDrift(theTpc1.DriftDirection() == geo::kPosX);
 
@@ -370,7 +386,8 @@ namespace lar_pandora {
         tpcList.insert(itpc1);
 
         LArDaughterDriftVolumeList tpcVolumeList;
-        tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc1,
+        tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat,
+                                                          itpc1,
                                                           0.5f * (driftMaxX + driftMinX),
                                                           0.5f * (driftMaxY + driftMinY),
                                                           0.5f * (driftMaxZ + driftMinZ),
@@ -404,23 +421,23 @@ namespace lar_pandora {
           if (dThetaU > maxDeltaTheta || dThetaV > maxDeltaTheta || dThetaW > maxDeltaTheta)
             continue;
 
-	  double dminx2 = theTpc2.ActiveBoundingBox().MinX();
-	  double dmaxx2 = theTpc2.ActiveBoundingBox().MaxX();
+          double dminx2 = theTpc2.ActiveBoundingBox().MinX();
+          double dmaxx2 = theTpc2.ActiveBoundingBox().MaxX();
 
-          const double min2( 0.5*(dminx2+dmaxx2) - 0.25*std::fabs(dmaxx2-dminx2) );
-          const double max2( 0.5*(dminx2+dmaxx2) + 0.25*std::fabs(dmaxx2-dminx2) );
+          const double min2(0.5 * (dminx2 + dmaxx2) - 0.25 * std::fabs(dmaxx2 - dminx2));
+          const double max2(0.5 * (dminx2 + dmaxx2) + 0.25 * std::fabs(dmaxx2 - dminx2));
 
           if ((min2 > max1) || (min1 > max2)) continue;
 
           cstatList.insert(itpc2);
           tpcList.insert(itpc2);
 
-	  const float driftMinX2(theTpc2.ActiveBoundingBox().MinX());
-	  const float driftMaxX2(theTpc2.ActiveBoundingBox().MaxX());
-	  const float driftMinY2(theTpc2.ActiveBoundingBox().MinY());
-	  const float driftMaxY2(theTpc2.ActiveBoundingBox().MaxY());
-	  const float driftMinZ2(theTpc2.ActiveBoundingBox().MinZ());
-	  const float driftMaxZ2(theTpc2.ActiveBoundingBox().MaxZ());
+          const float driftMinX2(theTpc2.ActiveBoundingBox().MinX());
+          const float driftMaxX2(theTpc2.ActiveBoundingBox().MaxX());
+          const float driftMinY2(theTpc2.ActiveBoundingBox().MinY());
+          const float driftMaxY2(theTpc2.ActiveBoundingBox().MaxY());
+          const float driftMinZ2(theTpc2.ActiveBoundingBox().MinZ());
+          const float driftMaxZ2(theTpc2.ActiveBoundingBox().MaxZ());
 
           driftMinX = std::min(driftMinX, driftMinX2);
           driftMaxX = std::max(driftMaxX, driftMaxX2);
@@ -429,7 +446,8 @@ namespace lar_pandora {
           driftMinZ = std::min(driftMinZ, driftMinZ2);
           driftMaxZ = std::max(driftMaxZ, driftMaxZ2);
 
-          tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat, itpc2, 
+          tpcVolumeList.emplace_back(LArDaughterDriftVolume(icstat,
+                                                            itpc2,
                                                             0.5f * (driftMaxX2 + driftMinX2),
                                                             0.5f * (driftMaxY2 + driftMinY2),
                                                             0.5f * (driftMaxZ2 + driftMinZ2),

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -19,7 +19,8 @@
 namespace lar_pandora {
 
   void
-  LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList& listOfGaps, bool m_useActiveBoundingBox)
+  LArPandoraGeometry::LoadDetectorGaps(LArDetectorGapList& listOfGaps,
+                                       const bool useActiveBoundingBox)
   {
     // Detector gaps can only be loaded once - throw an exception if the output lists are already filled
     if (!listOfGaps.empty())
@@ -28,7 +29,7 @@ namespace lar_pandora {
 
     // Loop over drift volumes and write out the dead regions at their boundaries
     LArDriftVolumeList driftVolumeList;
-    LArPandoraGeometry::LoadGeometry(driftVolumeList, m_useActiveBoundingBox);
+    LArPandoraGeometry::LoadGeometry(driftVolumeList, useActiveBoundingBox);
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.
     art::ServiceHandle<geo::Geometry const> theGeometry;
@@ -144,7 +145,7 @@ namespace lar_pandora {
   void
   LArPandoraGeometry::LoadGeometry(LArDriftVolumeList& outputVolumeList,
                                    LArDriftVolumeMap& outputVolumeMap,
-                                   bool m_useActiveBoundingBox)
+                                   const bool useActiveBoundingBox)
   {
     if (!outputVolumeList.empty())
       throw cet::exception("LArPandora")
@@ -152,7 +153,7 @@ namespace lar_pandora {
 
     // Use a global coordinate system but keep drift volumes separate
     LArDriftVolumeList inputVolumeList;
-    LArPandoraGeometry::LoadGeometry(inputVolumeList, m_useActiveBoundingBox);
+    LArPandoraGeometry::LoadGeometry(inputVolumeList, useActiveBoundingBox);
     LArPandoraGeometry::LoadGlobalDaughterGeometry(inputVolumeList, outputVolumeList);
 
     // Create mapping between tpc/cstat labels and drift volumes
@@ -282,7 +283,8 @@ namespace lar_pandora {
   //------------------------------------------------------------------------------------------------------------------------------------------
 
   void
-  LArPandoraGeometry::LoadGeometry(LArDriftVolumeList& driftVolumeList, bool m_useActiveBoundingBox)
+  LArPandoraGeometry::LoadGeometry(LArDriftVolumeList& driftVolumeList,
+                                   const bool useActiveBoundingBox)
   {
     // This method will group TPCs into "drift volumes" (these are regions of the detector that share a common drift direction,
     // common range of x coordinates, and common detector parameters such as wire pitch and wire angle).
@@ -373,25 +375,27 @@ namespace lar_pandora {
         double worldCoord1[3] = {0., 0., 0.};
         theTpc1.LocalToWorld(localCoord1, worldCoord1);
 
-        float driftMinX(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinX() :
-                                                 (worldCoord1[0] - theTpc1.ActiveHalfWidth()));
-        float driftMaxX(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxX() :
-                                                 (worldCoord1[0] + theTpc1.ActiveHalfWidth()));
-        float driftMinY(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinY() :
-                                                 (worldCoord1[1] - theTpc1.ActiveHalfHeight()));
-        float driftMaxY(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxY() :
-                                                 (worldCoord1[1] + theTpc1.ActiveHalfHeight()));
-        float driftMinZ(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinZ() :
-                                                 (worldCoord1[2] - 0.5f * theTpc1.ActiveLength()));
-        float driftMaxZ(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxZ() :
-                                                 (worldCoord1[2] + 0.5f * theTpc1.ActiveLength()));
+        const float driftMinX(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinX() :
+                                                     (worldCoord1[0] - theTpc1.ActiveHalfWidth()));
+        const float driftMaxX(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxX() :
+                                                     (worldCoord1[0] + theTpc1.ActiveHalfWidth()));
+        const float driftMinY(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinY() :
+                                                     (worldCoord1[1] - theTpc1.ActiveHalfHeight()));
+        const float driftMaxY(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxY() :
+                                                     (worldCoord1[1] + theTpc1.ActiveHalfHeight()));
+        const float driftMinZ(useActiveBoundingBox ?
+                                theTpc1.ActiveBoundingBox().MinZ() :
+                                (worldCoord1[2] - 0.5f * theTpc1.ActiveLength()));
+        const float driftMaxZ(useActiveBoundingBox ?
+                                theTpc1.ActiveBoundingBox().MaxZ() :
+                                (worldCoord1[2] + 0.5f * theTpc1.ActiveLength()));
 
         const double min1(
-          m_useActiveBoundingBox ?
+          useActiveBoundingBox ?
             (0.5 * (driftMinX + driftMaxX) - 0.25 * std::fabs(driftMaxX - driftMinX)) :
             (worldCoord1[0] - 0.5 * theTpc1.ActiveHalfWidth()));
         const double max1(
-          m_useActiveBoundingBox ?
+          useActiveBoundingBox ?
             (0.5 * (driftMinX + driftMaxX) + 0.25 * std::fabs(driftMaxX - driftMinX)) :
             (worldCoord1[0] + 0.5 * theTpc1.ActiveHalfWidth()));
 
@@ -440,19 +444,19 @@ namespace lar_pandora {
           double worldCoord2[3] = {0., 0., 0.};
           theTpc2.LocalToWorld(localCoord2, worldCoord2);
 
-          const float driftMinX2(m_useActiveBoundingBox ?
+          const float driftMinX2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MinX() :
                                    (worldCoord2[0] - theTpc2.ActiveHalfWidth()));
-          const float driftMaxX2(m_useActiveBoundingBox ?
+          const float driftMaxX2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MaxX() :
                                    (worldCoord2[0] + theTpc2.ActiveHalfWidth()));
 
           const double min2(
-            m_useActiveBoundingBox ?
+            useActiveBoundingBox ?
               (0.5 * (driftMinX2 + driftMaxX2) - 0.25 * std::fabs(driftMaxX2 - driftMinX2)) :
               (worldCoord2[0] - 0.5 * theTpc2.ActiveHalfWidth()));
           const double max2(
-            m_useActiveBoundingBox ?
+            useActiveBoundingBox ?
               (0.5 * (driftMinX2 + driftMaxX2) + 0.25 * std::fabs(driftMaxX2 - driftMinX2)) :
               (worldCoord2[0] + 0.5 * theTpc2.ActiveHalfWidth()));
 
@@ -461,16 +465,16 @@ namespace lar_pandora {
           cstatList.insert(itpc2);
           tpcList.insert(itpc2);
 
-          const float driftMinY2(m_useActiveBoundingBox ?
+          const float driftMinY2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MinY() :
                                    (worldCoord2[1] - theTpc2.ActiveHalfHeight()));
-          const float driftMaxY2(m_useActiveBoundingBox ?
+          const float driftMaxY2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MaxY() :
                                    (worldCoord2[1] + theTpc2.ActiveHalfHeight()));
-          const float driftMinZ2(m_useActiveBoundingBox ?
+          const float driftMinZ2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MinZ() :
                                    (worldCoord2[2] - 0.5f * theTpc2.ActiveLength()));
-          const float driftMaxZ2(m_useActiveBoundingBox ?
+          const float driftMaxZ2(useActiveBoundingBox ?
                                    theTpc2.ActiveBoundingBox().MaxZ() :
                                    (worldCoord2[2] + 0.5f * theTpc2.ActiveLength()));
 

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -375,20 +375,18 @@ namespace lar_pandora {
         double worldCoord1[3] = {0., 0., 0.};
         theTpc1.LocalToWorld(localCoord1, worldCoord1);
 
-        const float driftMinX(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinX() :
-                                                     (worldCoord1[0] - theTpc1.ActiveHalfWidth()));
-        const float driftMaxX(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxX() :
-                                                     (worldCoord1[0] + theTpc1.ActiveHalfWidth()));
-        const float driftMinY(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinY() :
-                                                     (worldCoord1[1] - theTpc1.ActiveHalfHeight()));
-        const float driftMaxY(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxY() :
-                                                     (worldCoord1[1] + theTpc1.ActiveHalfHeight()));
-        const float driftMinZ(useActiveBoundingBox ?
-                                theTpc1.ActiveBoundingBox().MinZ() :
-                                (worldCoord1[2] - 0.5f * theTpc1.ActiveLength()));
-        const float driftMaxZ(useActiveBoundingBox ?
-                                theTpc1.ActiveBoundingBox().MaxZ() :
-                                (worldCoord1[2] + 0.5f * theTpc1.ActiveLength()));
+        float driftMinX(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinX() :
+                                               (worldCoord1[0] - theTpc1.ActiveHalfWidth()));
+        float driftMaxX(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxX() :
+                                               (worldCoord1[0] + theTpc1.ActiveHalfWidth()));
+        float driftMinY(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinY() :
+                                               (worldCoord1[1] - theTpc1.ActiveHalfHeight()));
+        float driftMaxY(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxY() :
+                                               (worldCoord1[1] + theTpc1.ActiveHalfHeight()));
+        float driftMinZ(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinZ() :
+                                               (worldCoord1[2] - 0.5f * theTpc1.ActiveLength()));
+        float driftMaxZ(useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxZ() :
+                                               (worldCoord1[2] + 0.5f * theTpc1.ActiveLength()));
 
         const double min1(
           useActiveBoundingBox ?

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.cxx
@@ -28,7 +28,7 @@ namespace lar_pandora {
 
     // Loop over drift volumes and write out the dead regions at their boundaries
     LArDriftVolumeList driftVolumeList;
-    LArPandoraGeometry::LoadGeometry(driftVolumeList,m_useActiveBoundingBox);
+    LArPandoraGeometry::LoadGeometry(driftVolumeList, m_useActiveBoundingBox);
 
     // ATTN: Expectations here are that the input geometry corresponds to either a single or dual phase LArTPC.
     art::ServiceHandle<geo::Geometry const> theGeometry;
@@ -144,7 +144,7 @@ namespace lar_pandora {
   void
   LArPandoraGeometry::LoadGeometry(LArDriftVolumeList& outputVolumeList,
                                    LArDriftVolumeMap& outputVolumeMap,
-				   bool m_useActiveBoundingBox)
+                                   bool m_useActiveBoundingBox)
   {
     if (!outputVolumeList.empty())
       throw cet::exception("LArPandora")
@@ -282,8 +282,7 @@ namespace lar_pandora {
   //------------------------------------------------------------------------------------------------------------------------------------------
 
   void
-  LArPandoraGeometry::LoadGeometry(LArDriftVolumeList& driftVolumeList,
-				   bool m_useActiveBoundingBox)
+  LArPandoraGeometry::LoadGeometry(LArDriftVolumeList& driftVolumeList, bool m_useActiveBoundingBox)
   {
     // This method will group TPCs into "drift volumes" (these are regions of the detector that share a common drift direction,
     // common range of x coordinates, and common detector parameters such as wire pitch and wire angle).
@@ -370,21 +369,31 @@ namespace lar_pandora {
             (std::fabs(0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kY, itpc1, icstat))) :
             (0.5f * M_PI - theGeometry->WireAngleToVertical(geo::kW, itpc1, icstat)));
 
-	double localCoord1[3] = {0., 0., 0.};
-	double worldCoord1[3] = {0., 0., 0.};
-	theTpc1.LocalToWorld(localCoord1, worldCoord1);
+        double localCoord1[3] = {0., 0., 0.};
+        double worldCoord1[3] = {0., 0., 0.};
+        theTpc1.LocalToWorld(localCoord1, worldCoord1);
 
-        float driftMinX(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinX() : (worldCoord1[0] - theTpc1.ActiveHalfWidth()));
-        float driftMaxX(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxX() : (worldCoord1[0] + theTpc1.ActiveHalfWidth()));
-        float driftMinY(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinY() : (worldCoord1[1] - theTpc1.ActiveHalfHeight()));
-        float driftMaxY(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxY() : (worldCoord1[1] + theTpc1.ActiveHalfHeight()));
-        float driftMinZ(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinZ() : (worldCoord1[2] - 0.5f * theTpc1.ActiveLength()));
-        float driftMaxZ(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxZ() : (worldCoord1[2] + 0.5f * theTpc1.ActiveLength()));
+        float driftMinX(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinX() :
+                                                 (worldCoord1[0] - theTpc1.ActiveHalfWidth()));
+        float driftMaxX(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxX() :
+                                                 (worldCoord1[0] + theTpc1.ActiveHalfWidth()));
+        float driftMinY(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinY() :
+                                                 (worldCoord1[1] - theTpc1.ActiveHalfHeight()));
+        float driftMaxY(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxY() :
+                                                 (worldCoord1[1] + theTpc1.ActiveHalfHeight()));
+        float driftMinZ(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MinZ() :
+                                                 (worldCoord1[2] - 0.5f * theTpc1.ActiveLength()));
+        float driftMaxZ(m_useActiveBoundingBox ? theTpc1.ActiveBoundingBox().MaxZ() :
+                                                 (worldCoord1[2] + 0.5f * theTpc1.ActiveLength()));
 
-        const double min1(m_useActiveBoundingBox ? (0.5 * (driftMinX + driftMaxX) - 0.25 * std::fabs(driftMaxX - driftMinX)) :
-			                                           (worldCoord1[0] - 0.5 * theTpc1.ActiveHalfWidth()));
-        const double max1(m_useActiveBoundingBox ? (0.5 * (driftMinX + driftMaxX) + 0.25 * std::fabs(driftMaxX - driftMinX)) :
-			                                           (worldCoord1[0] + 0.5 * theTpc1.ActiveHalfWidth()));
+        const double min1(
+          m_useActiveBoundingBox ?
+            (0.5 * (driftMinX + driftMaxX) - 0.25 * std::fabs(driftMaxX - driftMinX)) :
+            (worldCoord1[0] - 0.5 * theTpc1.ActiveHalfWidth()));
+        const double max1(
+          m_useActiveBoundingBox ?
+            (0.5 * (driftMinX + driftMaxX) + 0.25 * std::fabs(driftMaxX - driftMinX)) :
+            (worldCoord1[0] + 0.5 * theTpc1.ActiveHalfWidth()));
 
         const bool isPositiveDrift(theTpc1.DriftDirection() == geo::kPosX);
 
@@ -427,29 +436,43 @@ namespace lar_pandora {
           if (dThetaU > maxDeltaTheta || dThetaV > maxDeltaTheta || dThetaW > maxDeltaTheta)
             continue;
 
-	  double localCoord2[3] = {0., 0., 0.};
-	  double worldCoord2[3] = {0., 0., 0.};
-	  theTpc2.LocalToWorld(localCoord2, worldCoord2);
+          double localCoord2[3] = {0., 0., 0.};
+          double worldCoord2[3] = {0., 0., 0.};
+          theTpc2.LocalToWorld(localCoord2, worldCoord2);
 
-          const float driftMinX2(m_useActiveBoundingBox ? theTpc2.ActiveBoundingBox().MinX() : (worldCoord2[0] - theTpc2.ActiveHalfWidth()));
-          const float driftMaxX2(m_useActiveBoundingBox ? theTpc2.ActiveBoundingBox().MaxX() : (worldCoord2[0] + theTpc2.ActiveHalfWidth()));
+          const float driftMinX2(m_useActiveBoundingBox ?
+                                   theTpc2.ActiveBoundingBox().MinX() :
+                                   (worldCoord2[0] - theTpc2.ActiveHalfWidth()));
+          const float driftMaxX2(m_useActiveBoundingBox ?
+                                   theTpc2.ActiveBoundingBox().MaxX() :
+                                   (worldCoord2[0] + theTpc2.ActiveHalfWidth()));
 
-          const double min2(m_useActiveBoundingBox ? (0.5 * (driftMinX2 + driftMaxX2) -
-								      0.25 * std::fabs(driftMaxX2 - driftMinX2)) :
-			                                             (worldCoord2[0] - 0.5 * theTpc2.ActiveHalfWidth()));
-          const double max2(m_useActiveBoundingBox ? (0.5 * (driftMinX2 + driftMaxX2) +
-								      0.25 * std::fabs(driftMaxX2 - driftMinX2)) :
-			                                             (worldCoord2[0] + 0.5 * theTpc2.ActiveHalfWidth()));
+          const double min2(
+            m_useActiveBoundingBox ?
+              (0.5 * (driftMinX2 + driftMaxX2) - 0.25 * std::fabs(driftMaxX2 - driftMinX2)) :
+              (worldCoord2[0] - 0.5 * theTpc2.ActiveHalfWidth()));
+          const double max2(
+            m_useActiveBoundingBox ?
+              (0.5 * (driftMinX2 + driftMaxX2) + 0.25 * std::fabs(driftMaxX2 - driftMinX2)) :
+              (worldCoord2[0] + 0.5 * theTpc2.ActiveHalfWidth()));
 
           if ((min2 > max1) || (min1 > max2)) continue;
 
           cstatList.insert(itpc2);
           tpcList.insert(itpc2);
 
-          const float driftMinY2(m_useActiveBoundingBox ? theTpc2.ActiveBoundingBox().MinY() : (worldCoord2[1] - theTpc2.ActiveHalfHeight()));
-          const float driftMaxY2(m_useActiveBoundingBox ? theTpc2.ActiveBoundingBox().MaxY() : (worldCoord2[1] + theTpc2.ActiveHalfHeight()));
-          const float driftMinZ2(m_useActiveBoundingBox ? theTpc2.ActiveBoundingBox().MinZ() : (worldCoord2[2] - 0.5f * theTpc2.ActiveLength()));
-          const float driftMaxZ2(m_useActiveBoundingBox ? theTpc2.ActiveBoundingBox().MaxZ() : (worldCoord2[2] + 0.5f * theTpc2.ActiveLength()));
+          const float driftMinY2(m_useActiveBoundingBox ?
+                                   theTpc2.ActiveBoundingBox().MinY() :
+                                   (worldCoord2[1] - theTpc2.ActiveHalfHeight()));
+          const float driftMaxY2(m_useActiveBoundingBox ?
+                                   theTpc2.ActiveBoundingBox().MaxY() :
+                                   (worldCoord2[1] + theTpc2.ActiveHalfHeight()));
+          const float driftMinZ2(m_useActiveBoundingBox ?
+                                   theTpc2.ActiveBoundingBox().MinZ() :
+                                   (worldCoord2[2] - 0.5f * theTpc2.ActiveLength()));
+          const float driftMaxZ2(m_useActiveBoundingBox ?
+                                   theTpc2.ActiveBoundingBox().MaxZ() :
+                                   (worldCoord2[2] + 0.5f * theTpc2.ActiveLength()));
 
           driftMinX = std::min(driftMinX, driftMinX2);
           driftMaxX = std::max(driftMaxX, driftMaxX2);

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.h
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.h
@@ -102,9 +102,14 @@ namespace lar_pandora {
      *  @param  widthY           width of tpc volume (Y)
      *  @param  widthZ           width of tpc volume (Z)
      */
-    LArDaughterDriftVolume(const unsigned int cryostat, const unsigned int tpc,
-                           const float centerX, const float centerY, const float centerZ,
-                           const float widthX, const float widthY, const float widthZ);
+    LArDaughterDriftVolume(const unsigned int cryostat,
+                           const unsigned int tpc,
+                           const float centerX,
+                           const float centerY,
+                           const float centerZ,
+                           const float widthX,
+                           const float widthY,
+                           const float widthZ);
 
     /**
      *  @brief  Return cryostat ID
@@ -146,16 +151,16 @@ namespace lar_pandora {
      */
     float GetWidthZ() const;
 
-private:
-    unsigned int    m_cryostat;
-    unsigned int    m_tpc;
-    float           m_centerX;
-    float           m_centerY;
-    float           m_centerZ;
-    float           m_widthX;
-    float           m_widthY;
-    float           m_widthZ;
-};
+  private:
+    unsigned int m_cryostat;
+    unsigned int m_tpc;
+    float m_centerX;
+    float m_centerY;
+    float m_centerZ;
+    float m_widthX;
+    float m_widthY;
+    float m_widthZ;
+  };
 
   typedef std::vector<LArDaughterDriftVolume> LArDaughterDriftVolumeList;
 
@@ -322,8 +327,7 @@ private:
      *
      *  @param listOfGaps the output list of 2D gaps.
      */
-    static void LoadDetectorGaps(LArDetectorGapList& listOfGaps,
-				 bool m_useActiveBoundingBox);
+    static void LoadDetectorGaps(LArDetectorGapList& listOfGaps, bool m_useActiveBoundingBox);
 
     /**
      *  @brief Load drift volume geometry
@@ -333,7 +337,7 @@ private:
      */
     static void LoadGeometry(LArDriftVolumeList& outputVolumeList,
                              LArDriftVolumeMap& outputVolumeMap,
-			     bool m_useActiveBoundingBox);
+                             bool m_useActiveBoundingBox);
 
     /**
      *  @brief  Get drift volume ID from a specified cryostat/tpc pair
@@ -398,8 +402,7 @@ private:
      *
      *  @param  driftVolumeList to receive the populated drift volume list
      */
-    static void LoadGeometry(LArDriftVolumeList& driftVolumeList,
-			     bool m_useActiveBoundingBox);
+    static void LoadGeometry(LArDriftVolumeList& driftVolumeList, bool m_useActiveBoundingBox);
 
     /**
      *  @brief  This method will create one or more daughter volumes (these share a common drift orientation along the X-axis,
@@ -483,12 +486,22 @@ private:
   //------------------------------------------------------------------------------------------------------------------------------------------
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  inline LArDaughterDriftVolume::LArDaughterDriftVolume(const unsigned int cryostat, const unsigned int tpc,
-                                                        const float centerX, const float centerY, const float centerZ,
-                                                        const float widthX, const float widthY, const float widthZ) :
-      m_cryostat(cryostat), m_tpc(tpc),
-      m_centerX(centerX), m_centerY(centerY), m_centerZ(centerZ),
-      m_widthX(widthX), m_widthY(widthY), m_widthZ(widthZ)      
+  inline LArDaughterDriftVolume::LArDaughterDriftVolume(const unsigned int cryostat,
+                                                        const unsigned int tpc,
+                                                        const float centerX,
+                                                        const float centerY,
+                                                        const float centerZ,
+                                                        const float widthX,
+                                                        const float widthY,
+                                                        const float widthZ)
+    : m_cryostat(cryostat)
+    , m_tpc(tpc)
+    , m_centerX(centerX)
+    , m_centerY(centerY)
+    , m_centerZ(centerZ)
+    , m_widthX(widthX)
+    , m_widthY(widthY)
+    , m_widthZ(widthZ)
   {}
 
   //------------------------------------------------------------------------------------------------------------------------------------------
@@ -544,7 +557,7 @@ private:
   inline float
   LArDaughterDriftVolume::GetWidthY() const
   {
-      return m_widthY;
+    return m_widthY;
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.h
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.h
@@ -326,18 +326,20 @@ namespace lar_pandora {
      *  @brief Load the 2D gaps that go with the chosen geometry
      *
      *  @param listOfGaps the output list of 2D gaps.
+     *  @param useActiveBoundingBox when true use ActiveBoundingBox instead of the default midpoint. Meant to handle offsets and things in a better way.
      */
-    static void LoadDetectorGaps(LArDetectorGapList& listOfGaps, bool m_useActiveBoundingBox);
+    static void LoadDetectorGaps(LArDetectorGapList& listOfGaps, const bool useActiveBoundingBox);
 
     /**
      *  @brief Load drift volume geometry
      *
      *  @param outputVolumeList the output list of drift volumes
      *  @param outputVolumeMap the output mapping between cryostat/tpc and drift volumes
+     *  @param useActiveBoundingBox when true use ActiveBoundingBox instead of the default midpoint. Meant to handle offsets and things in a better way.
      */
     static void LoadGeometry(LArDriftVolumeList& outputVolumeList,
                              LArDriftVolumeMap& outputVolumeMap,
-                             bool m_useActiveBoundingBox);
+                             const bool useActiveBoundingBox);
 
     /**
      *  @brief  Get drift volume ID from a specified cryostat/tpc pair
@@ -401,8 +403,9 @@ namespace lar_pandora {
      *          common range of X coordinates, and common detector parameters such as wire pitch and wire angle).
      *
      *  @param  driftVolumeList to receive the populated drift volume list
+     *  @param  useActiveBoundingBox when true use ActiveBoundingBox instead of the default midpoint. Meant to handle offsets and things in a better way.
      */
-    static void LoadGeometry(LArDriftVolumeList& driftVolumeList, bool m_useActiveBoundingBox);
+    static void LoadGeometry(LArDriftVolumeList& driftVolumeList, const bool useActiveBoundingBox);
 
     /**
      *  @brief  This method will create one or more daughter volumes (these share a common drift orientation along the X-axis,

--- a/larpandora/LArPandoraInterface/LArPandoraGeometry.h
+++ b/larpandora/LArPandoraInterface/LArPandoraGeometry.h
@@ -322,7 +322,8 @@ private:
      *
      *  @param listOfGaps the output list of 2D gaps.
      */
-    static void LoadDetectorGaps(LArDetectorGapList& listOfGaps);
+    static void LoadDetectorGaps(LArDetectorGapList& listOfGaps,
+				 bool m_useActiveBoundingBox);
 
     /**
      *  @brief Load drift volume geometry
@@ -331,7 +332,8 @@ private:
      *  @param outputVolumeMap the output mapping between cryostat/tpc and drift volumes
      */
     static void LoadGeometry(LArDriftVolumeList& outputVolumeList,
-                             LArDriftVolumeMap& outputVolumeMap);
+                             LArDriftVolumeMap& outputVolumeMap,
+			     bool m_useActiveBoundingBox);
 
     /**
      *  @brief  Get drift volume ID from a specified cryostat/tpc pair
@@ -396,7 +398,8 @@ private:
      *
      *  @param  driftVolumeList to receive the populated drift volume list
      */
-    static void LoadGeometry(LArDriftVolumeList& driftVolumeList);
+    static void LoadGeometry(LArDriftVolumeList& driftVolumeList,
+			     bool m_useActiveBoundingBox);
 
     /**
      *  @brief  This method will create one or more daughter volumes (these share a common drift orientation along the X-axis,

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -121,8 +121,8 @@ namespace lar_pandora {
         caloHitParameters.m_pParentAddress = (void*)((intptr_t)(++hitCounter));
         caloHitParameters.m_larTPCVolumeId =
           LArPandoraGeometry::GetVolumeID(driftVolumeMap, hit_WireID.Cryostat, hit_WireID.TPC);
-        caloHitParameters.m_daughterVolumeId = 
-          LArPandoraGeometry::GetDaughterVolumeID(driftVolumeMap, hit_WireID.Cryostat, hit_WireID.TPC);
+        caloHitParameters.m_daughterVolumeId = LArPandoraGeometry::GetDaughterVolumeID(
+          driftVolumeMap, hit_WireID.Cryostat, hit_WireID.TPC);
 
         const geo::View_t pandora_GlobalView(
           LArPandoraGeometry::GetGlobalView(hit_WireID.Cryostat, hit_WireID.TPC, hit_View));
@@ -673,14 +673,13 @@ namespace lar_pandora {
         MCProcessMap processMap;
         FillMCProcessMap(processMap);
         mcParticleParameters.m_nuanceCode = nuanceCode;
-        if (processMap.find(particle->Process()) != processMap.end())
-        {
-            mcParticleParameters.m_process = processMap[particle->Process()];
+        if (processMap.find(particle->Process()) != processMap.end()) {
+          mcParticleParameters.m_process = processMap[particle->Process()];
         }
-        else
-        {
-            mcParticleParameters.m_process = lar_content::MC_PROC_UNKNOWN;
-            mf::LogWarning("LArPandora") << "CreatePandoraMCParticles - found an unknown process" << std::endl;
+        else {
+          mcParticleParameters.m_process = lar_content::MC_PROC_UNKNOWN;
+          mf::LogWarning("LArPandora")
+            << "CreatePandoraMCParticles - found an unknown process" << std::endl;
         }
         mcParticleParameters.m_energy = E;
         mcParticleParameters.m_particleId = particle->PdgCode();
@@ -942,7 +941,7 @@ namespace lar_pandora {
   //------------------------------------------------------------------------------------------------------------------------------------------
 
   void
-  LArPandoraInput::FillMCProcessMap(MCProcessMap &processMap)
+  LArPandoraInput::FillMCProcessMap(MCProcessMap& processMap)
   {
     // QGSP_BERT and EM standard physics list mappings
     processMap["unknown"] = lar_content::MC_PROC_UNKNOWN;

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -1002,6 +1002,7 @@ namespace lar_pandora {
     : m_pPrimaryPandora(nullptr)
     , m_useHitWidths(true)
     , m_useBirksCorrection(false)
+    , m_useActiveBoundingBox(false)
     , m_uidOffset(100000000)
     , m_hitCounterOffset(0)
     , m_dx_cm(0.5)

--- a/larpandora/LArPandoraInterface/LArPandoraInput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.h
@@ -195,7 +195,7 @@ namespace lar_pandora {
      *
      *  @param  processMap the output map from MC process string to enumeration
      */
-    static void FillMCProcessMap(MCProcessMap &processMap);
+    static void FillMCProcessMap(MCProcessMap& processMap);
   };
 
 } // namespace lar_pandora

--- a/larpandora/LArPandoraInterface/LArPandoraInput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.h
@@ -38,6 +38,7 @@ namespace lar_pandora {
       const pandora::Pandora* m_pPrimaryPandora; ///<
       bool m_useHitWidths;                       ///<
       bool m_useBirksCorrection;                 ///<
+      bool m_useActiveBoundingBox;               ///<
       int m_uidOffset;                           ///<
       int m_hitCounterOffset;                    ///<
       double m_dx_cm;                            ///<


### PR DESCRIPTION
This PR adds support for direct use of active bounding boxes to define the active TPC volume. By default the existing geometry loading code remains active (a future release will likely make the new method the default).

This PR also applies the clang format to LArPandoraShower.

No product changes are expected for this release.