### PR TITLE
Feature/howard duplicate hit filter tool updated

### DIFF
--- a/larpandora/LArPandoraInterface/CMakeLists.txt
+++ b/larpandora/LArPandoraInterface/CMakeLists.txt
@@ -70,6 +70,12 @@ cet_build_plugin(StandardPandora lar::LArPandora
   PandoraPFA::PandoraSDK
 )
 
+cet_build_plugin(LArPandoraHitCollectionToolDefault art::tool
+  LIBRARIES PRIVATE
+  ${lib_target}
+  PandoraPFA::PandoraSDK
+)
+
 if (LARPANDORA_LIBTORCH)
   target_link_libraries(${module_target} PRIVATE larpandoracontent::LArPandoraDLContent)
   target_compile_definitions(${module_target} PRIVATE LIBTORCH_DL)

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -64,6 +64,7 @@ namespace lar_pandora {
     , m_enableMCParticles(pset.get<bool>("EnableMCParticles", false))
     , m_disableRealDataCheck(pset.get<bool>("DisableRealDataCheck", false))
     , m_lineGapsCreated(false)
+    , m_collectHitsTool{ art::make_tool<HitCollectionTools::HitCollectionTool>( this->ConstructHitCollectionToolParameterSet(pset) ) }
   {
     m_inputSettings.m_useHitWidths = pset.get<bool>("UseHitWidths", true);
     m_inputSettings.m_useBirksCorrection = pset.get<bool>("UseBirksCorrection", false);
@@ -86,15 +87,6 @@ namespace lar_pandora {
     m_outputSettings.m_isNeutrinoRecoOnlyNoSlicing =
       (!m_shouldRunSlicing && m_shouldRunNeutrinoRecoOption && !m_shouldRunCosmicRecoOption);
     m_outputSettings.m_hitfinderModuleLabel = m_hitfinderModuleLabel;
-
-    if ( pset.has_key("HitCollectionTool") ) {
-      m_collectHitsTool = art::make_tool<HitCollectionTools::HitCollectionTool>(pset.get<fhicl::ParameterSet>("HitCollectionTool"));
-    }
-    else {
-      fhicl::ParameterSet psetHitCollection;
-      psetHitCollection.put<std::string>("tool_type","LArPandoraHitCollectionToolDefault");
-      m_collectHitsTool = art::make_tool<HitCollectionTools::HitCollectionTool>(psetHitCollection);
-    }
 
     if (m_enableProduction) {
       // Set up the instance names to produces
@@ -259,6 +251,20 @@ namespace lar_pandora {
         LArPandoraOutput::ProduceArtOutput(m_outputSettings, idToHitMap, evt);
       }
     }
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  fhicl::ParameterSet LArPandora::ConstructHitCollectionToolParameterSet(const fhicl::ParameterSet& pset)
+  {
+    if ( pset.has_key("HitCollectionTool") )
+    {
+      return pset.get<fhicl::ParameterSet>("HitCollectionTool");
+    }
+
+    fhicl::ParameterSet psetHitCollection;
+    psetHitCollection.put<std::string>("tool_type","LArPandoraHitCollectionToolDefault");
+    return psetHitCollection;
   }
 
 } // namespace lar_pandora

--- a/larpandora/LArPandoraInterface/LArPandora.h
+++ b/larpandora/LArPandoraInterface/LArPandora.h
@@ -37,6 +37,8 @@ namespace lar_pandora {
     void CreatePandoraInput(art::Event& evt, IdToHitMap& idToHitMap);
     void ProcessPandoraOutput(art::Event& evt, const IdToHitMap& idToHitMap);
 
+    fhicl::ParameterSet ConstructHitCollectionToolParameterSet(const fhicl::ParameterSet& pset);
+
     std::string m_configFile; ///< The config file
 
     bool
@@ -71,7 +73,6 @@ namespace lar_pandora {
       m_disableRealDataCheck; ///< Whether to check if the input file contains real data before accessing MC information
     bool m_lineGapsCreated; ///< Book-keeping: whether line gap creation has been called
 
-    // TODO: may need to change class/namespace names as I progress here...
     std::unique_ptr<HitCollectionTools::HitCollectionTool> m_collectHitsTool; ///< art tool used to collect the hits
 
     LArPandoraInput::Settings m_inputSettings;   ///< The lar pandora input settings

--- a/larpandora/LArPandoraInterface/LArPandora.h
+++ b/larpandora/LArPandoraInterface/LArPandora.h
@@ -12,6 +12,8 @@
 #include "larpandora/LArPandoraInterface/LArPandoraInput.h"
 #include "larpandora/LArPandoraInterface/LArPandoraOutput.h"
 
+#include "larpandora/LArPandoraInterface/LArPandoraHitCollectionTool.h"
+
 #include <string>
 
 namespace lar_pandora {
@@ -68,6 +70,9 @@ namespace lar_pandora {
     bool
       m_disableRealDataCheck; ///< Whether to check if the input file contains real data before accessing MC information
     bool m_lineGapsCreated; ///< Book-keeping: whether line gap creation has been called
+
+    // TODO: may need to change class/namespace names as I progress here...
+    std::unique_ptr<HitCollectionTools::HitCollectionTool> m_collectHitsTool; ///< art tool used to collect the hits
 
     LArPandoraInput::Settings m_inputSettings;   ///< The lar pandora input settings
     LArPandoraOutput::Settings m_outputSettings; ///< The lar pandora output settings

--- a/larpandora/LArPandoraInterface/LArPandoraHitCollectionTool.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHitCollectionTool.h
@@ -1,0 +1,25 @@
+/**
+ *  @file  larpandora/LArPandoraInterface/Tools/LArPandoraHitCollectionTool.h
+ * 
+ *  @brief Define class for hit collection tools and implements base tool
+ * 
+ */
+#ifndef LAR_PANDORA_HIT_COLLECTION_TOOL_H
+#define LAR_PANDORA_HIT_COLLECTION_TOOL_H
+
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
+
+#include "art/Framework/Principal/Event.h"
+
+namespace HitCollectionTools {
+
+  class HitCollectionTool
+  {
+  public:
+    virtual ~HitCollectionTool() noexcept = default;
+    virtual void CollectHits(const art::Event& evt, const std::string& label, lar_pandora::HitVector& hitVector) = 0;
+  };
+
+} // namespace lar_pandora
+
+#endif //  LAR_PANDORA_HITCOLLECTION_TOOL_H

--- a/larpandora/LArPandoraInterface/LArPandoraHitCollectionToolDefault_tool.cc
+++ b/larpandora/LArPandoraInterface/LArPandoraHitCollectionToolDefault_tool.cc
@@ -1,0 +1,31 @@
+/**
+ *  @file  larpandora/LArPandoraInterface/Tools/LArPandoraHitCollectionToolDefault_tool.cc
+ * 
+ *  @brief Define class for hit collection tools and implements DEFAULT base tool
+ * 
+ */
+
+#include "art/Utilities/ToolMacros.h"
+
+//#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
+#include "larpandora/LArPandoraInterface/LArPandoraHitCollectionTool.h"
+
+namespace HitCollectionTools {
+
+  class LArPandoraHitCollectionToolDefault : public HitCollectionTool
+  {
+  public:
+    explicit LArPandoraHitCollectionToolDefault(const fhicl::ParameterSet& pset);
+    void CollectHits(const art::Event& evt, const std::string& label, lar_pandora::HitVector& hitVector) override;
+  };
+
+  LArPandoraHitCollectionToolDefault::LArPandoraHitCollectionToolDefault(const fhicl::ParameterSet& pset){}
+
+  void LArPandoraHitCollectionToolDefault::CollectHits(const art::Event& evt, const std::string& label, lar_pandora::HitVector& hitVector)
+  {
+    lar_pandora::LArPandoraHelper::CollectHits(evt, label, hitVector);
+  }
+
+} // namespace lar_pandora
+
+DEFINE_ART_CLASS_TOOL(HitCollectionTools::LArPandoraHitCollectionToolDefault)


### PR DESCRIPTION
The intent of this PR is to turn the usage of CollectHits in `LArPandora.cxx` into an art tool to allow one to do some customization at this stage of input. For example, with this we would plan to have a tool living in `icaruscode` that basically copies CollectHits but does some filtering while inputting the hits. The default functionality here is intended to effectively preserve previous behavior.

Appreciate eyes on the intended changes. I spotted a few comments and things we probably want to remove before merging, but in any case making the PR now to get people looking at it...

A question: in putting together the art tool, I took some inspiration and guidance from other code. Do we want to actually specify a destructor here? I noticed `IShowerTool` does, for example, but wasn't sure.