### PR TITLE
Swap to use of geo::Vector_t

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackTrajPointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackTrajPointDirection_tool.cc
@@ -84,7 +84,7 @@ namespace ShowerRecoTools {
       return 1;
     }
 
-    geo::Vector_t Direction_vec;
+    geo::Vector_t Direction;
     //Get the difference between the point and the start position.
     if (fUsePositonInfo) {
       //Get the start position.
@@ -104,14 +104,13 @@ namespace ShowerRecoTools {
       }
       //Get the specific trajectory point and look and and the direction from the start position
       geo::Point_t TrajPosition = InitialTrack.LocationAtPoint(fTrajPoint);
-      Direction_vec = (TrajPosition - StartPosition).Unit();
+      Direction = (TrajPosition - StartPosition).Unit();
     }
     else {
       //Use the direction of the trajection at tat point;
-      Direction_vec = InitialTrack.DirectionAtPoint(fTrajPoint);
+      Direction = InitialTrack.DirectionAtPoint(fTrajPoint);
     }
 
-    geo::Vector_t Direction = {Direction_vec.X(), Direction_vec.Y(), Direction_vec.Z()};
     TVector3 DirectionErr = {-999, -999, -999};
     ShowerEleHolder.SetElement(Direction, DirectionErr, fShowerDirectionOutputLabel);
     return 0;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackTrajPointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackTrajPointDirection_tool.cc
@@ -111,7 +111,7 @@ namespace ShowerRecoTools {
       Direction_vec = InitialTrack.DirectionAtPoint(fTrajPoint);
     }
 
-    TVector3 Direction = {Direction_vec.X(), Direction_vec.Y(), Direction_vec.Z()};
+    geo::Vector_t Direction = {Direction_vec.X(), Direction_vec.Y(), Direction_vec.Z()};
     TVector3 DirectionErr = {-999, -999, -999};
     ShowerEleHolder.SetElement(Direction, DirectionErr, fShowerDirectionOutputLabel);
     return 0;


### PR DESCRIPTION
Further to #30 while testing in SBND we found an issue relating to the same mismatch between TVector3 and geo::Vector_t at runtime.

This PR resolves this runtime issue.