### PR TITLE
Fix call to WireReadoutGeom::Plane

### DIFF
--- a/larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h
+++ b/larpandora/LArPandoraInterface/Detectors/VintageLArTPCThreeView.h
@@ -142,7 +142,7 @@ namespace lar_pandora {
 
   inline float VintageLArTPCThreeView::WirePitchW() const
   {
-    return m_wireReadoutGeom->Plane({0, 0, TargetViewW(0, 0)}).WirePitch();
+    return m_wireReadoutGeom->Plane({0, 0}, TargetViewW(0, 0)).WirePitch();
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a CI issue encountered by https://github.com/SBNSoftware/icaruscode/pull/642.