### PR TITLE
feature/larpandora_v10_00_28

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -413,10 +413,10 @@ namespace ShowerRecoTools {
 
       //Always override previous results
       //This will keep the previous result only if the current tool fails on all planes
-      case 0:
+      case 0: {
 
         if (fVerbose > 1) {
-          std::cout << "Always overriding the previous result." << std::endl;
+          std::cout << "Always overriding the previous result" << std::endl;
         } 
 
         ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
@@ -424,12 +424,13 @@ namespace ShowerRecoTools {
         ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
 
         break;
+      }
 
       //Override plane-by-plane
-      case 1:
+      case 1: {
 
         if (fVerbose > 1) {
-          std::cout << "Overriding the previous result plane-by-plane." << std::endl;
+          std::cout << "Overriding the previous result plane-by-plane" << std::endl;
         } 
 
         std::vector<double> dEdx_val_overriddenPerPlane(dEdx_val);
@@ -452,12 +453,13 @@ namespace ShowerRecoTools {
         ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
         ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
         break;
+      }
 
       //Override only if all three planes are well-defined
-      case 2:
+      case 2: {
 
         if (fVerbose > 1) {
-          std::cout << "Only overriding if all three planes are well-defined." << std::endl;
+          std::cout << "Only overriding if all three planes are well-defined" << std::endl;
         } 
 
         if (dEdx_val[0] > 0. &&
@@ -474,6 +476,7 @@ namespace ShowerRecoTools {
         }
 
         break;
+      }
     }
     
     return 0;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -66,15 +66,18 @@ namespace ShowerRecoTools {
     bool fUseMedian;        //Use the median value as the dEdx rather than the mean.
     bool fCutStartPosition; //Remove hits using MinDistCutOff from the vertex as well.
 
-    bool fT0Correct;       // Whether to look for a T0 associated to the PFP
-    bool fSCECorrectPitch; // Whether to correct the "squeezing" of pitch, requires corrected input
+    bool fT0Correct;       //Whether to look for a T0 associated to the PFP
+    bool fSCECorrectPitch; //Whether to correct the "squeezing" of pitch, requires corrected input
     bool
-      fSCECorrectEField;   // Whether to use the local electric field, from SpaceChargeService, in recombination calc.
+      fSCECorrectEField;   //Whether to use the local electric field, from SpaceChargeService, in recombination calc.
     bool
-      fSCEInputCorrected;  // Whether the input has already been corrected for spatial SCE distortions
+      fSCEInputCorrected;  //Whether the input has already been corrected for spatial SCE distortions
 
-    bool fSumHitSnippets;  // Whether to treat hits individually or only one hit per snippet
-    bool fOverrideByPlane; // Whether to override plane-by-plane the results from a previous tool writing on the same label
+    bool fSumHitSnippets;      //Whether to treat hits individually or only one hit per snippet
+    int fResultsOverrideMode;  //How results from a previous tool writing on the same tool are overridden
+    //0: always override previous results
+    //1: override plane-by-plane
+    //2: override only if all three planes are well-defined
 
     art::InputTag fPFParticleLabel;
     int fVerbose;
@@ -104,7 +107,7 @@ namespace ShowerRecoTools {
     , fSCECorrectEField(pset.get<bool>("SCECorrectEField"))
     , fSCEInputCorrected(pset.get<bool>("SCEInputCorrected"))
     , fSumHitSnippets(pset.get<bool>("SumHitSnippets"))
-    , fOverrideByPlane(pset.get<bool>("OverrideByPlane"))
+    , fResultsOverrideMode(pset.get<int>("ResultsOverrideMode"))
     , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
     , fVerbose(pset.get<int>("Verbose"))
     , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
@@ -395,47 +398,84 @@ namespace ShowerRecoTools {
       }
     }
 
-    //Override the tool result plane-by-plane
-    if (fOverrideByPlane) {
+    //Get results from the same label, if set by a previous tool of the same type
+    std::vector<double> dEdx_val_previousTool;
+    ShowerEleHolder.GetElement(fShowerdEdxOutputLabel, dEdx_val_previousTool);
+    if (fVerbose > 2) {
+      std::cout << "Result from previous dEdx tool..." << std::endl;
+      for (unsigned int plane = 0; plane < dEdx_val_previousTool.size(); plane++) {
+        std::cout << "Plane: " << plane << " with dEdx: " << dEdx_val_previousTool[plane] << std::endl;
+      }
+    } 
 
-      //Get results from the same label, if set by a previous tool of the same type
-      std::vector<double> dEdx_val_previousTool;
-      ShowerEleHolder.GetElement(fShowerdEdxOutputLabel, dEdx_val_previousTool);
-      if (fVerbose > 2) {
-        std::cout << "Result from previous dEdx tool..." << std::endl;
-        for (unsigned int plane = 0; plane < dEdx_val_previousTool.size(); plane++) {
-          std::cout << "Plane: " << plane << " with dEdx: " << dEdx_val_previousTool[plane] << std::endl;
-        }
-      } 
+    //Choose how to override results from the previous tool
+    switch (fResultsOverrideMode) {
 
-      std::vector<double> dEdx_val_overriddenPerPlane(dEdx_val);
+      //Always override previous results
+      //This will keep the previous result only if the current tool fails on all planes
+      case 0:
 
-      for (unsigned int plane = 0; plane < dEdx_val.size(); plane++) {
-        //If the current tool fails, just retain plane-by-plane the result from the previous tool
-        if (dEdx_val[plane] < 0.) {
-          dEdx_val_overriddenPerPlane[plane] = dEdx_val_previousTool[plane];
-          if (fVerbose > 2) {
-            std::cout << "This tool failed in plane " << plane << " and I am keeping the previous value" << std::endl;
-            std::cout << "Current value: " << dEdx_val[plane] << std::endl;
-            std::cout << "Chosen value:  " << dEdx_val_overriddenPerPlane[plane] << std::endl;
+        if (fVerbose > 1) {
+          std::cout << "Always overriding the previous result." << std::endl;
+        } 
+
+        ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
+        ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+        ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+
+        break;
+
+      //Override plane-by-plane
+      case 1:
+
+        if (fVerbose > 1) {
+          std::cout << "Overriding the previous result plane-by-plane." << std::endl;
+        } 
+
+        std::vector<double> dEdx_val_overriddenPerPlane(dEdx_val);
+        for (unsigned int plane = 0; plane < dEdx_val.size(); plane++) {
+          //If the current tool fails, just retain plane-by-plane the result from the previous tool
+          if (dEdx_val[plane] < 0.) {
+            dEdx_val_overriddenPerPlane[plane] = dEdx_val_previousTool[plane];
+            if (fVerbose > 2) {
+              std::cout << "This tool failed in plane " << plane << " and I am keeping the previous value" << std::endl;
+              std::cout << "Current value: " << dEdx_val[plane] << std::endl;
+              std::cout << "Chosen value:  " << dEdx_val_overriddenPerPlane[plane] << std::endl;
+            }
+          }
+          else {
+            dEdx_val_overriddenPerPlane[plane] = dEdx_val[plane];
           }
         }
-        else {
-          dEdx_val_overriddenPerPlane[plane] = dEdx_val[plane];
+
+        ShowerEleHolder.SetElement(dEdx_val_overriddenPerPlane, dEdx_valErr, fShowerdEdxOutputLabel);
+        ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+        ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+        break;
+
+      //Override only if all three planes are well-defined
+      case 2:
+
+        if (fVerbose > 1) {
+          std::cout << "Only overriding if all three planes are well-defined." << std::endl;
+        } 
+
+        if (dEdx_val[0] > 0. &&
+            dEdx_val[1] > 0. &&
+            dEdx_val[2] > 0.) {
+          ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
+          ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+          ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
         }
-      }
+        else {
+          ShowerEleHolder.SetElement(dEdx_val_previousTool, dEdx_valErr, fShowerdEdxOutputLabel);
+          ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+          ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);  
+        }
 
-      //Need to sort out errors sensibly.
-      ShowerEleHolder.SetElement(dEdx_val_overriddenPerPlane, dEdx_valErr, fShowerdEdxOutputLabel);
-      ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
-      ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
-      return 0;
+        break;
     }
-
-    //Need to sort out errors sensibly.
-    ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
-    ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
-    ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+    
     return 0;
   }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -69,11 +69,12 @@ namespace ShowerRecoTools {
     bool fT0Correct;       // Whether to look for a T0 associated to the PFP
     bool fSCECorrectPitch; // Whether to correct the "squeezing" of pitch, requires corrected input
     bool
-      fSCECorrectEField; // Whether to use the local electric field, from SpaceChargeService, in recombination calc.
+      fSCECorrectEField;   // Whether to use the local electric field, from SpaceChargeService, in recombination calc.
     bool
-      fSCEInputCorrected; // Whether the input has already been corrected for spatial SCE distortions
+      fSCEInputCorrected;  // Whether the input has already been corrected for spatial SCE distortions
 
-    bool fSumHitSnippets; // Whether to treat hits individually or only one hit per snippet
+    bool fSumHitSnippets;  // Whether to treat hits individually or only one hit per snippet
+    bool fOverrideByPlane; // Whether to override plane-by-plane the results from a previous tool writing on the same label
 
     art::InputTag fPFParticleLabel;
     int fVerbose;
@@ -103,6 +104,7 @@ namespace ShowerRecoTools {
     , fSCECorrectEField(pset.get<bool>("SCECorrectEField"))
     , fSCEInputCorrected(pset.get<bool>("SCEInputCorrected"))
     , fSumHitSnippets(pset.get<bool>("SumHitSnippets"))
+    , fOverrideByPlane(pset.get<bool>("OverrideByPlane"))
     , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
     , fVerbose(pset.get<int>("Verbose"))
     , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
@@ -391,6 +393,43 @@ namespace ShowerRecoTools {
           }
         }
       }
+    }
+
+    //Override the tool result plane-by-plane
+    if (fOverrideByPlane) {
+
+      //Get results from the same label, if set by a previous tool of the same type
+      std::vector<double> dEdx_val_previousTool;
+      ShowerEleHolder.GetElement(fShowerdEdxOutputLabel, dEdx_val_previousTool);
+      if (fVerbose > 2) {
+        std::cout << "Result from previous dEdx tool..." << std::endl;
+        for (unsigned int plane = 0; plane < dEdx_val_previousTool.size(); plane++) {
+          std::cout << "Plane: " << plane << " with dEdx: " << dEdx_val_previousTool[plane] << std::endl;
+        }
+      } 
+
+      std::vector<double> dEdx_val_overriddenPerPlane(dEdx_val);
+
+      for (unsigned int plane = 0; plane < dEdx_val.size(); plane++) {
+        //If the current tool fails, just retain plane-by-plane the result from the previous tool
+        if (dEdx_val[plane] < 0.) {
+          dEdx_val_overriddenPerPlane[plane] = dEdx_val_previousTool[plane];
+          if (fVerbose > 2) {
+            std::cout << "This tool failed in plane " << plane << " and I am keeping the previous value" << std::endl;
+            std::cout << "Current value: " << dEdx_val[plane] << std::endl;
+            std::cout << "Chosen value:  " << dEdx_val_overriddenPerPlane[plane] << std::endl;
+          }
+        }
+        else {
+          dEdx_val_overriddenPerPlane[plane] = dEdx_val[plane];
+        }
+      }
+
+      //Need to sort out errors sensibly.
+      ShowerEleHolder.SetElement(dEdx_val_overriddenPerPlane, dEdx_valErr, fShowerdEdxOutputLabel);
+      ShowerEleHolder.SetElement(best_plane, fShowerBestPlaneOutputLabel);
+      ShowerEleHolder.SetElement(dEdx_vec_cut, fShowerdEdxVecOutputLabel);
+      return 0;
     }
 
     //Need to sort out errors sensibly.

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -289,7 +289,7 @@ showertrajpointdedx:{
     SCECorrectEField:     false
     SCEInputCorrected:    false
     SumHitSnippets:       false
-    OverrideByPlane:      false
+    ResultsOverrideMode:  0
     # PFParticleLabel: "pandora"
     ShowerStartPositionInputLabel: "ShowerStartPosition"
     InitialTrackSpacePointsInputLabel: "InitialTrackSpacePoints"

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -288,7 +288,8 @@ showertrajpointdedx:{
     SCECorrectPitch:      false
     SCECorrectEField:     false
     SCEInputCorrected:    false
-    SumHitSnippets: false
+    SumHitSnippets:       false
+    OverrideByPlane:      false
     # PFParticleLabel: "pandora"
     ShowerStartPositionInputLabel: "ShowerStartPosition"
     InitialTrackSpacePointsInputLabel: "InitialTrackSpacePoints"


### PR DESCRIPTION
This update for larpandora v10_00_28 contains an update that permits plane-by-plane selection of the shower dE/dx tool results. A FHiCL parameter controls the behaviour, with the default mode retaining the existing behaviour (override only if failures on all planes), and therefore no product changes are expected at this time.