### PR TITLE
Initialize pointer to null to silence GCC 12.5 warning

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerDirectionCheater_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/Cheating/ShowerDirectionCheater_tool.cc
@@ -79,7 +79,7 @@ namespace ShowerRecoTools {
                                                reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
 
-    const simb::MCParticle* trueParticle;
+    const simb::MCParticle* trueParticle{nullptr};
 
     //Get the hits from the shower:
     auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);


### PR DESCRIPTION
The pointer is eventually set by a method, but initializing it to `nullptr` silences a warning from GCC 12.5 during a Spack build.