### PR TITLE
Add nuance code for supernova neutrinos

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -418,7 +418,10 @@ namespace lar_pandora {
         lar_content::LArMCParticleParameters mcParticleParameters;
 
         try {
-          mcParticleParameters.m_nuanceCode = neutrino.InteractionType();
+          if (truth->Origin() == simb::kSuperNovaNeutrino)
+            mcParticleParameters.m_nuanceCode = 4000;
+          else
+            mcParticleParameters.m_nuanceCode = neutrino.InteractionType();
           mcParticleParameters.m_process = lar_content::MC_PROC_INCIDENT_NU;
           mcParticleParameters.m_energy = neutrino.Nu().E();
           mcParticleParameters.m_momentum =
@@ -544,6 +547,9 @@ namespace lar_pandora {
       }
       else if (simb::kSingleParticle == origin) {
         nuanceCode = 2000;
+      }
+      else if (simb::kSuperNovaNeutrino == origin) {
+        nuanceCode = 4000;
       }
 
       // Create 3D Pandora MC Particle


### PR DESCRIPTION
Pandora uses the nuance code in some decision making e.g. does this particle come from a neutrino interaction or a cosmic ray. MARLEY sets nuance codes to 0, which breaks a lot of the logic in the decision making. This update adds an override to Pandora's internal nuance code override for supernova origin particles (code==4000).