### PR TITLE
Norm Tools in Shower dEdx/Energy Tools

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/CMakeLists.txt
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/CMakeLists.txt
@@ -167,6 +167,8 @@ cet_build_plugin(ShowerUnidirectiondEdx larpandora::ShowerTool
   larreco::Calorimetry
   lardata::DetectorClocksService
   lardata::DetectorPropertiesService
+  larpandora::LArPandoraInterface
+
 )
 
 add_subdirectory(Cheating)

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/CMakeLists.txt
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/CMakeLists.txt
@@ -69,6 +69,7 @@ cet_build_plugin(ShowerNumElectronsEnergy larpandora::ShowerTool
   larreco::Calorimetry
   lardataobj::RecoBase
   larcoreobj::headers
+  larpandora::LArPandoraInterface
 )
 
 cet_build_plugin(ShowerPCADirection larpandora::ShowerTool

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerNumElectronsEnergy_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerNumElectronsEnergy_tool.cc
@@ -21,8 +21,16 @@
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "larreco/Calorimetry/CalorimetryAlg.h"
 
+// For Calorimetry normalization
+#include "art/Utilities/make_tool.h"
+#include "larreco/Calorimetry/INormalizeCharge.h"
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
+#include "lardataobj/RecoBase/SpacePoint.h"
+
 //C++ Includes
 #include <tuple>
+
+using namespace lar_pandora;
 
 namespace ShowerRecoTools {
 
@@ -40,7 +48,19 @@ namespace ShowerRecoTools {
     double CalculateEnergy(const detinfo::DetectorClocksData& clockData,
                            const detinfo::DetectorPropertiesData& detProp,
                            const std::vector<art::Ptr<recob::Hit>>& hits,
-                           const geo::PlaneID::PlaneID_t plane) const;
+                           const geo::PlaneID::PlaneID_t plane,
+                           const art::Event& Event,  
+                           const bool applyNormalization,
+                           const HitsToSpacePoints& hitsToSpacePoints,
+                           const geo::Vector_t& showerPCADir) const;
+
+    // Normalization function
+    double Normalize(const double dQdx,
+		     const art::Event& e,
+		     const recob::Hit& h,
+		     const geo::Point_t& location,
+		     const geo::Vector_t& direction,
+		     const double t0) const;
 
     art::InputTag fPFParticleLabel;
     int fVerbose;
@@ -48,12 +68,16 @@ namespace ShowerRecoTools {
     std::string fShowerEnergyOutputLabel;
     std::string fShowerBestPlaneOutputLabel;
 
+    std::vector< std::unique_ptr<INormalizeCharge> > fNormalizationTools;
+
     //Services
     geo::WireReadoutGeom const& fChannelMap = art::ServiceHandle<geo::WireReadout>()->Get();
     calo::CalorimetryAlg fCalorimetryAlg;
 
     // Declare stuff
     double fRecombinationFactor;
+    bool fApplyCorrectionsInNorm; // Whether to instead apply calorimetry corrections in norm.
+
   };
 
   ShowerNumElectronsEnergy::ShowerNumElectronsEnergy(const fhicl::ParameterSet& pset)
@@ -64,7 +88,19 @@ namespace ShowerRecoTools {
     , fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel"))
     , fCalorimetryAlg(pset.get<fhicl::ParameterSet>("CalorimetryAlg"))
     , fRecombinationFactor(pset.get<double>("RecombinationFactor"))
-  {}
+    , fApplyCorrectionsInNorm(pset.get<bool>("ApplyCorrectionsInNorm"))
+  {
+    if ( fApplyCorrectionsInNorm ) {
+      auto tool_psets = pset.get< std::vector< fhicl::ParameterSet > >("NormTools");
+
+      int tCounter = 0;
+      for ( auto const& tool_pset : tool_psets ) {
+        //std::cout << "pushing back tools..." << tCounter << std::endl;
+        tCounter++;
+	      fNormalizationTools.push_back( art::make_tool<INormalizeCharge>(tool_pset) );
+      }
+    }
+  }
 
   int ShowerNumElectronsEnergy::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
                                                  art::Event& Event,
@@ -82,6 +118,9 @@ namespace ShowerRecoTools {
     //Get the clusters
     auto const clusHandle = Event.getValidHandle<std::vector<recob::Cluster>>(fPFParticleLabel);
 
+    geo::Vector_t showerPCADir = {-999, -999, -999};
+    ShowerEleHolder.GetElement("ShowerDirection", showerPCADir);
+
     const art::FindManyP<recob::Cluster>& fmc =
       ShowerEleHolder.GetFindManyP<recob::Cluster>(pfpHandle, Event, fPFParticleLabel);
     // art::FindManyP<recob::Cluster> fmc(pfpHandle, Event, fPFParticleLabel);
@@ -93,6 +132,16 @@ namespace ShowerRecoTools {
     // art::FindManyP<recob::Hit> fmhc(clusHandle, Event, fPFParticleLabel);
 
     std::map<geo::PlaneID::PlaneID_t, std::vector<art::Ptr<recob::Hit>>> planeHits;
+
+
+    SpacePointVector spacePointVector;
+    SpacePointsToHits spacePointsToHits;
+    HitsToSpacePoints hitsToSpacePoints;
+    LArPandoraHelper::CollectSpacePoints(Event, fPFParticleLabel.label(), spacePointVector, spacePointsToHits, hitsToSpacePoints);
+
+    // Setup normalization tools
+    for (auto const& nt : fNormalizationTools)
+      nt->setup(Event);
 
     //Loop over the clusters in the plane and get the hits
     for (auto const& cluster : clusters) {
@@ -124,7 +173,8 @@ namespace ShowerRecoTools {
       unsigned int planeNumHits = hits.size();
 
       //Calculate the Energy for
-      double Energy = CalculateEnergy(clockData, detProp, hits, plane);
+      double Energy = CalculateEnergy(clockData, detProp, hits, plane, Event, fApplyCorrectionsInNorm, hitsToSpacePoints, showerPCADir);
+
       // If the energy is negative, leave it at -999
       if (Energy > 0) energyVec.at(plane) = Energy;
 
@@ -150,27 +200,81 @@ namespace ShowerRecoTools {
   double ShowerNumElectronsEnergy::CalculateEnergy(const detinfo::DetectorClocksData& clockData,
                                                    const detinfo::DetectorPropertiesData& detProp,
                                                    const std::vector<art::Ptr<recob::Hit>>& hits,
-                                                   const geo::PlaneID::PlaneID_t plane) const
+                                                   const geo::PlaneID::PlaneID_t plane,
+                                                   const art::Event& Event,
+                                                   const bool applyNormalization = false,
+                                                   const HitsToSpacePoints& hitsToSpacePoints = HitsToSpacePoints{},
+                                                   const geo::Vector_t& showerPCADir = geo::Vector_t{0, 0, 0}) const
   {
+
+    if (applyNormalization && hitsToSpacePoints.empty()) {
+      if (fVerbose) {
+          mf::LogError("ShowerNumElectronsEnergy") << "No hits to space points mapping provided, returning " << std::endl;
+      }
+      return 1;
+    }
 
     double totalCharge = 0;
     double totalEnergy = 0;
     double correctedtotalCharge = 0;
     double nElectrons = 0;
+    double totalChargePos = 0;
+    geo::Point_t chargeWeightedPosition = {0, 0, 0}; // Initialize charge weighted position
 
     for (auto const& hit : hits) {
       totalCharge +=
         hit->Integral() *
         fCalorimetryAlg.LifetimeCorrection(
           clockData, detProp, hit->PeakTime()); // obtain charge and correct for lifetime
+        
+          if ( applyNormalization ) {
+            HitsToSpacePoints::const_iterator hIter = hitsToSpacePoints.find(hit);
+            if (hitsToSpacePoints.end() != hIter){
+              const art::Ptr<recob::SpacePoint> spacepoint = hIter->second;            
+              auto const& pos = spacepoint->position();  // this is a geo::Point_t
+              chargeWeightedPosition += geo::Vector_t{pos.X(), pos.Y(), pos.Z()} * hit->Integral();
+              totalChargePos += hit->Integral(); // Accumulate total charge
+            }
+        }
     }
 
     // correct charge due to recombination
     correctedtotalCharge = totalCharge / fRecombinationFactor;
+
+    //std::cout << "Applying normalization: " << applyNormalization << std::endl;
+
+    // apply normalization if needed
+    if ( applyNormalization && hits.size() > 0 ) {
+      //std::cout << "\t" << "Total charge before norm: " << correctedtotalCharge << std::endl;
+      if (totalChargePos > 0) chargeWeightedPosition /= totalChargePos; // Normalize by total charge
+      correctedtotalCharge = Normalize( correctedtotalCharge,
+        Event,
+        *hits.at(0),
+        chargeWeightedPosition,
+        showerPCADir,
+        0 );
+      //std::cout << "\t" << "Total charge after norm: " << correctedtotalCharge << std::endl;
+    }
     // calculate # of electrons and the corresponding energy
     nElectrons = fCalorimetryAlg.ElectronsFromADCArea(correctedtotalCharge, plane);
     totalEnergy = (nElectrons / util::kGeVToElectrons) * 1000; // energy in MeV
     return totalEnergy;
+  }
+
+  double ShowerNumElectronsEnergy::Normalize(const double dQdx,
+					const art::Event& e,
+					const recob::Hit& h,
+					const geo::Point_t& location,
+					const geo::Vector_t& direction,
+					const double t0) const
+  {
+    double ret = dQdx;
+    for (auto const& nt : fNormalizationTools) {
+      ret = nt->Normalize(ret, e, h, location, direction, t0);
+      //std::cout << "\t norm: dQdx = " << ret << std::endl;
+    }
+    
+    return ret;
   }
 }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -339,14 +339,15 @@ namespace ShowerRecoTools {
         localEField = IShowerTool::GetLArPandoraShowerAlg().SCECorrectEField(localEField, pos);
       }
 
-      // Attempt the normalization
+      // Attempt the normalization //Ivan
       if ( fApplyCorrectionsInNorm ) {
-	dQdx = Normalize( dQdx,
-			  Event,
-			  *hit,
-			  InitialTrack.LocationAtPoint(index),
-			  InitialTrack.DirectionAtPoint(index),
-			  pfpT0Time );
+        //std::cout << "Running the CorrectionsInNorm for showers" << std::endl;
+	      dQdx = Normalize( dQdx,
+			    Event,
+			    *hit,
+			    InitialTrack.LocationAtPoint(index),
+			    InitialTrack.DirectionAtPoint(index),
+			    pfpT0Time );
       }
 
       double dEdx = fCalorimetryAlg.dEdx_AREA(

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -137,8 +137,11 @@ namespace ShowerRecoTools {
     if ( fApplyCorrectionsInNorm ) {
       auto tool_psets = pset.get< std::vector< fhicl::ParameterSet > >("NormTools");
 
+      int tCounter = 0;
       for ( auto const& tool_pset : tool_psets ) {
-	fNormalizationTools.push_back( art::make_tool<INormalizeCharge>(tool_pset) );
+        std::cout << "pushing back tools..." << tCounter << std::endl;
+        tCounter++;
+	      fNormalizationTools.push_back( art::make_tool<INormalizeCharge>(tool_pset) );
       }
     }
   }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -49,12 +49,12 @@ namespace ShowerRecoTools {
 
   private:
     // Normalization function
-    double Normalize(double dQdx,
+    const double Normalize(const double dQdx,
 		     const art::Event& e,
 		     const recob::Hit& h,
 		     const geo::Point_t& location,
 		     const geo::Vector_t& direction,
-		     double t0);
+		     const double t0);
 
     //Servcies and Algorithms
     art::ServiceHandle<geo::Geometry> fGeom;
@@ -346,9 +346,10 @@ namespace ShowerRecoTools {
       }
 
       // Attempt the normalization //Ivan
+      double dQdxNorm = dQdx;
       if ( fApplyCorrectionsInNorm ) {
         //std::cout << "Running the CorrectionsInNorm for showers" << std::endl;
-	      dQdx = Normalize( dQdx,
+	      dQdxNorm = Normalize( dQdx,
 			    Event,
 			    *hit,
 			    InitialTrack.LocationAtPoint(index),
@@ -356,8 +357,10 @@ namespace ShowerRecoTools {
 			    pfpT0Time );
       }
 
+      std::cout << "Traj Point: dQdx: " << dQdx << " dQdxNorm: " << dQdxNorm << std::endl;
+
       double dEdx = fCalorimetryAlg.dEdx_AREA(
-        clockData, detProp, dQdx, hit->PeakTime(), planeid.Plane, pfpT0Time, localEField);
+        clockData, detProp, dQdxNorm, hit->PeakTime(), planeid.Plane, pfpT0Time, localEField);
 
       //Add the value to the dEdx
       dEdx_vec[planeid.Plane].push_back(dEdx);
@@ -433,10 +436,10 @@ namespace ShowerRecoTools {
     }
 
     // BH - test
-    std::cout << "--------------------------------------------------------------------" << std::endl;
-    std::cout << "  Init trk start (" << InitialTrack.Start().X() << ", " << InitialTrack.Start().Y() << ", " << InitialTrack.Start().Z() << ")" << std::endl;
-    std::cout << "  dE/dx on plane2: " << dEdx_val[2] << " MeV/cm" << std::endl;
-    std::cout << "--------------------------------------------------------------------" << std::endl;
+    // std::cout << "--------------------------------------------------------------------" << std::endl;
+    // std::cout << "  Init trk start (" << InitialTrack.Start().X() << ", " << InitialTrack.Start().Y() << ", " << InitialTrack.Start().Z() << ")" << std::endl;
+    // std::cout << "  dE/dx on plane2: " << dEdx_val[2] << " MeV/cm" << std::endl;
+    // std::cout << "--------------------------------------------------------------------" << std::endl;
     
     //Need to sort out errors sensibly.
     ShowerEleHolder.SetElement(dEdx_val, dEdx_valErr, fShowerdEdxOutputLabel);
@@ -541,16 +544,17 @@ namespace ShowerRecoTools {
     return;
   }
   
-  double ShowerTrajPointdEdx::Normalize(double dQdx,
+  const double ShowerTrajPointdEdx::Normalize(const double dQdx,
 					const art::Event& e,
 					const recob::Hit& h,
 					const geo::Point_t& location,
 					const geo::Vector_t& direction,
-					double t0)
+					const double t0)
   {
     double ret = dQdx;
     for (auto const& nt : fNormalizationTools) {
       ret = nt->Normalize(ret, e, h, location, direction, t0);
+      std::cout << "\t norm: dQdx = " << ret << std::endl;
     }
     
     return ret;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrajPointdEdx_tool.cc
@@ -139,7 +139,7 @@ namespace ShowerRecoTools {
 
       int tCounter = 0;
       for ( auto const& tool_pset : tool_psets ) {
-        std::cout << "pushing back tools..." << tCounter << std::endl;
+        //std::cout << "pushing back tools..." << tCounter << std::endl;
         tCounter++;
 	      fNormalizationTools.push_back( art::make_tool<INormalizeCharge>(tool_pset) );
       }
@@ -183,6 +183,10 @@ namespace ShowerRecoTools {
 
     // Get the spacepoints
     auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
+
+    // Setup normalization tools
+    for (auto const& nt : fNormalizationTools)
+      nt->setup(Event);
 
     // Get the hits associated with the space points
     const art::FindManyP<recob::Hit>& fmsp =
@@ -357,7 +361,7 @@ namespace ShowerRecoTools {
 			    pfpT0Time );
       }
 
-      std::cout << "Traj Point: dQdx: " << dQdx << " dQdxNorm: " << dQdxNorm << std::endl;
+      //std::cout << "Traj Point: dQdx: " << dQdx << " dQdxNorm: " << dQdxNorm << std::endl;
 
       double dEdx = fCalorimetryAlg.dEdx_AREA(
         clockData, detProp, dQdxNorm, hit->PeakTime(), planeid.Plane, pfpT0Time, localEField);
@@ -554,7 +558,7 @@ namespace ShowerRecoTools {
     double ret = dQdx;
     for (auto const& nt : fNormalizationTools) {
       ret = nt->Normalize(ret, e, h, location, direction, t0);
-      std::cout << "\t norm: dQdx = " << ret << std::endl;
+      //std::cout << "\t norm: dQdx = " << ret << std::endl;
     }
     
     return ret;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerUnidirectiondEdx_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerUnidirectiondEdx_tool.cc
@@ -18,6 +18,16 @@
 #include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
 #include "larreco/Calorimetry/CalorimetryAlg.h"
 
+// For Calorimetry normalization
+#include "art/Utilities/make_tool.h"
+#include "larreco/Calorimetry/INormalizeCharge.h"
+
+#include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
+#include "lardataobj/RecoBase/SpacePoint.h"
+#include "lardataobj/RecoBase/PFParticle.h"
+
+using namespace lar_pandora;
+
 namespace ShowerRecoTools {
 
   class ShowerUnidirectiondEdx : IShowerTool {
@@ -31,10 +41,21 @@ namespace ShowerRecoTools {
                          reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
   private:
+
+    // Normalization function
+    double Normalize(double dQdx,
+		     const art::Event& e,
+		     const recob::Hit& h,
+		     const geo::Point_t& location,
+		     const geo::Vector_t& direction,
+		     double t0);
+
     //Define the services and algorithms
     art::ServiceHandle<geo::Geometry> fGeom;
     geo::WireReadoutGeom const& fChannelMap = art::ServiceHandle<geo::WireReadout>()->Get();
     calo::CalorimetryAlg fCalorimetryAlg;
+
+    std::vector< std::unique_ptr<INormalizeCharge> > fNormalizationTools;
 
     //fcl parameters.
     int fVerbose;
@@ -43,11 +64,14 @@ namespace ShowerRecoTools {
     bool fMaxHitPlane;    //Set the best planes as the one with the most hits
     bool fMissFirstPoint; //Do not use any hits from the first wire.
     bool fSumHitSnippets; // Whether to treat hits individually or only one hit per snippet
+    bool fApplyCorrectionsInNorm; // Whether to instead apply calorimetry corrections in norm.
+
     std::string fShowerStartPositionInputLabel;
     std::string fInitialTrackHitsInputLabel;
     std::string fShowerDirectionInputLabel;
     std::string fShowerdEdxOutputLabel;
     std::string fShowerBestPlaneOutputLabel;
+    art::InputTag fPFParticleLabel;
   };
 
   ShowerUnidirectiondEdx::ShowerUnidirectiondEdx(const fhicl::ParameterSet& pset)
@@ -58,12 +82,27 @@ namespace ShowerRecoTools {
     , fMaxHitPlane(pset.get<bool>("MaxHitPlane"))
     , fMissFirstPoint(pset.get<bool>("MissFirstPoint"))
     , fSumHitSnippets(pset.get<bool>("SumHitSnippets"))
+    , fApplyCorrectionsInNorm(pset.get<bool>("ApplyCorrectionsInNorm"))
     , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
     , fInitialTrackHitsInputLabel(pset.get<std::string>("InitialTrackHitsInputLabel"))
+    //, fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel"))
     , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
     , fShowerdEdxOutputLabel(pset.get<std::string>("ShowerdEdxOutputLabel"))
     , fShowerBestPlaneOutputLabel(pset.get<std::string>("ShowerBestPlaneOutputLabel"))
-  {}
+    , fPFParticleLabel(pset.get<std::string>("PFParticleLabel"))
+
+  {
+    if ( fApplyCorrectionsInNorm ) {
+      auto tool_psets = pset.get< std::vector< fhicl::ParameterSet > >("NormTools");
+
+      int tCounter = 0;
+      for ( auto const& tool_pset : tool_psets ) {
+        std::cout << "pushing back tools..." << tCounter << std::endl;
+        tCounter++;
+	      fNormalizationTools.push_back( art::make_tool<INormalizeCharge>(tool_pset) );
+      }
+    }
+  }
 
   int ShowerUnidirectiondEdx::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
                                                art::Event& Event,
@@ -71,6 +110,12 @@ namespace ShowerRecoTools {
   {
 
     dEdxTrackLength = fdEdxTrackLength;
+
+    SpacePointVector spacePointVector;
+    SpacePointsToHits spacePointsToHits;
+    HitsToSpacePoints hitsToSpacePoints;
+    LArPandoraHelper::CollectSpacePoints(Event, fPFParticleLabel.label(), spacePointVector, spacePointsToHits, hitsToSpacePoints);
+    std::cout << "There are " << hitsToSpacePoints.size() << " hits associated with space points" << std::endl;
 
     // Shower dEdx calculation
     if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
@@ -90,6 +135,10 @@ namespace ShowerRecoTools {
       return 1;
     }
 
+    // auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
+    // const art::FindManyP<recob::SpacePoint>& fmspp =
+    //  ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
+
     //Get the initial track hits
     std::vector<art::Ptr<recob::Hit>> trackhits;
     ShowerEleHolder.GetElement(fInitialTrackHitsInputLabel, trackhits);
@@ -105,6 +154,9 @@ namespace ShowerRecoTools {
 
     geo::Vector_t showerDir = {-999, -999, -999};
     ShowerEleHolder.GetElement(fShowerDirectionInputLabel, showerDir);
+
+    //std::cout << TString(Form("Shower position %f %f %f, and direction %f %f %f", ShowerStartPosition.X(), ShowerStartPosition.Y(), ShowerStartPosition.Z(),
+    //                      showerDir.X(), showerDir.Y(), showerDir.Z())) << std::endl;
 
     geo::TPCID vtxTPC = fGeom->FindTPCAtPosition(geo::vect::toPoint(ShowerStartPosition));
 
@@ -166,6 +218,9 @@ namespace ShowerRecoTools {
           //Get the first wire
           int w0 = trackPlaneHits.at(0)->WireID().Wire;
 
+          geo::Point_t chargeWeightedPosition = {0, 0, 0}; // Initialize charge weighted position
+          double totalCharge = 0; // Initialize total charge
+
           for (auto const& hit : trackPlaneHits) {
 
             if (fSumHitSnippets && !hitSnippets.count(hit)) continue;
@@ -174,7 +229,7 @@ namespace ShowerRecoTools {
             int w1 = hit->WireID().Wire;
             if (fMissFirstPoint && w0 == w1) { continue; }
 
-            //Ignore hits that are too far away.
+            // Ignore hits that are too far away.
             if (std::abs((w1 - w0) * pitch) < dEdxTrackLength) {
 
               double q = hit->Integral();
@@ -187,7 +242,36 @@ namespace ShowerRecoTools {
               totQ += hit->Integral();
               avgT += hit->PeakTime();
               ++nhits;
+              
+              //std::cout << "There are " << fmspp.size() << " spacepoint collections" << std::endl;
+
+              /*if (fmspp.size() <= hit.key()) {
+                std::cout << "No spacepoints for this hit" << std::endl;
+                continue;
+              }
+              std::vector<art::Ptr<recob::SpacePoint>> sps = fmspp.at(hit.key());
+              std::cout << "Found " << sps.size() << " spacepoints for this hit." << std::endl;*/
+
+              HitsToSpacePoints::const_iterator hIter = hitsToSpacePoints.find(hit);
+              if (hitsToSpacePoints.end() != hIter){
+                const art::Ptr<recob::SpacePoint> spacepoint = hIter->second;
+                //const double X(spacepoint->XYZ()[0]);
+                //std::cout << "Found spacepoint at X: " << X << std::endl;
+
+                auto const& pos = spacepoint->position();  // this is a geo::Point_t
+                chargeWeightedPosition += geo::Vector_t{pos.X(), pos.Y(), pos.Z()} * q;
+                totalCharge += q; // Accumulate total charge
+                std::cout << "updating charge weighted position with q: " << q << std::endl;
+              }
+
             }
+          }
+
+          // Calculate the final charge weighted average position
+          if (totalCharge > 0) {
+            chargeWeightedPosition /= totalCharge; // Normalize by total charge
+            std::cout << "Charge weighted position: (" << chargeWeightedPosition.X() << ", "
+                      << chargeWeightedPosition.Y() << ", " << chargeWeightedPosition.Z() << ")" << std::endl;
           }
 
           if (totQ) {
@@ -199,6 +283,19 @@ namespace ShowerRecoTools {
 
             //Get the median and calculate the dEdx using the algorithm.
             double dQdx = TMath::Median(vQ.size(), &vQ[0]) / pitch;
+            const auto& hit = trackPlaneHits.at(0);
+            // Attempt the normalization //Mike 
+            if ( fApplyCorrectionsInNorm ) {
+              geo::Vector_t displacement(0, 0, 0);
+              //std::cout << "Running the CorrectionsInNorm for showers" << std::endl;
+              dQdx = Normalize( dQdx,
+                Event,
+                *hit,
+                chargeWeightedPosition,
+                displacement,
+                0 );
+            }
+
             dEdx = fCalorimetryAlg.dEdx_AREA(
               clockData, detProp, dQdx, avgT / nhits, trackPlaneHits.at(0)->WireID().Plane);
 
@@ -245,6 +342,21 @@ namespace ShowerRecoTools {
     }
 
     return 0;
+  }
+
+  double ShowerUnidirectiondEdx::Normalize(double dQdx,
+					const art::Event& e,
+					const recob::Hit& h,
+					const geo::Point_t& location,
+					const geo::Vector_t& direction,
+					double t0)
+  {
+    double ret = dQdx;
+    for (auto const& nt : fNormalizationTools) {
+      ret = nt->Normalize(ret, e, h, location, direction, t0);
+    }
+    
+    return ret;
   }
 }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -294,6 +294,9 @@ showertrajpointdedx:{
     ShowerdEdxOutputLabel: "ShowerdEdx"
     ShowerBestPlaneOutputLabel: "ShowerBestPlane"
     ShowerdEdxVecOutputLabel: "ShowerdEdxVec"
+
+    ApplyCorrectionsInNorm: false # do not expect INormalizeCharge tools
+    NormTools: []                 # empty list of INormalizeCharge tools
 }
 
 showerincrementaltrackhitfinder:{

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -298,7 +298,7 @@ showertrajpointdedx:{
     ShowerBestPlaneOutputLabel: "ShowerBestPlane"
     ShowerdEdxVecOutputLabel: "ShowerdEdxVec"
 
-    ApplyCorrectionsInNorm: false # do not expect INormalizeCharge tools
+    ApplyCorrectionsInNorm: true # do not expect INormalizeCharge tools
     NormTools: []                 # empty list of INormalizeCharge tools
 }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -124,6 +124,10 @@ showerunidirectiondedx:{
     ShowerDirectionInputLabel: "ShowerDirection"
     ShowerdEdxOutputLabel: "ShowerdEdx"
     ShowerBestPlaneOutputLabel: "ShowerBestPlane"
+    # PFParticleLabel: "pandora"
+
+    ApplyCorrectionsInNorm: false # do not expect INormalizeCharge tools
+    NormTools: []                 # empty list of INormalizeCharge tools
 }
 
 showertrackhitdirection:{
@@ -298,7 +302,7 @@ showertrajpointdedx:{
     ShowerBestPlaneOutputLabel: "ShowerBestPlane"
     ShowerdEdxVecOutputLabel: "ShowerdEdxVec"
 
-    ApplyCorrectionsInNorm: true # do not expect INormalizeCharge tools
+    ApplyCorrectionsInNorm: false # do not expect INormalizeCharge tools
     NormTools: []                 # empty list of INormalizeCharge tools
 }
 


### PR DESCRIPTION
This PR adds the ability to run normalization tools inside some shower energy and dEdx tools. Specifically the below tools have an added function `Normalize` which will can run a list of normalization tools on the energy/dedx

- ShowerNumElectronsEnergy
- ShowerTrajPointDEdx
- ShowerUnidirectionDEdx