### PR TITLE
Use the WireReadoutGeom::Plane() method accepting a TPCID and a view instead of PlaneID to make PDDP happy

### DIFF
--- a/larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h
+++ b/larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h
@@ -128,14 +128,14 @@ namespace lar_pandora {
 
   inline float VintageLArTPCThreeView::WirePitchU() const
   {
-    return m_wireReadoutGeom->Plane({0, 0, TargetViewU(0, 0)}).WirePitch();
+    return m_wireReadoutGeom->Plane({0,0},TargetViewU(0,0)).WirePitch();
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
   inline float VintageLArTPCThreeView::WirePitchV() const
   {
-    return m_wireReadoutGeom->Plane({0, 0, TargetViewV(0, 0)}).WirePitch();
+    return m_wireReadoutGeom->Plane({0,0}, TargetViewV(0,0)).WirePitch();
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h
+++ b/larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h
@@ -128,14 +128,14 @@ namespace lar_pandora {
 
   inline float VintageLArTPCThreeView::WirePitchU() const
   {
-    return m_wireReadoutGeom->Plane({0,0},TargetViewU(0,0)).WirePitch();
+    return m_wireReadoutGeom->Plane({0, 0}, TargetViewU(0, 0)).WirePitch();
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
   inline float VintageLArTPCThreeView::WirePitchV() const
   {
-    return m_wireReadoutGeom->Plane({0,0}, TargetViewV(0,0)).WirePitch();
+    return m_wireReadoutGeom->Plane({0, 0}, TargetViewV(0, 0)).WirePitch();
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -89,7 +89,7 @@ namespace lar_pandora {
       const double z0_cm(xyz.Z());
 
       // Get other hit properties here
-      const double wire_pitch_cm(wireReadoutGeom.Plane({0, 0, hit_View}).WirePitch()); // cm
+      const double wire_pitch_cm(wireReadoutGeom.Plane({0, 0}, hit_View).WirePitch()); // cm
       const double mips(LArPandoraInput::GetMips(detProp, settings, hit_Charge, hit_View));
 
       // Create Pandora CaloHit
@@ -792,7 +792,7 @@ namespace lar_pandora {
     auto const& wireReadoutGeom = art::ServiceHandle<geo::WireReadout const>()->Get();
 
     // TODO: Unite this procedure with other calorimetry procedures under development
-    const double dQdX(hit_Charge / (wireReadoutGeom.Plane({0, 0, hit_View}).WirePitch())); // ADC/cm
+    const double dQdX(hit_Charge / (wireReadoutGeom.Plane({0, 0}, hit_View).WirePitch())); // ADC/cm
     const double dQdX_e(dQdX /
                         (detProp.ElectronsToADC() * settings.m_recombination_factor)); // e/cm
     const double dEdX(settings.m_useBirksCorrection ?


### PR DESCRIPTION
In the V10 refactored geometry, there has been a pattern of finding the wire pitch by querying the WireReadoutGeometry to get a Plane from a PlaneID, and then querying that to get WirePitch. The issue is that forming the arguments to WireReadoutGeometry::Plane() by using a view instead of a plane number breaks when running ProtoDUNE-DP reconstruction. The views in PD-DP are numbered 2 and 3, but the planes have different numbers, and these lines throw exceptions. Fortunately there is a second way of getting a Plane out of WireReadoutGeometry once the view is known, and for the most part, it just involves moving a right-brace over. There are four instances here in larpandora.  These fixes are similar to those in https://github.com/LArSoft/larreco/pull/73  though they can be merged independently. Both need to be merged for the ProtoDUNE-DP reco CI test to succeed, and they ought not to break other CI tests.