### PR TITLE
feature/nugraph_interface

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -192,7 +192,8 @@ namespace lar_pandora {
     }
 
     HitVector artHits;
-    std::map<art::Ptr<recob::Hit>, std::pair<float, float>> hitToPred;
+    HitToScores hitToScores;
+    HitToScoreLabels hitToScoreLabels;
     SimChannelVector artSimChannels;
     HitsToTrackIDEs artHitsToTrackIDEs;
     MCParticleVector artMCParticleVector;
@@ -205,7 +206,7 @@ namespace lar_pandora {
     m_collectHitsTool->CollectHits(evt, m_hitfinderModuleLabel, artHits);
 
     if (m_shouldCollectHitPredictions) {
-      LArPandoraHelper::CollectNuGraphHitLabels(evt, m_hitfinderModuleLabel, hitToPred);
+      LArPandoraHelper::CollectNuGraphHitLabels(evt, m_hitfinderModuleLabel, hitToScores, hitToScoreLabels);
     }
 
     if (m_enableMCParticles && (m_disableRealDataCheck || !evt.isRealData())) {
@@ -240,7 +241,7 @@ namespace lar_pandora {
     }
 
     LArPandoraInput::CreatePandoraHits2D(
-      evt, m_inputSettings, m_driftVolumeMap, artHits, hitToPred, idToHitMap);
+      evt, m_inputSettings, m_driftVolumeMap, artHits, hitToScores, hitToScoreLabels, idToHitMap);
 
     if (m_enableMCParticles && (m_disableRealDataCheck || !evt.isRealData())) {
       LArPandoraInput::CreatePandoraMCParticles(m_inputSettings,

--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -206,7 +206,8 @@ namespace lar_pandora {
     m_collectHitsTool->CollectHits(evt, m_hitfinderModuleLabel, artHits);
 
     if (m_shouldCollectHitPredictions) {
-      LArPandoraHelper::CollectNuGraphHitLabels(evt, m_hitfinderModuleLabel, hitToScores, hitToScoreLabels);
+      LArPandoraHelper::CollectNuGraphHitLabels(
+        evt, m_hitfinderModuleLabel, hitToScores, hitToScoreLabels);
     }
 
     if (m_enableMCParticles && (m_disableRealDataCheck || !evt.isRealData())) {

--- a/larpandora/LArPandoraInterface/LArPandora.h
+++ b/larpandora/LArPandoraInterface/LArPandora.h
@@ -56,6 +56,7 @@ namespace lar_pandora {
     bool
       m_shouldPerformSliceId; ///< Steering: whether to identify slices and select most appropriate pfos
     bool m_shouldProduceAllOutcomes; ///< Steering: whether to produce all reconstruction outcomes
+    bool m_shouldCollectHitPredictions; ///< Whether there are some hit-level predicted labels to be collected
     bool m_printOverallRecoStatus; ///< Steering: whether to print current operation status messages
 
     std::string m_generatorModuleLabel;   ///< The generator module label

--- a/larpandora/LArPandoraInterface/LArPandora.h
+++ b/larpandora/LArPandoraInterface/LArPandora.h
@@ -56,7 +56,8 @@ namespace lar_pandora {
     bool
       m_shouldPerformSliceId; ///< Steering: whether to identify slices and select most appropriate pfos
     bool m_shouldProduceAllOutcomes; ///< Steering: whether to produce all reconstruction outcomes
-    bool m_shouldCollectHitPredictions; ///< Whether there are some hit-level predicted labels to be collected
+    bool
+      m_shouldCollectHitPredictions; ///< Whether there are some hit-level predicted labels to be collected
     bool m_printOverallRecoStatus; ///< Steering: whether to print current operation status messages
 
     std::string m_generatorModuleLabel;   ///< The generator module label

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -18,6 +18,7 @@
 #include "lardataobj/AnalysisBase/BackTrackerMatchingData.h"
 #include "lardataobj/AnalysisBase/CosmicTag.h"
 #include "lardataobj/AnalysisBase/T0.h"
+#include "lardataobj/AnalysisBase/MVAOutput.h"
 #include "lardataobj/RecoBase/Cluster.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/PFParticle.h"
@@ -86,6 +87,59 @@ namespace lar_pandora {
       const art::Ptr<recob::Hit> hit(theHits, i);
       hitVector.push_back(hit);
     }
+  }
+
+  //------------------------------------------------------------------------------------------------------------------------------------------
+
+  void LArPandoraHelper::CollectNuGraphHitLabels(const art::Event& evt,
+                                                 const std::string& label,
+                                                 HitToPred& hitToPred)
+  {
+    float pFilter, pSemantic;
+
+    art::Handle<std::vector<recob::Hit>> theHits;
+    evt.getByLabel(label, theHits);    
+
+    if (!theHits.isValid()) {
+      mf::LogDebug("LArPandora") << "  Failed to find hits... " << std::endl;
+      return;
+    }
+    else {
+      mf::LogDebug("LArPandora") << "  Found: " << theHits->size() << " Hits " << std::endl;
+    }
+
+    art::Handle<std::vector<anab::FeatureVector<1>>> filterHandle;
+    evt.getByLabel(label, filterHandle);
+
+    if (!filterHandle.isValid()) {
+      mf::LogDebug("LArPandora") << "  Failed to find filter label... " << std::endl;
+      return;
+    }
+
+    art::Handle<std::vector<anab::FeatureVector<5>>> semanticHandle;
+    evt.getByLabel(label, semanticHandle);
+
+    if (!semanticHandle.isValid()) {
+      mf::LogDebug("LArPandora") << "  Failed to find semantic label... " << std::endl;
+      return;
+    }
+
+    for (unsigned int i = 0; i < theHits->size(); ++i) {
+      const art::Ptr<recob::Hit> hit(theHits, i);
+
+      // filter 
+      pFilter = filterHandle->at(i).at(0);
+
+      // semantic 
+      // encoding: <first_semantic_category><second_semantic_category>.<confidence>
+      // pSemantic = hitToSemanticAssoc.at(i)->at(0); // placeholder :) this is just the score of the MIP category
+      pSemantic = semanticHandle->at(i).at(0); ///< placeholder :) this is just the score of the MIP category
+                                               ///< to do, actually perform the encoding -- this was just to test the infrastructure
+      std::cout << pFilter << "\t" << pSemantic << std::endl;
+
+      hitToPred[hit] = std::make_pair(pFilter, pSemantic);
+    }
+
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -140,21 +140,16 @@ namespace lar_pandora {
 
       const float pSemanticFirst = pSemanticIdx[0];   ///< Best category
       const float pSemanticSecond = pSemanticIdx[1];  ///< Next-to-best category
-      const float pSemanticConfidence = (scores[pSemanticIdx[1]] > 0.) ? 
-                                        (scores[pSemanticIdx[0]] / scores[pSemanticIdx[1]]) : 
-                                        1.;           ///< Ratio of the two scores
 
-      // Encoding: <first_semantic_category+1><second_semantic_category+1>.<log10(confidence)_capped>
-      const float pSemantic = static_cast<float>((pSemanticFirst+1) * 10 + (pSemanticSecond+1))
-                              + 0.1 * std::clamp(std::log10(pSemanticConfidence), 0.f, 9.99f);
+      // Encoding: <first_semantic_category><second_semantic_category>.<second_score.2><first_score.2>
+      const float pSemantic = static_cast<float>((pSemanticFirst) * 10 + (pSemanticSecond))
+                              + 1.e-2f * std::clamp(static_cast<int>(std::floor(scores[pSemanticSecond] * 1e2)), 0, 99)
+                              + 1.e-4f * std::clamp(static_cast<int>(std::floor(scores[pSemanticFirst] * 1e2)), 0, 99);
 
-
-      // std::cout << filterHandle->at(i).at(0) << "\t" << semanticHandle->at(i).at(0) << "\t" << semanticHandle->at(i).at(1) 
-      //                                        << "\t" << semanticHandle->at(i).at(2) << "\t" << semanticHandle->at(i).at(3) 
-      //                                        << "\t" <<  semanticHandle->at(i).at(4) << std::endl;
-      // std::cout << pFilter << "\t" << pSemanticFirst << "\t" << 
-      //              pSemanticSecond << "\t" << pSemanticConfidence << "\t" <<
-      //              pSemantic << std::endl;
+      // std::cout << semanticHandle->at(i).at(0) << "\t" << semanticHandle->at(i).at(1) 
+      //           << "\t" << semanticHandle->at(i).at(2) << "\t" << semanticHandle->at(i).at(3) 
+      //           << "\t" << semanticHandle->at(i).at(4) << std::endl;
+      // std::cout << pSemanticFirst << "\t" << pSemanticSecond << "\t" << std::fixed << std::setprecision(6) << pSemantic << std::endl;
 
       hitToPred[hit] = std::make_pair(pFilter, pSemantic);
     }

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.cxx
@@ -17,8 +17,8 @@
 
 #include "lardataobj/AnalysisBase/BackTrackerMatchingData.h"
 #include "lardataobj/AnalysisBase/CosmicTag.h"
-#include "lardataobj/AnalysisBase/T0.h"
 #include "lardataobj/AnalysisBase/MVAOutput.h"
+#include "lardataobj/AnalysisBase/T0.h"
 #include "lardataobj/RecoBase/Cluster.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/PFParticle.h"
@@ -98,7 +98,7 @@ namespace lar_pandora {
   {
 
     art::Handle<std::vector<recob::Hit>> theHits;
-    evt.getByLabel(label, theHits);    
+    evt.getByLabel(label, theHits);
 
     if (!theHits.isValid()) {
       mf::LogDebug("LArPandora") << "  Failed to find hits... " << std::endl;
@@ -128,17 +128,17 @@ namespace lar_pandora {
       const art::Ptr<recob::Hit> hit(theHits, i);
 
       const float filterScore = filterHandle->at(i).at(0);
-      const auto &semanticScores  = semanticHandle->at(i);
+      const auto& semanticScores = semanticHandle->at(i);
 
       std::vector<float> hitScores = {filterScore};
-      for (unsigned int j = 0; j < semanticScores.size(); ++j) 
+      for (unsigned int j = 0; j < semanticScores.size(); ++j)
         hitScores.push_back(semanticScores[j]);
-      std::vector<std::string> hitScoreLabels = {"filter", "mip", "hip", "shower", "michel", "diffuse"};
+      std::vector<std::string> hitScoreLabels = {
+        "filter", "mip", "hip", "shower", "michel", "diffuse"};
 
       hitToScores[hit] = hitScores;
       hitToScoreLabels[hit] = hitScoreLabels;
     }
-
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -76,6 +76,7 @@ namespace lar_pandora {
 
   typedef std::unordered_set<art::Ptr<recob::Hit>> HitSet;
 
+  typedef std::map<art::Ptr<recob::Hit>, std::pair<float, float>> HitToPred;
   typedef std::map<art::Ptr<recob::PFParticle>, TrackVector> PFParticlesToTracks;
   typedef std::map<art::Ptr<recob::PFParticle>, ShowerVector> PFParticlesToShowers;
   typedef std::map<art::Ptr<recob::PFParticle>, ClusterVector> PFParticlesToClusters;
@@ -149,6 +150,17 @@ namespace lar_pandora {
      */
     static void CollectHits(const art::Event& evt, const std::string& label, HitVector& hitVector);
 
+    /**
+     *  @brief Collect predicted hit labels from the ART event record
+     *
+     *  @param evt the ART event record
+     *  @param label the label for the Hit list in the event
+     *  @param hitToPred the output map between a hit and its predicted labels, encoded in two values
+     */
+    static void CollectNuGraphHitLabels(const art::Event& evt, 
+                                        const std::string& label, 
+                                        HitToPred& hitToPred);
+                                          
     /**
      *  @brief Collect the reconstructed PFParticles from the ART event record
      *

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -76,7 +76,8 @@ namespace lar_pandora {
 
   typedef std::unordered_set<art::Ptr<recob::Hit>> HitSet;
 
-  typedef std::map<art::Ptr<recob::Hit>, std::pair<float, float>> HitToPred;
+  typedef std::map<art::Ptr<recob::Hit>, std::vector<float>> HitToScores;
+  typedef std::map<art::Ptr<recob::Hit>, std::vector<std::string>> HitToScoreLabels;
   typedef std::map<art::Ptr<recob::PFParticle>, TrackVector> PFParticlesToTracks;
   typedef std::map<art::Ptr<recob::PFParticle>, ShowerVector> PFParticlesToShowers;
   typedef std::map<art::Ptr<recob::PFParticle>, ClusterVector> PFParticlesToClusters;
@@ -155,11 +156,13 @@ namespace lar_pandora {
      *
      *  @param evt the ART event record
      *  @param label the label for the Hit list in the event
-     *  @param hitToPred the output map between a hit and its predicted labels, encoded in two values
+     *  @param hitToScores the output map between a hit and its predicted scores
+     *  @param hitToScoreLabels the output map between a hit and its predicted score labels
      */
     static void CollectNuGraphHitLabels(const art::Event& evt, 
                                         const std::string& label, 
-                                        HitToPred& hitToPred);
+                                        HitToScores& hitToScores,
+                                        HitToScoreLabels& hitToScoreLabels);
                                           
     /**
      *  @brief Collect the reconstructed PFParticles from the ART event record

--- a/larpandora/LArPandoraInterface/LArPandoraHelper.h
+++ b/larpandora/LArPandoraInterface/LArPandoraHelper.h
@@ -159,11 +159,11 @@ namespace lar_pandora {
      *  @param hitToScores the output map between a hit and its predicted scores
      *  @param hitToScoreLabels the output map between a hit and its predicted score labels
      */
-    static void CollectNuGraphHitLabels(const art::Event& evt, 
-                                        const std::string& label, 
+    static void CollectNuGraphHitLabels(const art::Event& evt,
+                                        const std::string& label,
                                         HitToScores& hitToScores,
                                         HitToScoreLabels& hitToScoreLabels);
-                                          
+
     /**
      *  @brief Collect the reconstructed PFParticles from the ART event record
      *

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -47,6 +47,7 @@ namespace lar_pandora {
                                             const Settings& settings,
                                             const LArDriftVolumeMap& driftVolumeMap,
                                             const HitVector& hitVector,
+                                            HitToPred& hitToPred,
                                             IdToHitMap& idToHitMap)
   {
     mf::LogDebug("LArPandora") << " *** LArPandoraInput::CreatePandoraHits2D(...) *** "
@@ -148,6 +149,19 @@ namespace lar_pandora {
              "be finite, calo hit omitted "
           << std::endl;
         continue;
+      }
+
+      // If wanted, populate the hit predictions
+      if (settings.m_useHitPredictions) {
+        auto itPred = hitToPred.find(hit);
+        if (itPred != hitToPred.end()) {
+            const auto &pred = itPred->second;
+            caloHitParameters.m_pTrack  = pred.first;
+            caloHitParameters.m_pShower = pred.second;
+        } else {
+            caloHitParameters.m_pTrack  = -1.;
+            caloHitParameters.m_pShower = -1.;
+        }
       }
 
       // Store the hit address

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -47,7 +47,8 @@ namespace lar_pandora {
                                             const Settings& settings,
                                             const LArDriftVolumeMap& driftVolumeMap,
                                             const HitVector& hitVector,
-                                            HitToPred& hitToPred,
+                                            const HitToScores& hitToScores,
+                                            const HitToScoreLabels& hitToScoreLabels,
                                             IdToHitMap& idToHitMap)
   {
     mf::LogDebug("LArPandora") << " *** LArPandoraInput::CreatePandoraHits2D(...) *** "
@@ -153,15 +154,13 @@ namespace lar_pandora {
 
       // If wanted, populate the hit predictions
       if (settings.m_useHitPredictions) {
-        auto itPred = hitToPred.find(hit);
-        if (itPred != hitToPred.end()) {
-            const auto &pred = itPred->second;
-            caloHitParameters.m_pTrack  = pred.first;
-            caloHitParameters.m_pShower = pred.second;
-        } else {
-            caloHitParameters.m_pTrack  = -1.;
-            caloHitParameters.m_pShower = -1.;
-        }
+        auto itScorePred = hitToScores.find(hit);
+        auto itLabelPred = hitToScoreLabels.find(hit);
+        if ((itScorePred != hitToScores.end()) && 
+            (itLabelPred != hitToScoreLabels.end())) {
+          caloHitParameters.m_hitScores = itScorePred->second;
+          caloHitParameters.m_hitScoreLabels = itLabelPred->second;
+        } 
       }
 
       // Store the hit address

--- a/larpandora/LArPandoraInterface/LArPandoraInput.cxx
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.cxx
@@ -156,11 +156,10 @@ namespace lar_pandora {
       if (settings.m_useHitPredictions) {
         auto itScorePred = hitToScores.find(hit);
         auto itLabelPred = hitToScoreLabels.find(hit);
-        if ((itScorePred != hitToScores.end()) && 
-            (itLabelPred != hitToScoreLabels.end())) {
+        if ((itScorePred != hitToScores.end()) && (itLabelPred != hitToScoreLabels.end())) {
           caloHitParameters.m_hitScores = itScorePred->second;
           caloHitParameters.m_hitScoreLabels = itLabelPred->second;
-        } 
+        }
       }
 
       // Store the hit address

--- a/larpandora/LArPandoraInterface/LArPandoraInput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.h
@@ -61,6 +61,7 @@ namespace lar_pandora {
       bool m_useHitWidths;                       ///<
       bool m_useBirksCorrection;                 ///<
       bool m_useActiveBoundingBox;               ///<
+      bool m_useHitPredictions;                  ///<
       int m_uidOffset;                           ///<
       int m_hitCounterOffset;                    ///<
       double m_dx_cm;                            ///<
@@ -80,12 +81,14 @@ namespace lar_pandora {
      *  @param  settings the settings
      *  @param  driftVolumeMap the mapping from volume id to drift volume
      *  @param  hits the input list of ART hits for this event
+     *  @param  hitToPred to receive the mapping between Pandora hits and their predictions, if available
      *  @param  idToHitMap to receive the mapping from Pandora hit ID to ART hit
      */
     static void CreatePandoraHits2D(const art::Event& evt,
                                     const Settings& settings,
                                     const LArDriftVolumeMap& driftVolumeMap,
                                     const HitVector& hitVector,
+                                    HitToPred& hitToPred,
                                     IdToHitMap& idToHitMap);
 
     /**

--- a/larpandora/LArPandoraInterface/LArPandoraInput.h
+++ b/larpandora/LArPandoraInterface/LArPandoraInput.h
@@ -81,14 +81,16 @@ namespace lar_pandora {
      *  @param  settings the settings
      *  @param  driftVolumeMap the mapping from volume id to drift volume
      *  @param  hits the input list of ART hits for this event
-     *  @param  hitToPred to receive the mapping between Pandora hits and their predictions, if available
+     *  @param  hitToScores to receive the mapping between a hit and its predicted scores, if available
+     *  @param  hitToScoreLabels to receive the mapping between a hit and its predicted score labels, if available
      *  @param  idToHitMap to receive the mapping from Pandora hit ID to ART hit
      */
     static void CreatePandoraHits2D(const art::Event& evt,
                                     const Settings& settings,
                                     const LArDriftVolumeMap& driftVolumeMap,
                                     const HitVector& hitVector,
-                                    HitToPred& hitToPred,
+                                    const HitToScores& hitToScores,
+                                    const HitToScoreLabels& hitToScoreLabels,
                                     IdToHitMap& idToHitMap);
 
     /**


### PR DESCRIPTION
This PR adds an interface to support decoration of Pandora's internal LArCaloHits with externally derived information, such as track and shower probabilities from NuGraph. No product changes are expected. This pull request depends upon the associated larpandoracontent [PR 88](https://github.com/LArSoft/larpandoracontent/pull/88). There is also an associated [ubreco PR](https://github.com/uboone/ubreco/pull/38).