### PR TITLE
Add SummedIntegral Calorimetry to dE/dx

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Algs/LArPandoraShowerAlg.h
@@ -110,6 +110,9 @@ public:
 
   double SCECorrectEField(double const& EField, geo::Point_t const& pos) const;
 
+  std::map<art::Ptr<recob::Hit>, std::vector<art::Ptr<recob::Hit>>> OrganizeHits(
+    const std::vector<art::Ptr<recob::Hit>>& hits) const;
+
   void DebugEVD(art::Ptr<recob::PFParticle> const& pfparticle,
                 art::Event const& Event,
                 const reco::shower::ShowerElementHolder& ShowerEleHolder,

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -118,6 +118,7 @@ showerunidirectiondedx:{
     MaxHitPlane:     true #Set the best planes as the one with the most hits
     MissFirstPoint:  true #Do not use any hits from the first wire
     dEdxTrackLength: 3    #Max length from a hit can be to the start point in cm.
+    SumHitSnippets: false
     ShowerStartPositionInputLabel: "ShowerStartPosition"
     InitialTrackHitsInputLabel: "InitialTrackHits"
     ShowerDirectionInputLabel: "ShowerDirection"
@@ -287,9 +288,11 @@ showertrajpointdedx:{
     SCECorrectPitch:      false
     SCECorrectEField:     false
     SCEInputCorrected:    false
+    SumHitSnippets: false
     # PFParticleLabel: "pandora"
     ShowerStartPositionInputLabel: "ShowerStartPosition"
     InitialTrackSpacePointsInputLabel: "InitialTrackSpacePoints"
+    InitialTrackHitsInputLabel: "InitialTrackHits"
     InitialTrackInputLabel: "InitialTrack"
     ShowerdEdxOutputLabel: "ShowerdEdx"
     ShowerBestPlaneOutputLabel: "ShowerBestPlane"


### PR DESCRIPTION
Similarly to https://github.com/LArSoft/larreco/pull/51, this adds the ability to  sum the integral of all hits within a snippet when calculating the shower dE/dx.  This behaviour is disabled by default and thus no changes to existing workflows are expected. 