### PR TITLE
Update ShowerStartPosition type to fix the type mismatch bug. 

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPFPVertexStartPosition_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPFPVertexStartPosition_tool.cc
@@ -83,9 +83,7 @@ namespace ShowerRecoTools {
     //If there is only one vertex good news we just say that is the start of the shower.
     if (vtx_cand.size() == 1) {
       art::Ptr<recob::Vertex> StartPositionVertex = vtx_cand[0];
-      double xyz[3] = {-999, -999, -999};
-      StartPositionVertex->XYZ(xyz);
-      TVector3 ShowerStartPosition = {xyz[0], xyz[1], xyz[2]};
+      auto ShowerStartPosition(StartPositionVertex->position());
       TVector3 ShowerStartPositionErr = {-999, -999, -999};
       ShowerEleHolder.SetElement(
         ShowerStartPosition, ShowerStartPositionErr, fShowerStartPositionOutputLabel);


### PR DESCRIPTION
Resolves: #30

This PR will also need folding back into the pandora-owned larpandora repo: https://github.com/PandoraPFA/larpandora

In principle, the TVector3 StartPositionErrors should also be updated to geo::Point_ts, but that's a job for another day...