### PR TITLE
feature/sbnd_unique_mc

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -848,8 +848,7 @@ namespace lar_pandora {
       throw cet::exception("LArPandora") << " PandoraCollector::CollectGeneratorMCParticles --- "
                                             "Unexpected number of MC truth blocks ";
 
-    for (size_t b = 0; b < mcTruthBlocks->size(); ++b)
-    {
+    for (size_t b = 0; b < mcTruthBlocks->size(); ++b) {
       const art::Ptr<simb::MCTruth> mcTruth(mcTruthBlocks, b);
       for (int i = 0; i < mcTruth->NParticles(); ++i) {
         particleVector.push_back(mcTruth->GetParticle(i));

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -844,14 +844,16 @@ namespace lar_pandora {
                                  << std::endl;
     }
 
-    if (mcTruthBlocks->size() != 1)
+    if (mcTruthBlocks->size() < 1)
       throw cet::exception("LArPandora") << " PandoraCollector::CollectGeneratorMCParticles --- "
                                             "Unexpected number of MC truth blocks ";
 
-    const art::Ptr<simb::MCTruth> mcTruth(mcTruthBlocks, 0);
-
-    for (int i = 0; i < mcTruth->NParticles(); ++i) {
-      particleVector.push_back(mcTruth->GetParticle(i));
+    for (size_t b = 0; b < mcTruthBlocks->size(); ++b)
+    {
+      const art::Ptr<simb::MCTruth> mcTruth(mcTruthBlocks, b);
+      for (int i = 0; i < mcTruth->NParticles(); ++i) {
+        particleVector.push_back(mcTruth->GetParticle(i));
+      }
     }
   }
 

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -466,7 +466,7 @@ namespace lar_pandora {
           const int trackID(particle->TrackId());
 
           // Mother/Daughter Links
-          if (particle->Mother() == 0) {
+          if (particle->Mother() == 0 || particle->Process() == "primary") {
             try {
               PANDORA_THROW_RESULT_IF(
                 pandora::STATUS_CODE_SUCCESS,
@@ -492,7 +492,7 @@ namespace lar_pandora {
     int particleCounter(0);
 
     // Find Primary Generator Particles
-    std::map<const simb::MCParticle, bool> primaryGeneratorMCParticleMap;
+    std::map<const simb::MCParticle, bool, MCParticleCompare> primaryGeneratorMCParticleMap;
     LArPandoraInput::FindPrimaryParticles(generatorMCParticleVector, primaryGeneratorMCParticleMap);
 
     for (MCParticleMap::const_iterator iterI = particleMap.begin(), iterEndI = particleMap.end();
@@ -565,7 +565,7 @@ namespace lar_pandora {
         else {
           mcParticleParameters.m_process = lar_content::MC_PROC_UNKNOWN;
           mf::LogWarning("LArPandora")
-            << "CreatePandoraMCParticles - found an unknown process" << std::endl;
+            << "CreatePandoraMCParticles - found an unknown process: " << particle->Process() << std::endl;
         }
         mcParticleParameters.m_energy = E;
         mcParticleParameters.m_particleId = particle->PdgCode();
@@ -624,7 +624,7 @@ namespace lar_pandora {
 
   void LArPandoraInput::FindPrimaryParticles(
     const RawMCParticleVector& mcParticleVector,
-    std::map<const simb::MCParticle, bool>& primaryMCParticleMap)
+    std::map<const simb::MCParticle, bool, MCParticleCompare>& primaryMCParticleMap)
   {
     for (const simb::MCParticle& mcParticle : mcParticleVector) {
       if ("primary" == mcParticle.Process()) {
@@ -637,7 +637,7 @@ namespace lar_pandora {
 
   bool LArPandoraInput::IsPrimaryMCParticle(
     const art::Ptr<simb::MCParticle>& mcParticle,
-    std::map<const simb::MCParticle, bool>& primaryMCParticleMap)
+    std::map<const simb::MCParticle, bool, MCParticleCompare>& primaryMCParticleMap)
   {
     for (auto& mcParticleIter : primaryMCParticleMap) {
       if (!mcParticleIter.second) {
@@ -867,6 +867,7 @@ namespace lar_pandora {
     processMap["muonNuclear"] = lar_content::MC_PROC_MU_NUCLEAR;
     processMap["tInelastic"] = lar_content::MC_PROC_TRITON_INELASTIC;
     processMap["primaryBackground"] = lar_content::MC_PROC_PRIMARY_BACKGROUND;
+    processMap["RadioactiveDecayBase"] = lar_content::MC_PROC_RADIOACTIVE_DECAY_BASE;
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -565,7 +565,8 @@ namespace lar_pandora {
         else {
           mcParticleParameters.m_process = lar_content::MC_PROC_UNKNOWN;
           mf::LogWarning("LArPandora")
-            << "CreatePandoraMCParticles - found an unknown process: " << particle->Process() << std::endl;
+            << "CreatePandoraMCParticles - found an unknown process: " << particle->Process()
+            << std::endl;
         }
         mcParticleParameters.m_energy = E;
         mcParticleParameters.m_particleId = particle->PdgCode();

--- a/larpandora/LArPandoraInterface/LArPandoraInput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.h
@@ -17,11 +17,30 @@ namespace detinfo {
 
 #include "larpandoracontent/LArObjects/LArMCParticle.h"
 
+#include <tuple>
+
 namespace pandora {
   class Pandora;
 }
 
 namespace lar_pandora {
+
+  struct MCParticleCompare {
+    bool operator()(const simb::MCParticle &lhs, const simb::MCParticle &rhs) const
+    {
+      const int lhsId{lhs.TrackId()}, rhsId{rhs.TrackId()};
+      const int lhsPdg{lhs.PdgCode()}, rhsPdg{rhs.PdgCode()};
+      const double lhsE{lhs.E()}, rhsE{rhs.E()};
+      const double lhsVx{lhs.Vx()}, rhsVx{rhs.Vx()};
+      const double lhsVy{lhs.Vy()}, rhsVy{rhs.Vy()};
+      const double lhsVz{lhs.Vz()}, rhsVz{rhs.Vz()};
+      const double lhsPx{lhs.Px()}, rhsPx{rhs.Px()};
+      const double lhsPy{lhs.Py()}, rhsPy{rhs.Py()};
+      const double lhsPz{lhs.Pz()}, rhsPz{rhs.Pz()};
+      return std::tie(lhsId, lhsPdg, lhsE, lhsVx, lhsVy, lhsVz, lhsPx, lhsPy, lhsPz) <
+        std::tie(rhsId, rhsPdg, rhsE, rhsVx, rhsVy, rhsVz, rhsPx, rhsPy, rhsPz);
+    }
+ };
 
   /**
  *  @brief  LArPandoraInput class
@@ -117,7 +136,7 @@ namespace lar_pandora {
      *  @param primaryMCParticleMap map containing primary MCParticles and bool indicating whether particle has been accounted for
      */
     static void FindPrimaryParticles(const RawMCParticleVector& mcParticleVector,
-                                     std::map<const simb::MCParticle, bool>& primaryMCParticleMap);
+                                     std::map<const simb::MCParticle, bool, MCParticleCompare>& primaryMCParticleMap);
 
     /**
      *  @brief Check whether an MCParticle can be found in a given map
@@ -126,7 +145,7 @@ namespace lar_pandora {
      *  @param primaryMCParticleMap map containing primary MCParticles and bool indicating whether particle has been accounted for
      */
     static bool IsPrimaryMCParticle(const art::Ptr<simb::MCParticle>& mcParticle,
-                                    std::map<const simb::MCParticle, bool>& primaryMCParticleMap);
+                                    std::map<const simb::MCParticle, bool, MCParticleCompare>& primaryMCParticleMap);
 
     /**
      *  @brief  Create links between the 2D hits and Pandora MC particles

--- a/larpandora/LArPandoraInterface/LArPandoraInput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.h
@@ -26,7 +26,7 @@ namespace pandora {
 namespace lar_pandora {
 
   struct MCParticleCompare {
-    bool operator()(const simb::MCParticle &lhs, const simb::MCParticle &rhs) const
+    bool operator()(const simb::MCParticle& lhs, const simb::MCParticle& rhs) const
     {
       const int lhsId{lhs.TrackId()}, rhsId{rhs.TrackId()};
       const int lhsPdg{lhs.PdgCode()}, rhsPdg{rhs.PdgCode()};
@@ -38,9 +38,9 @@ namespace lar_pandora {
       const double lhsPy{lhs.Py()}, rhsPy{rhs.Py()};
       const double lhsPz{lhs.Pz()}, rhsPz{rhs.Pz()};
       return std::tie(lhsId, lhsPdg, lhsE, lhsVx, lhsVy, lhsVz, lhsPx, lhsPy, lhsPz) <
-        std::tie(rhsId, rhsPdg, rhsE, rhsVx, rhsVy, rhsVz, rhsPx, rhsPy, rhsPz);
+             std::tie(rhsId, rhsPdg, rhsE, rhsVx, rhsVy, rhsVz, rhsPx, rhsPy, rhsPz);
     }
- };
+  };
 
   /**
  *  @brief  LArPandoraInput class
@@ -135,8 +135,9 @@ namespace lar_pandora {
      *  @param mcParticleVector vector of all MCParticles to consider
      *  @param primaryMCParticleMap map containing primary MCParticles and bool indicating whether particle has been accounted for
      */
-    static void FindPrimaryParticles(const RawMCParticleVector& mcParticleVector,
-                                     std::map<const simb::MCParticle, bool, MCParticleCompare>& primaryMCParticleMap);
+    static void FindPrimaryParticles(
+      const RawMCParticleVector& mcParticleVector,
+      std::map<const simb::MCParticle, bool, MCParticleCompare>& primaryMCParticleMap);
 
     /**
      *  @brief Check whether an MCParticle can be found in a given map
@@ -144,8 +145,9 @@ namespace lar_pandora {
      *  @param mcParticle target MCParticle
      *  @param primaryMCParticleMap map containing primary MCParticles and bool indicating whether particle has been accounted for
      */
-    static bool IsPrimaryMCParticle(const art::Ptr<simb::MCParticle>& mcParticle,
-                                    std::map<const simb::MCParticle, bool, MCParticleCompare>& primaryMCParticleMap);
+    static bool IsPrimaryMCParticle(
+      const art::Ptr<simb::MCParticle>& mcParticle,
+      std::map<const simb::MCParticle, bool, MCParticleCompare>& primaryMCParticleMap);
 
     /**
      *  @brief  Create links between the 2D hits and Pandora MC particles


### PR DESCRIPTION
Please note that this PR depends upon [larpandoracontent PR 83](https://github.com/LArSoft/larpandoracontent/pull/83).

For SBND, the presence of multiple MC truth blocks causes a problem for Pandora's internal truth matching when inserting simb::MCParticles into maps, because the operator< function uses track ID, which is no longer globally unique. This results in mismatches between reco hits and MC truth. This PR introduces a bespoke comparator to use with ordered collections to ensure uniqueness (by using track ID, PDG code, energy, vertex and momentum). It tangentially adds an extra radiologicial decay process to the set of MC processes Pandora recognises.

No product changes are expected.