### PR TITLE
New RefinedPCA shower direction tool + fixes to lesser used tools

### DIFF
--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/CMakeLists.txt
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/CMakeLists.txt
@@ -55,6 +55,15 @@ cet_build_plugin(ShowerLengthPercentile larpandora::ShowerTool
   LIBRARIES PRIVATE
 )
 
+cet_build_plugin(ShowerRefinedPCADirection larpandora::ShowerTool
+  LIBRARIES PRIVATE
+  lardata::DetectorClocksService
+  lardata::DetectorPropertiesService
+  lardataalg::DetectorInfo
+  lardataobj::RecoBase
+  Eigen3::Eigen
+)
+
 cet_build_plugin(ShowerLinearEnergy larpandora::ShowerTool
   LIBRARIES PRIVATE
   lardata::DetectorClocksService

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCADirection_tool.cc
@@ -56,6 +56,7 @@ namespace ShowerRecoTools {
     //fcl
     art::InputTag fPFParticleLabel;
     int fVerbose;
+    bool fWritePCAxis; //Should write out a PCAxis to event
     unsigned int
       fNSegments; //Used in the RMS gradient. How many segments should we split the shower into.
     bool fUseStartPosition; //If we use the start position the drection of the
@@ -72,6 +73,7 @@ namespace ShowerRecoTools {
     : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
     , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
     , fVerbose(pset.get<int>("Verbose"))
+    , fWritePCAxis(pset.get<bool>("WritePCAxis"))
     , fNSegments(pset.get<unsigned int>("NSegments"))
     , fUseStartPosition(pset.get<bool>("UseStartPosition"))
     , fChargeWeighted(pset.get<bool>("ChargeWeighted"))
@@ -83,6 +85,8 @@ namespace ShowerRecoTools {
 
   void ShowerPCADirection::InitialiseProducers()
   {
+    if (!fWritePCAxis)
+      return;
     InitialiseProduct<std::vector<recob::PCAxis>>(fShowerPCAOutputLabel);
     InitialiseProduct<art::Assns<recob::Shower, recob::PCAxis>>("ShowerPCAxisAssn");
     InitialiseProduct<art::Assns<recob::PFParticle, recob::PCAxis>>("PFParticlePCAxisAssn");
@@ -273,6 +277,8 @@ namespace ShowerRecoTools {
                                           art::Event& Event,
                                           reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
+    if (!fWritePCAxis)
+      return 0;
 
     //First check the element has been set
     if (!ShowerEleHolder.CheckElement(fShowerPCAOutputLabel)) {

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCADirection_tool.cc
@@ -38,7 +38,7 @@ namespace ShowerRecoTools {
   private:
     void InitialiseProducers() override;
 
-    //Function to add the assoctions
+    //Function to add the associations
     int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
                         art::Event& Event,
                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerPCADirection_tool.cc
@@ -85,8 +85,7 @@ namespace ShowerRecoTools {
 
   void ShowerPCADirection::InitialiseProducers()
   {
-    if (!fWritePCAxis)
-      return;
+    if (!fWritePCAxis) return;
     InitialiseProduct<std::vector<recob::PCAxis>>(fShowerPCAOutputLabel);
     InitialiseProduct<art::Assns<recob::Shower, recob::PCAxis>>("ShowerPCAxisAssn");
     InitialiseProduct<art::Assns<recob::PFParticle, recob::PCAxis>>("PFParticlePCAxisAssn");
@@ -277,8 +276,7 @@ namespace ShowerRecoTools {
                                           art::Event& Event,
                                           reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-    if (!fWritePCAxis)
-      return 0;
+    if (!fWritePCAxis) return 0;
 
     //First check the element has been set
     if (!ShowerEleHolder.CheckElement(fShowerPCAOutputLabel)) {

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerRefinedPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerRefinedPCADirection_tool.cc
@@ -67,6 +67,7 @@ namespace ShowerRecoTools {
     //fcl
     art::InputTag fPFParticleLabel;
     int fVerbose;
+    bool fWritePCAxis;
     bool fChargeWeighted;
     bool fQuadraticLongitudinalWeight;
     bool fQuadraticTransverseWeight;
@@ -88,6 +89,7 @@ namespace ShowerRecoTools {
     : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
     , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
     , fVerbose(pset.get<int>("Verbose"))
+    , fWritePCAxis(pset.get<bool>("WritePCAxis"))
     , fChargeWeighted(pset.get<bool>("ChargeWeighted"))
     , fQuadraticLongitudinalWeight(pset.get<bool>("QuadraticLongitudinalWeight"))
     , fQuadraticTransverseWeight(pset.get<bool>("QuadraticTransverseWeight"))
@@ -106,6 +108,8 @@ namespace ShowerRecoTools {
 
   void ShowerRefinedPCADirection::InitialiseProducers()
   {
+    if (!fWritePCAxis)
+      return;
     InitialiseProduct<std::vector<recob::PCAxis>>(fShowerPCAOutputLabel);
     InitialiseProduct<art::Assns<recob::Shower, recob::PCAxis>>("ShowerPCAxisAssn");
     InitialiseProduct<art::Assns<recob::PFParticle, recob::PCAxis>>("PFParticlePCAxisAssn");
@@ -136,7 +140,7 @@ namespace ShowerRecoTools {
     {
       if (fVerbose)
         mf::LogError("ShowerRefinedPCADirection") << "Not enough spacepoints for PCA (" << spacePoints.size() << ")" << std::endl;
-      return 1;
+      return 0;
     }
 
     geo::Point_t startPosition = {-999, -999, -999};
@@ -144,7 +148,6 @@ namespace ShowerRecoTools {
 
     geo::Vector_t currentDirection = {-999, -999, -999};
     ShowerEleHolder.GetElement(fShowerDirectionInputLabel, currentDirection);
-    std::cout << "!!!!!!: Seed =  " << currentDirection.X() << ", " << currentDirection.Y() << ", " << currentDirection.Z() << "\n";
 
     if (currentDirection.R() == 0.)
     {
@@ -174,17 +177,21 @@ namespace ShowerRecoTools {
       std::vector<double> weights = CalculateWeights(spacePoints, startPosition, currentDirection, clockData, detProp, fmh);
       PCAResult nextResult = CalculateWeightedPCA(spacePoints, weights);
 
-      if (nextResult.nPoints < static_cast<int>(fMinPCAPoints) || nextResult.direction.R() == 0.) {
+      if (nextResult.nPoints < static_cast<int>(fMinPCAPoints) || nextResult.direction.R() == 0.)
+      {
         if (!foundWeightedSolution)
         {
           if (fVerbose)
-            mf::LogError("ShowerRefinedPCADirection") << "Unable to calculate a weighted PCA from the seed direction" << std::endl;
-          return 1;
+            mf::LogWarning("ShowerRefinedPCADirection")
+              << "Unable to calculate a weighted PCA from the seed direction, keeping the seed PCA" << std::endl;
+          return nextResult.direction.R() == 0. ? 1 : 0;
         }
 
         if (fVerbose)
-          mf::LogWarning("ShowerRefinedPCADirection") << "Weighted PCA dropped below the minimum number of usable spacepoints, "
-                                                      << "using the previous successful iteration" << std::endl;
+          mf::LogWarning("ShowerRefinedPCADirection")
+            << "Weighted PCA dropped below the minimum number of usable spacepoints (" << fMinPCAPoints << "), "
+            << "using the previous successful iteration" << std::endl;
+
         break;
       }
 
@@ -198,13 +205,11 @@ namespace ShowerRecoTools {
       if (std::acos(dot) < fConvergenceAngle || iteration + 1 == fMaxIterations)
       {
         if (fVerbose)
-          mf::LogInfo("ShowerRefinedPCADirection") << "Finished at " << iteration + 1 << " / " << fMaxIterations << std::endl;
+          mf::LogInfo("ShowerRefinedPCADirection")
+            << "Finished PCA refinement at iteration " << iteration + 1 << " / " << fMaxIterations << std::endl;
         break;
       }
     }
-
-    if (!foundWeightedSolution)
-      return 1;
 
     //Not implementing errors
     geo::Point_t showerCentreErr = {-999, -999, -999};
@@ -213,8 +218,6 @@ namespace ShowerRecoTools {
     ShowerEleHolder.SetElement(currentResult.centre, showerCentreErr, fShowerCentreOutputLabel);
     ShowerEleHolder.SetElement(currentResult.pca, fShowerPCAOutputLabel);
     ShowerEleHolder.SetElement(currentDirection, showerDirectionErr, fShowerDirectionOutputLabel);
-
-    std::cout << "!!!!!!: Refined =  " << currentDirection.X() << ", " << currentDirection.Y() << ", " << currentDirection.Z() << "\n";
 
     return 0;
   }
@@ -361,6 +364,9 @@ namespace ShowerRecoTools {
   int ShowerRefinedPCADirection::AddAssociations(
     const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
+    if (!fWritePCAxis)
+      return 0;
+
     if (!ShowerEleHolder.CheckElement(fShowerPCAOutputLabel))
     {
       if (fVerbose)

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerRefinedPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerRefinedPCADirection_tool.cc
@@ -1,0 +1,382 @@
+//############################################################################
+//### Name:        ShowerRefinedPCADirection                               ###
+//### Author:      ALex Wilkinson                                          ###
+//### Date:        23.06.26                                                ###
+//### Description: Tool for finding the shower direction using an          ###
+//###              iterative weighted PCA on shower space points.          ###
+//###              Aim is to find an axis weighted towards the early       ###
+//###              and core parts of the shower.                           ###
+//############################################################################
+
+//Framework Includes
+#include "art/Utilities/ToolMacros.h"
+
+//LArSoft Includes
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
+#include "lardataalg/DetectorInfo/DetectorClocksData.h"
+#include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
+#include "lardataobj/RecoBase/Hit.h"
+#include "lardataobj/RecoBase/PCAxis.h"
+#include "lardataobj/RecoBase/PFParticle.h"
+#include "lardataobj/RecoBase/Shower.h"
+#include "lardataobj/RecoBase/SpacePoint.h"
+#include "larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/IShowerTool.h"
+
+//C++ Includes
+#include <Eigen/Dense>
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace ShowerRecoTools {
+
+  class ShowerRefinedPCADirection : public IShowerTool {
+
+  public:
+    ShowerRefinedPCADirection(const fhicl::ParameterSet& pset);
+
+    //Calculate the direction of the shower.
+    int CalculateElement(
+      const art::Ptr<recob::PFParticle>& pfparticle, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+
+  private:
+    void InitialiseProducers() override;
+
+    //Function to add the assoctions
+    int AddAssociations(
+      const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+
+    struct PCAResult {
+      recob::PCAxis pca;
+      geo::Point_t centre;
+      geo::Vector_t direction;
+      int nPoints;
+    };
+
+    PCAResult CalculateWeightedPCA(const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints, const std::vector<double>& weights) const;
+
+    std::vector<double> CalculateWeights(
+      const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints, geo::Point_t const& startPosition,
+      geo::Vector_t const& direction, detinfo::DetectorClocksData const* clockData,
+      detinfo::DetectorPropertiesData const* detProp, art::FindManyP<recob::Hit> const* fmh) const;
+
+    void OrientDirection(geo::Point_t const& startPosition, geo::Point_t const& centre, geo::Vector_t& direction) const;
+
+    //fcl
+    art::InputTag fPFParticleLabel;
+    int fVerbose;
+    bool fChargeWeighted;
+    bool fQuadraticLongitudinalWeight;
+    bool fQuadraticTransverseWeight;
+    unsigned int fMinPCAPoints;
+    unsigned int fMaxIterations;
+    double fConvergenceAngle;
+    double fTransverseScale;
+    double fLongitudinalScale;
+    double fDistanceFloor;
+
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionInputLabel; //Requires an initial seed direction
+    std::string fShowerDirectionOutputLabel;
+    std::string fShowerCentreOutputLabel;
+    std::string fShowerPCAOutputLabel;
+  };
+
+  ShowerRefinedPCADirection::ShowerRefinedPCADirection(const fhicl::ParameterSet& pset)
+    : IShowerTool(pset.get<fhicl::ParameterSet>("BaseTools"))
+    , fPFParticleLabel(pset.get<art::InputTag>("PFParticleLabel"))
+    , fVerbose(pset.get<int>("Verbose"))
+    , fChargeWeighted(pset.get<bool>("ChargeWeighted"))
+    , fQuadraticLongitudinalWeight(pset.get<bool>("QuadraticLongitudinalWeight"))
+    , fQuadraticTransverseWeight(pset.get<bool>("QuadraticTransverseWeight"))
+    , fMinPCAPoints(pset.get<unsigned int>("MinPCAPoints"))
+    , fMaxIterations(pset.get<unsigned int>("MaxIterations"))
+    , fConvergenceAngle(pset.get<double>("ConvergenceAngle"))
+    , fTransverseScale(pset.get<double>("TransverseScale"))
+    , fLongitudinalScale(pset.get<double>("LongitudinalScale"))
+    , fDistanceFloor(pset.get<double>("DistanceFloor"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionInputLabel(pset.get<std::string>("ShowerDirectionInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirectionOutputLabel"))
+    , fShowerCentreOutputLabel(pset.get<std::string>("ShowerCentreOutputLabel"))
+    , fShowerPCAOutputLabel(pset.get<std::string>("ShowerPCAOutputLabel"))
+  {}
+
+  void ShowerRefinedPCADirection::InitialiseProducers()
+  {
+    InitialiseProduct<std::vector<recob::PCAxis>>(fShowerPCAOutputLabel);
+    InitialiseProduct<art::Assns<recob::Shower, recob::PCAxis>>("ShowerPCAxisAssn");
+    InitialiseProduct<art::Assns<recob::PFParticle, recob::PCAxis>>("PFParticlePCAxisAssn");
+  }
+
+  int ShowerRefinedPCADirection::CalculateElement(
+    const art::Ptr<recob::PFParticle>& pfparticle, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel))
+    {
+      if (fVerbose)
+        mf::LogError("ShowerReginedPCADirection") << "Start position not set. Stopping." << std::endl;
+      return 1;
+    }
+
+    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel))
+    {
+      if (fVerbose)
+        mf::LogError("ShowerRefinedPCADirection") << "Seed direction not set. Stopping." << std::endl;
+      return 1;
+    }
+
+    auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
+    const art::FindManyP<recob::SpacePoint>& fmspp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
+
+    std::vector<art::Ptr<recob::SpacePoint>> spacePoints = fmspp.at(pfparticle.key());
+    if (spacePoints.size() < fMinPCAPoints)
+    {
+      if (fVerbose)
+        mf::LogError("ShowerRefinedPCADirection") << "Not enough spacepoints for PCA (" << spacePoints.size() << ")" << std::endl;
+      return 1;
+    }
+
+    geo::Point_t startPosition = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, startPosition);
+
+    geo::Vector_t currentDirection = {-999, -999, -999};
+    ShowerEleHolder.GetElement(fShowerDirectionInputLabel, currentDirection);
+    std::cout << "!!!!!!: Seed =  " << currentDirection.X() << ", " << currentDirection.Y() << ", " << currentDirection.Z() << "\n";
+
+    if (currentDirection.R() == 0.)
+    {
+      if (fVerbose)
+        mf::LogError("ShowerRefinedPCADirection") << "Seed direction has zero magnitude" << std::endl;
+      return 1;
+    }
+
+    auto const spHandle = Event.getValidHandle<std::vector<recob::SpacePoint>>(fPFParticleLabel);
+    art::FindManyP<recob::Hit> const* fmh = nullptr;
+    detinfo::DetectorClocksData const* clockData = nullptr;
+    detinfo::DetectorPropertiesData const* detProp = nullptr;
+    if (fChargeWeighted)
+    {
+      auto const clockDataForEvent = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+      auto const detPropForEvent = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockDataForEvent);
+      clockData = &clockDataForEvent;
+      detProp = &detPropForEvent;
+      fmh = &(ShowerEleHolder.GetFindManyP<recob::Hit>(spHandle, Event, fPFParticleLabel));
+    }
+
+    PCAResult currentResult;
+    bool foundWeightedSolution = false;
+
+    for (unsigned int iteration = 0; iteration < fMaxIterations; ++iteration)
+    {
+      std::vector<double> weights = CalculateWeights(spacePoints, startPosition, currentDirection, clockData, detProp, fmh);
+      PCAResult nextResult = CalculateWeightedPCA(spacePoints, weights);
+
+      if (nextResult.nPoints < static_cast<int>(fMinPCAPoints) || nextResult.direction.R() == 0.) {
+        if (!foundWeightedSolution)
+        {
+          if (fVerbose)
+            mf::LogError("ShowerRefinedPCADirection") << "Unable to calculate a weighted PCA from the seed direction" << std::endl;
+          return 1;
+        }
+
+        if (fVerbose)
+          mf::LogWarning("ShowerRefinedPCADirection") << "Weighted PCA dropped below the minimum number of usable spacepoints, "
+                                                      << "using the previous successful iteration" << std::endl;
+        break;
+      }
+
+      OrientDirection(startPosition, nextResult.centre, nextResult.direction);
+
+      const double dot = std::clamp(currentDirection.Unit().Dot(nextResult.direction.Unit()), -1., 1.);
+      currentResult = nextResult;
+      currentDirection = nextResult.direction;
+      foundWeightedSolution = true;
+
+      if (std::acos(dot) < fConvergenceAngle || iteration + 1 == fMaxIterations)
+      {
+        if (fVerbose)
+          mf::LogInfo("ShowerRefinedPCADirection") << "Finished at " << iteration + 1 << " / " << fMaxIterations << std::endl;
+        break;
+      }
+    }
+
+    if (!foundWeightedSolution)
+      return 1;
+
+    //Not implementing errors
+    geo::Point_t showerCentreErr = {-999, -999, -999};
+    geo::Vector_t showerDirectionErr = {-999, -999, -999};
+
+    ShowerEleHolder.SetElement(currentResult.centre, showerCentreErr, fShowerCentreOutputLabel);
+    ShowerEleHolder.SetElement(currentResult.pca, fShowerPCAOutputLabel);
+    ShowerEleHolder.SetElement(currentDirection, showerDirectionErr, fShowerDirectionOutputLabel);
+
+    std::cout << "!!!!!!: Refined =  " << currentDirection.X() << ", " << currentDirection.Y() << ", " << currentDirection.Z() << "\n";
+
+    return 0;
+  }
+
+  ShowerRefinedPCADirection::PCAResult ShowerRefinedPCADirection::CalculateWeightedPCA(
+    const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints, const std::vector<double>& weights) const
+  {
+    if (spacePoints.size() != weights.size())
+      throw cet::exception("ShowerRefinedPCADirection") << "Spacepoint and weight vectors are different sizes" << std::endl;
+
+    double sumWeights = 0.;
+    double x = 0.;
+    double y = 0.;
+    double z = 0.;
+    int nPoints = 0;
+
+    for (std::size_t i = 0; i < spacePoints.size(); ++i)
+    {
+      const double weight = weights[i];
+      if (weight <= 0.)
+        continue;
+
+      auto const pos = spacePoints[i]->position();
+      x += weight * pos.X();
+      y += weight * pos.Y();
+      z += weight * pos.Z();
+      sumWeights += weight;
+      ++nPoints;
+    }
+
+    if (sumWeights <= 0. || nPoints < 2)
+      return {recob::PCAxis(), {}, {}, nPoints};
+
+    geo::Point_t centre{x / sumWeights, y / sumWeights, z / sumWeights};
+
+    double xx = 0.;
+    double yy = 0.;
+    double zz = 0.;
+    double xy = 0.;
+    double xz = 0.;
+    double yz = 0.;
+
+    for (std::size_t i = 0; i < spacePoints.size(); ++i) {
+      const double weight = weights[i];
+      if (weight <= 0.)
+        continue;
+
+      auto const delta = spacePoints[i]->position() - centre;
+      xx += weight * delta.X() * delta.X();
+      yy += weight * delta.Y() * delta.Y();
+      zz += weight * delta.Z() * delta.Z();
+      xy += weight * delta.X() * delta.Y();
+      xz += weight * delta.X() * delta.Z();
+      yz += weight * delta.Y() * delta.Z();
+    }
+
+    Eigen::Matrix3d covariance;
+    covariance << xx, xy, xz, xy, yy, yz, xz, yz, zz;
+    covariance /= sumWeights;
+
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> eigenMatrix(covariance);
+    Eigen::Vector3d eigenValuesVector = eigenMatrix.eigenvalues();
+    Eigen::Matrix3d eigenVectorsMatrix = eigenMatrix.eigenvectors();
+
+    const double eigenValues[3] = {eigenValuesVector(2), eigenValuesVector(1), eigenValuesVector(0)};
+    std::vector<std::vector<double>> eigenVectors = {
+      {eigenVectorsMatrix(0, 2), eigenVectorsMatrix(1, 2), eigenVectorsMatrix(2, 2)},
+      {eigenVectorsMatrix(0, 1), eigenVectorsMatrix(1, 1), eigenVectorsMatrix(2, 1)},
+      {eigenVectorsMatrix(0, 0), eigenVectorsMatrix(1, 0), eigenVectorsMatrix(2, 0)}};
+    const double avePos[3] = {centre.X(), centre.Y(), centre.Z()};
+
+    recob::PCAxis pca(true, nPoints, eigenValues, eigenVectors, avePos);
+    geo::Vector_t direction{eigenVectorsMatrix(0, 2), eigenVectorsMatrix(1, 2), eigenVectorsMatrix(2, 2)};
+
+    return {pca, centre, direction, nPoints};
+  }
+
+  std::vector<double> ShowerRefinedPCADirection::CalculateWeights(
+    const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints, geo::Point_t const& startPosition, geo::Vector_t const& direction,
+    detinfo::DetectorClocksData const* clockData, detinfo::DetectorPropertiesData const* detProp,
+    art::FindManyP<recob::Hit> const* fmh) const
+  {
+    std::vector<double> weights(spacePoints.size(), 0.);
+    const geo::Vector_t unitDirection = direction.Unit();
+    double totalCharge = 0.;
+
+    if (fmh != nullptr) //Means charge weighting is desired
+    {
+      for (std::size_t i = 0; i < spacePoints.size(); ++i)
+      {
+        const auto delta = spacePoints[i]->position() - startPosition;
+        const double longitudinalDistance = delta.Dot(unitDirection);
+        if (longitudinalDistance < 0.) // Ignore hits "behind" the start position
+          continue;
+
+        double charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(spacePoints[i], *fmh);
+        double time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(spacePoints[i], *fmh);
+        charge *= std::exp((sampling_rate(*clockData) * time) / (detProp->ElectronLifetime() * 1e3));
+        totalCharge += std::max(charge, 0.);
+      }
+    }
+
+    for (std::size_t i = 0; i < spacePoints.size(); ++i)
+    {
+      const auto delta = spacePoints[i]->position() - startPosition;
+      double longDist = delta.Dot(unitDirection);
+      if (longDist < 0.) // Ignore hits "behind" the start position
+        continue;
+
+      double transDist = (delta - longDist * unitDirection).R();
+
+      longDist = std::max(longDist, fDistanceFloor);
+      transDist = std::max(transDist, fDistanceFloor);
+      const double longWeight = fQuadraticLongitudinalWeight ? 1. / (1. + std::pow(longDist / fLongitudinalScale, 2))
+                                                             : 1. / (1. + longDist / fLongitudinalScale);
+      const double transWeight = fQuadraticTransverseWeight ? 1. / (1. + std::pow(transDist / fTransverseScale, 2))
+                                                            : 1. / (1. + transDist / fTransverseScale);
+
+      double chargeWeight = 1.;
+      if (fmh != nullptr && totalCharge > 0.)
+      {
+        double charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(spacePoints[i], *fmh);
+        double time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(spacePoints[i], *fmh);
+        charge *= std::exp((sampling_rate(*clockData) * time) / (detProp->ElectronLifetime() * 1e3));
+        chargeWeight = std::sqrt(std::max(charge, 0.) / totalCharge);
+      }
+
+      weights[i] = transWeight * longWeight * chargeWeight;
+    }
+
+    return weights;
+  }
+
+  void ShowerRefinedPCADirection::OrientDirection(geo::Point_t const& startPosition, geo::Point_t const& centre, geo::Vector_t& direction) const
+  {
+    if ((centre - startPosition).R() == 0. || direction.R() == 0.)
+       return;
+
+    const geo::Vector_t generalDirection = (centre - startPosition).Unit();
+    if (direction.Dot(generalDirection) < 0.)
+      direction *= -1.;
+  }
+
+  int ShowerRefinedPCADirection::AddAssociations(
+    const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder)
+  {
+    if (!ShowerEleHolder.CheckElement(fShowerPCAOutputLabel))
+    {
+      if (fVerbose)
+        mf::LogError("ShowerRefinedPCADirection: Add Assns") << "PCA not set." << std::endl;
+      return 1;
+    }
+
+    int ptrSize = GetVectorPtrSize(fShowerPCAOutputLabel);
+    const art::Ptr<recob::PCAxis> pcaPtr = GetProducedElementPtr<recob::PCAxis>(fShowerPCAOutputLabel, ShowerEleHolder, ptrSize - 1);
+    const art::Ptr<recob::Shower> showerPtr = GetProducedElementPtr<recob::Shower>("shower", ShowerEleHolder);
+
+    AddSingle<art::Assns<recob::Shower, recob::PCAxis>>(showerPtr, pcaPtr, "ShowerPCAxisAssn");
+    AddSingle<art::Assns<recob::PFParticle, recob::PCAxis>>(pfpPtr, pcaPtr, "PFParticlePCAxisAssn");
+
+    return 0;
+  }
+}
+
+DEFINE_ART_CLASS_TOOL(ShowerRecoTools::ShowerRefinedPCADirection)

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerRefinedPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerRefinedPCADirection_tool.cc
@@ -38,15 +38,17 @@ namespace ShowerRecoTools {
     ShowerRefinedPCADirection(const fhicl::ParameterSet& pset);
 
     //Calculate the direction of the shower.
-    int CalculateElement(
-      const art::Ptr<recob::PFParticle>& pfparticle, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+    int CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
+                         art::Event& Event,
+                         reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
   private:
     void InitialiseProducers() override;
 
     //Function to add the associations
-    int AddAssociations(
-      const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder) override;
+    int AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                        art::Event& Event,
+                        reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
     struct PCAResult {
       recob::PCAxis pca;
@@ -55,14 +57,20 @@ namespace ShowerRecoTools {
       int nPoints;
     };
 
-    PCAResult CalculateWeightedPCA(const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints, const std::vector<double>& weights) const;
+    PCAResult CalculateWeightedPCA(const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints,
+                                   const std::vector<double>& weights) const;
 
     std::vector<double> CalculateWeights(
-      const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints, geo::Point_t const& startPosition,
-      geo::Vector_t const& direction, detinfo::DetectorClocksData const* clockData,
-      detinfo::DetectorPropertiesData const* detProp, art::FindManyP<recob::Hit> const* fmh) const;
+      const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints,
+      geo::Point_t const& startPosition,
+      geo::Vector_t const& direction,
+      detinfo::DetectorClocksData const* clockData,
+      detinfo::DetectorPropertiesData const* detProp,
+      art::FindManyP<recob::Hit> const* fmh) const;
 
-    void OrientDirection(geo::Point_t const& startPosition, geo::Point_t const& centre, geo::Vector_t& direction) const;
+    void OrientDirection(geo::Point_t const& startPosition,
+                         geo::Point_t const& centre,
+                         geo::Vector_t& direction) const;
 
     //fcl
     art::InputTag fPFParticleLabel;
@@ -108,48 +116,49 @@ namespace ShowerRecoTools {
 
   void ShowerRefinedPCADirection::InitialiseProducers()
   {
-    if (!fWritePCAxis)
-      return;
+    if (!fWritePCAxis) return;
     InitialiseProduct<std::vector<recob::PCAxis>>(fShowerPCAOutputLabel);
     InitialiseProduct<art::Assns<recob::Shower, recob::PCAxis>>("ShowerPCAxisAssn");
     InitialiseProduct<art::Assns<recob::PFParticle, recob::PCAxis>>("PFParticlePCAxisAssn");
   }
 
   int ShowerRefinedPCADirection::CalculateElement(
-    const art::Ptr<recob::PFParticle>& pfparticle, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder)
+    const art::Ptr<recob::PFParticle>& pfparticle,
+    art::Event& Event,
+    reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
     if (std::abs(fLongitudinalScale) <= std::numeric_limits<double>::epsilon() ||
-        std::abs(fTransverseScale) <= std::numeric_limits<double>::epsilon())
-    {
+        std::abs(fTransverseScale) <= std::numeric_limits<double>::epsilon()) {
       if (fVerbose)
         mf::LogError("ShowerReginedPCADirection")
-          << "Longitudinal or transverse scale parameter is too small ("
-          << fLongitudinalScale << ", " << fTransverseScale << ")" << std::endl;
+          << "Longitudinal or transverse scale parameter is too small (" << fLongitudinalScale
+          << ", " << fTransverseScale << ")" << std::endl;
       return 1;
     }
 
-    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel))
-    {
+    if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerReginedPCADirection") << "Start position not set. Stopping." << std::endl;
+        mf::LogError("ShowerReginedPCADirection")
+          << "Start position not set. Stopping." << std::endl;
       return 1;
     }
 
-    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel))
-    {
+    if (!ShowerEleHolder.CheckElement(fShowerDirectionInputLabel)) {
       if (fVerbose)
-        mf::LogError("ShowerRefinedPCADirection") << "Seed direction not set. Stopping." << std::endl;
+        mf::LogError("ShowerRefinedPCADirection")
+          << "Seed direction not set. Stopping." << std::endl;
       return 1;
     }
 
     auto const pfpHandle = Event.getValidHandle<std::vector<recob::PFParticle>>(fPFParticleLabel);
-    const art::FindManyP<recob::SpacePoint>& fmspp = ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
+    const art::FindManyP<recob::SpacePoint>& fmspp =
+      ShowerEleHolder.GetFindManyP<recob::SpacePoint>(pfpHandle, Event, fPFParticleLabel);
 
     std::vector<art::Ptr<recob::SpacePoint>> spacePoints = fmspp.at(pfparticle.key());
-    if (spacePoints.size() < fMinPCAPoints)
-    {
+    if (spacePoints.size() < fMinPCAPoints) {
       if (fVerbose)
-        mf::LogError("ShowerRefinedPCADirection") << "Not enough spacepoints for PCA (" << spacePoints.size() << ")" << std::endl;
+        mf::LogError("ShowerRefinedPCADirection")
+          << "Not enough spacepoints for PCA (" << spacePoints.size() << ")" << std::endl;
       return 0;
     }
 
@@ -159,10 +168,10 @@ namespace ShowerRecoTools {
     geo::Vector_t currentDirection = {-999, -999, -999};
     ShowerEleHolder.GetElement(fShowerDirectionInputLabel, currentDirection);
 
-    if (currentDirection.R() == 0.)
-    {
+    if (currentDirection.R() == 0.) {
       if (fVerbose)
-        mf::LogError("ShowerRefinedPCADirection") << "Seed direction has zero magnitude" << std::endl;
+        mf::LogError("ShowerRefinedPCADirection")
+          << "Seed direction has zero magnitude" << std::endl;
       return 1;
     }
 
@@ -170,10 +179,12 @@ namespace ShowerRecoTools {
     art::FindManyP<recob::Hit> const* fmh = nullptr;
     detinfo::DetectorClocksData const* clockData = nullptr;
     detinfo::DetectorPropertiesData const* detProp = nullptr;
-    if (fChargeWeighted)
-    {
-      auto const clockDataForEvent = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
-      auto const detPropForEvent = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event, clockDataForEvent);
+    if (fChargeWeighted) {
+      auto const clockDataForEvent =
+        art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(Event);
+      auto const detPropForEvent =
+        art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataFor(Event,
+                                                                                clockDataForEvent);
       clockData = &clockDataForEvent;
       detProp = &detPropForEvent;
       fmh = &(ShowerEleHolder.GetFindManyP<recob::Hit>(spHandle, Event, fPFParticleLabel));
@@ -182,24 +193,24 @@ namespace ShowerRecoTools {
     PCAResult currentResult;
     bool foundWeightedSolution = false;
 
-    for (unsigned int iteration = 0; iteration < fMaxIterations; ++iteration)
-    {
-      std::vector<double> weights = CalculateWeights(spacePoints, startPosition, currentDirection, clockData, detProp, fmh);
+    for (unsigned int iteration = 0; iteration < fMaxIterations; ++iteration) {
+      std::vector<double> weights =
+        CalculateWeights(spacePoints, startPosition, currentDirection, clockData, detProp, fmh);
       PCAResult nextResult = CalculateWeightedPCA(spacePoints, weights);
 
-      if (nextResult.nPoints < static_cast<int>(fMinPCAPoints) || nextResult.direction.R() == 0.)
-      {
-        if (!foundWeightedSolution)
-        {
+      if (nextResult.nPoints < static_cast<int>(fMinPCAPoints) || nextResult.direction.R() == 0.) {
+        if (!foundWeightedSolution) {
           if (fVerbose)
             mf::LogWarning("ShowerRefinedPCADirection")
-              << "Unable to calculate a weighted PCA from the seed direction, keeping the seed PCA" << std::endl;
+              << "Unable to calculate a weighted PCA from the seed direction, keeping the seed PCA"
+              << std::endl;
           return nextResult.direction.R() == 0. ? 1 : 0;
         }
 
         if (fVerbose)
           mf::LogWarning("ShowerRefinedPCADirection")
-            << "Weighted PCA dropped below the minimum number of usable spacepoints (" << fMinPCAPoints << "), "
+            << "Weighted PCA dropped below the minimum number of usable spacepoints ("
+            << fMinPCAPoints << "), "
             << "using the previous successful iteration" << std::endl;
 
         break;
@@ -207,16 +218,17 @@ namespace ShowerRecoTools {
 
       OrientDirection(startPosition, nextResult.centre, nextResult.direction);
 
-      const double dot = std::clamp(currentDirection.Unit().Dot(nextResult.direction.Unit()), -1., 1.);
+      const double dot =
+        std::clamp(currentDirection.Unit().Dot(nextResult.direction.Unit()), -1., 1.);
       currentResult = nextResult;
       currentDirection = nextResult.direction;
       foundWeightedSolution = true;
 
-      if (std::acos(dot) < fConvergenceAngle || iteration + 1 == fMaxIterations)
-      {
+      if (std::acos(dot) < fConvergenceAngle || iteration + 1 == fMaxIterations) {
         if (fVerbose)
           mf::LogInfo("ShowerRefinedPCADirection")
-            << "Finished PCA refinement at iteration " << iteration + 1 << " / " << fMaxIterations << std::endl;
+            << "Finished PCA refinement at iteration " << iteration + 1 << " / " << fMaxIterations
+            << std::endl;
         break;
       }
     }
@@ -233,10 +245,12 @@ namespace ShowerRecoTools {
   }
 
   ShowerRefinedPCADirection::PCAResult ShowerRefinedPCADirection::CalculateWeightedPCA(
-    const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints, const std::vector<double>& weights) const
+    const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints,
+    const std::vector<double>& weights) const
   {
     if (spacePoints.size() != weights.size())
-      throw cet::exception("ShowerRefinedPCADirection") << "Spacepoint and weight vectors are different sizes" << std::endl;
+      throw cet::exception("ShowerRefinedPCADirection")
+        << "Spacepoint and weight vectors are different sizes" << std::endl;
 
     double sumWeights = 0.;
     double x = 0.;
@@ -244,11 +258,9 @@ namespace ShowerRecoTools {
     double z = 0.;
     int nPoints = 0;
 
-    for (std::size_t i = 0; i < spacePoints.size(); ++i)
-    {
+    for (std::size_t i = 0; i < spacePoints.size(); ++i) {
       const double weight = weights[i];
-      if (weight <= 0.)
-        continue;
+      if (weight <= 0.) continue;
 
       auto const pos = spacePoints[i]->position();
       x += weight * pos.X();
@@ -258,8 +270,7 @@ namespace ShowerRecoTools {
       ++nPoints;
     }
 
-    if (sumWeights <= 0. || nPoints < 2)
-      return {recob::PCAxis(), {}, {}, nPoints};
+    if (sumWeights <= 0. || nPoints < 2) return {recob::PCAxis(), {}, {}, nPoints};
 
     geo::Point_t centre{x / sumWeights, y / sumWeights, z / sumWeights};
 
@@ -272,8 +283,7 @@ namespace ShowerRecoTools {
 
     for (std::size_t i = 0; i < spacePoints.size(); ++i) {
       const double weight = weights[i];
-      if (weight <= 0.)
-        continue;
+      if (weight <= 0.) continue;
 
       auto const delta = spacePoints[i]->position() - centre;
       xx += weight * delta.X() * delta.X();
@@ -292,7 +302,8 @@ namespace ShowerRecoTools {
     Eigen::Vector3d eigenValuesVector = eigenMatrix.eigenvalues();
     Eigen::Matrix3d eigenVectorsMatrix = eigenMatrix.eigenvectors();
 
-    const double eigenValues[3] = {eigenValuesVector(2), eigenValuesVector(1), eigenValuesVector(0)};
+    const double eigenValues[3] = {
+      eigenValuesVector(2), eigenValuesVector(1), eigenValuesVector(0)};
     std::vector<std::vector<double>> eigenVectors = {
       {eigenVectorsMatrix(0, 2), eigenVectorsMatrix(1, 2), eigenVectorsMatrix(2, 2)},
       {eigenVectorsMatrix(0, 1), eigenVectorsMatrix(1, 1), eigenVectorsMatrix(2, 1)},
@@ -300,14 +311,18 @@ namespace ShowerRecoTools {
     const double avePos[3] = {centre.X(), centre.Y(), centre.Z()};
 
     recob::PCAxis pca(true, nPoints, eigenValues, eigenVectors, avePos);
-    geo::Vector_t direction{eigenVectorsMatrix(0, 2), eigenVectorsMatrix(1, 2), eigenVectorsMatrix(2, 2)};
+    geo::Vector_t direction{
+      eigenVectorsMatrix(0, 2), eigenVectorsMatrix(1, 2), eigenVectorsMatrix(2, 2)};
 
     return {pca, centre, direction, nPoints};
   }
 
   std::vector<double> ShowerRefinedPCADirection::CalculateWeights(
-    const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints, geo::Point_t const& startPosition, geo::Vector_t const& direction,
-    detinfo::DetectorClocksData const* clockData, detinfo::DetectorPropertiesData const* detProp,
+    const std::vector<art::Ptr<recob::SpacePoint>>& spacePoints,
+    geo::Point_t const& startPosition,
+    geo::Vector_t const& direction,
+    detinfo::DetectorClocksData const* clockData,
+    detinfo::DetectorPropertiesData const* detProp,
     art::FindManyP<recob::Hit> const* fmh) const
   {
     std::vector<double> weights(spacePoints.size(), 0.);
@@ -316,22 +331,22 @@ namespace ShowerRecoTools {
 
     if (fmh != nullptr) //Means charge weighting is desired
     {
-      for (std::size_t i = 0; i < spacePoints.size(); ++i)
-      {
+      for (std::size_t i = 0; i < spacePoints.size(); ++i) {
         const auto delta = spacePoints[i]->position() - startPosition;
         const double longitudinalDistance = delta.Dot(unitDirection);
         if (longitudinalDistance < 0.) // Ignore hits "behind" the start position
           continue;
 
-        double charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(spacePoints[i], *fmh);
+        double charge =
+          IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(spacePoints[i], *fmh);
         double time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(spacePoints[i], *fmh);
-        charge *= std::exp((sampling_rate(*clockData) * time) / (detProp->ElectronLifetime() * 1e3));
+        charge *=
+          std::exp((sampling_rate(*clockData) * time) / (detProp->ElectronLifetime() * 1e3));
         totalCharge += std::max(charge, 0.);
       }
     }
 
-    for (std::size_t i = 0; i < spacePoints.size(); ++i)
-    {
+    for (std::size_t i = 0; i < spacePoints.size(); ++i) {
       const auto delta = spacePoints[i]->position() - startPosition;
       double longDist = delta.Dot(unitDirection);
       if (longDist < 0.) // Ignore hits "behind" the start position
@@ -341,17 +356,20 @@ namespace ShowerRecoTools {
 
       longDist = std::max(longDist, fDistanceFloor);
       transDist = std::max(transDist, fDistanceFloor);
-      const double longWeight = fQuadraticLongitudinalWeight ? 1. / (1. + std::pow(longDist / fLongitudinalScale, 2))
-                                                             : 1. / (1. + longDist / fLongitudinalScale);
-      const double transWeight = fQuadraticTransverseWeight ? 1. / (1. + std::pow(transDist / fTransverseScale, 2))
-                                                            : 1. / (1. + transDist / fTransverseScale);
+      const double longWeight = fQuadraticLongitudinalWeight ?
+                                  1. / (1. + std::pow(longDist / fLongitudinalScale, 2)) :
+                                  1. / (1. + longDist / fLongitudinalScale);
+      const double transWeight = fQuadraticTransverseWeight ?
+                                   1. / (1. + std::pow(transDist / fTransverseScale, 2)) :
+                                   1. / (1. + transDist / fTransverseScale);
 
       double chargeWeight = 1.;
-      if (fmh != nullptr && totalCharge > 0.)
-      {
-        double charge = IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(spacePoints[i], *fmh);
+      if (fmh != nullptr && totalCharge > 0.) {
+        double charge =
+          IShowerTool::GetLArPandoraShowerAlg().SpacePointCharge(spacePoints[i], *fmh);
         double time = IShowerTool::GetLArPandoraShowerAlg().SpacePointTime(spacePoints[i], *fmh);
-        charge *= std::exp((sampling_rate(*clockData) * time) / (detProp->ElectronLifetime() * 1e3));
+        charge *=
+          std::exp((sampling_rate(*clockData) * time) / (detProp->ElectronLifetime() * 1e3));
         chargeWeight = std::sqrt(std::max(charge, 0.) / totalCharge);
       }
 
@@ -361,32 +379,33 @@ namespace ShowerRecoTools {
     return weights;
   }
 
-  void ShowerRefinedPCADirection::OrientDirection(geo::Point_t const& startPosition, geo::Point_t const& centre, geo::Vector_t& direction) const
+  void ShowerRefinedPCADirection::OrientDirection(geo::Point_t const& startPosition,
+                                                  geo::Point_t const& centre,
+                                                  geo::Vector_t& direction) const
   {
-    if ((centre - startPosition).R() == 0. || direction.R() == 0.)
-       return;
+    if ((centre - startPosition).R() == 0. || direction.R() == 0.) return;
 
     const geo::Vector_t generalDirection = (centre - startPosition).Unit();
-    if (direction.Dot(generalDirection) < 0.)
-      direction *= -1.;
+    if (direction.Dot(generalDirection) < 0.) direction *= -1.;
   }
 
-  int ShowerRefinedPCADirection::AddAssociations(
-    const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder)
+  int ShowerRefinedPCADirection::AddAssociations(const art::Ptr<recob::PFParticle>& pfpPtr,
+                                                 art::Event& Event,
+                                                 reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
-    if (!fWritePCAxis)
-      return 0;
+    if (!fWritePCAxis) return 0;
 
-    if (!ShowerEleHolder.CheckElement(fShowerPCAOutputLabel))
-    {
+    if (!ShowerEleHolder.CheckElement(fShowerPCAOutputLabel)) {
       if (fVerbose)
         mf::LogError("ShowerRefinedPCADirection: Add Assns") << "PCA not set." << std::endl;
       return 1;
     }
 
     int ptrSize = GetVectorPtrSize(fShowerPCAOutputLabel);
-    const art::Ptr<recob::PCAxis> pcaPtr = GetProducedElementPtr<recob::PCAxis>(fShowerPCAOutputLabel, ShowerEleHolder, ptrSize - 1);
-    const art::Ptr<recob::Shower> showerPtr = GetProducedElementPtr<recob::Shower>("shower", ShowerEleHolder);
+    const art::Ptr<recob::PCAxis> pcaPtr =
+      GetProducedElementPtr<recob::PCAxis>(fShowerPCAOutputLabel, ShowerEleHolder, ptrSize - 1);
+    const art::Ptr<recob::Shower> showerPtr =
+      GetProducedElementPtr<recob::Shower>("shower", ShowerEleHolder);
 
     AddSingle<art::Assns<recob::Shower, recob::PCAxis>>(showerPtr, pcaPtr, "ShowerPCAxisAssn");
     AddSingle<art::Assns<recob::PFParticle, recob::PCAxis>>(pfpPtr, pcaPtr, "PFParticlePCAxisAssn");

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerRefinedPCADirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerRefinedPCADirection_tool.cc
@@ -44,7 +44,7 @@ namespace ShowerRecoTools {
   private:
     void InitialiseProducers() override;
 
-    //Function to add the assoctions
+    //Function to add the associations
     int AddAssociations(
       const art::Ptr<recob::PFParticle>& pfpPtr, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder) override;
 
@@ -118,6 +118,16 @@ namespace ShowerRecoTools {
   int ShowerRefinedPCADirection::CalculateElement(
     const art::Ptr<recob::PFParticle>& pfparticle, art::Event& Event, reco::shower::ShowerElementHolder& ShowerEleHolder)
   {
+    if (std::abs(fLongitudinalScale) <= std::numeric_limits<double>::epsilon() ||
+        std::abs(fTransverseScale) <= std::numeric_limits<double>::epsilon())
+    {
+      if (fVerbose)
+        mf::LogError("ShowerReginedPCADirection")
+          << "Longitudinal or transverse scale parameter is too small ("
+          << fLongitudinalScale << ", " << fTransverseScale << ")" << std::endl;
+      return 1;
+    }
+
     if (!ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel))
     {
       if (fVerbose)

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackDirection_tool.cc
@@ -35,6 +35,10 @@ namespace ShowerRecoTools {
     bool fUsePositionInfo; //Don't use the directionAtPoint rather
                            //than definition above.
                            //i.e((Position of traj point + 1) - (Position of traj point)
+
+    std::string fInitialTrackInputLabel;
+    std::string fShowerStartPositionInputLabel;
+    std::string fShowerDirectionOutputLabel;
   };
 
   ShowerTrackDirection::ShowerTrackDirection(const fhicl::ParameterSet& pset)
@@ -42,6 +46,9 @@ namespace ShowerRecoTools {
     , fVerbose(pset.get<int>("Verbose"))
     , fUsePandoraVertex(pset.get<bool>("UsePandoraVertex"))
     , fUsePositionInfo(pset.get<bool>("UsePositionInfo"))
+    , fInitialTrackInputLabel(pset.get<std::string>("InitialTrackInputLabel"))
+    , fShowerStartPositionInputLabel(pset.get<std::string>("ShowerStartPositionInputLabel"))
+    , fShowerDirectionOutputLabel(pset.get<std::string>("ShowerDirecitonOutputLabel"))
   {}
 
   int ShowerTrackDirection::CalculateElement(const art::Ptr<recob::PFParticle>& pfparticle,
@@ -50,13 +57,13 @@ namespace ShowerRecoTools {
   {
 
     //Check the Track has been defined
-    if (!ShowerEleHolder.CheckElement("InitialTrack")) {
+    if (!ShowerEleHolder.CheckElement(fInitialTrackInputLabel)) {
       if (fVerbose) mf::LogError("ShowerTrackDirection") << "Initial track not set" << std::endl;
       return 0;
     }
 
     //Check the start position is set.
-    if (fUsePandoraVertex && !ShowerEleHolder.CheckElement("ShowerStartPosition")) {
+    if (fUsePandoraVertex && !ShowerEleHolder.CheckElement(fShowerDirectionOutputLabel)) {
       if (fVerbose)
         mf::LogError("ShowerTrackDirection") << "Start position not set, returning " << std::endl;
       return 0;
@@ -64,11 +71,11 @@ namespace ShowerRecoTools {
 
     //Get the track
     recob::Track InitialTrack;
-    ShowerEleHolder.GetElement("InitialTrack", InitialTrack);
+    ShowerEleHolder.GetElement(fInitialTrackInputLabel, InitialTrack);
 
     if (fUsePositionInfo) {
       geo::Point_t StartPosition;
-      if (fUsePandoraVertex) { ShowerEleHolder.GetElement("ShowerStartPosition", StartPosition); }
+      if (fUsePandoraVertex) { ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPosition); }
       else {
         StartPosition = InitialTrack.Start();
       }
@@ -140,7 +147,7 @@ namespace ShowerRecoTools {
       if (N > 0) {
         geo::Vector_t Direction = geo::vect::toVector(Direction_Mean.Unit());
         geo::Vector_t DirectionErr = {RMSX, RMSY, RMSZ};
-        ShowerEleHolder.SetElement(Direction, DirectionErr, "ShowerDirection");
+        ShowerEleHolder.SetElement(Direction, DirectionErr, fShowerDirectionOutputLabel);
       }
       else {
         if (fVerbose)
@@ -212,7 +219,7 @@ namespace ShowerRecoTools {
       if (N > 0) {
         geo::Vector_t Direction = geo::vect::toVector(Direction_Mean.Unit());
         geo::Vector_t DirectionErr = {RMSX, RMSY, RMSZ};
-        ShowerEleHolder.SetElement(Direction, DirectionErr, "ShowerDirection");
+        ShowerEleHolder.SetElement(Direction, DirectionErr, fShowerDirectionOutputLabel);
       }
       else {
         if (fVerbose)

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackDirection_tool.cc
@@ -63,7 +63,7 @@ namespace ShowerRecoTools {
     }
 
     //Check the start position is set.
-    if (fUsePandoraVertex && !ShowerEleHolder.CheckElement(fShowerDirectionOutputLabel)) {
+    if (fUsePandoraVertex && !ShowerEleHolder.CheckElement(fShowerStartPositionInputLabel)) {
       if (fVerbose)
         mf::LogError("ShowerTrackDirection") << "Start position not set, returning " << std::endl;
       return 0;

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackDirection_tool.cc
@@ -75,7 +75,9 @@ namespace ShowerRecoTools {
 
     if (fUsePositionInfo) {
       geo::Point_t StartPosition;
-      if (fUsePandoraVertex) { ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPosition); }
+      if (fUsePandoraVertex) {
+        ShowerEleHolder.GetElement(fShowerStartPositionInputLabel, StartPosition);
+      }
       else {
         StartPosition = InitialTrack.Start();
       }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
@@ -130,7 +130,8 @@ namespace ShowerRecoTools {
     }
     else {
       if (fVerbose)
-        mf::LogError("ShowerTrackHitDirection") << "No points found to calculate a direction" << std::endl;
+        mf::LogError("ShowerTrackHitDirection")
+          << "No points found to calculate a direction" << std::endl;
       return 1;
     }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
@@ -103,72 +103,37 @@ namespace ShowerRecoTools {
     std::vector<art::Ptr<recob::Hit>> InitialTrackHits;
     ShowerEleHolder.GetElement(fInitialTrackHitsInputLabel, InitialTrackHits);
 
-    //Calculate the mean direction and the the standard deviation
-    float sumX = 0, sumX2 = 0;
-    float sumY = 0, sumY2 = 0;
-    float sumZ = 0, sumZ2 = 0;
+    //Calculate the mean direction
+    geo::Vector_t meanDir = {0., 0., 0.};
 
     //Get the spacepoints associated to the track hit
     std::vector<art::Ptr<recob::SpacePoint>> intitaltrack_sp;
+    int N = 0;
     for (auto const hit : InitialTrackHits) {
       std::vector<art::Ptr<recob::SpacePoint>> sps = fmsp.at(hit.key());
       for (auto const sp : sps) {
         intitaltrack_sp.push_back(sp);
 
         //Get the direction relative to the start positon
-        auto const pos = sp->position() - StartPosition;
+        auto const pos = (sp->position() - StartPosition).Unit();
         if (pos.R() == 0) { continue; }
-
-        sumX += pos.X();
-        sumX2 += pos.X() * pos.X();
-        sumY += pos.Y();
-        sumY2 += pos.Y() * pos.Y();
-        sumZ += pos.Z();
-        sumZ2 += pos.Z() * pos.Z();
-      }
-    }
-
-    float NumSps = intitaltrack_sp.size();
-    auto const Mean = geo::Vector_t{sumX / NumSps, sumY / NumSps, sumZ / NumSps}.Unit();
-
-    float RMSX = 999;
-    float RMSY = 999;
-    float RMSZ = 999;
-    if (sumX2 / NumSps - ((sumX / NumSps) * ((sumX / NumSps))) > 0) {
-      RMSX = std::sqrt(sumX2 / NumSps - ((sumX / NumSps) * ((sumX / NumSps))));
-    }
-    if (sumY2 / NumSps - ((sumY / NumSps) * ((sumY / NumSps))) > 0) {
-      RMSY = std::sqrt(sumY2 / NumSps - ((sumY / NumSps) * ((sumY / NumSps))));
-    }
-    if (sumZ2 / NumSps - ((sumZ / NumSps) * ((sumZ / NumSps))) > 0) {
-      RMSZ = std::sqrt(sumZ2 / NumSps - ((sumZ / NumSps) * ((sumZ / NumSps))));
-    }
-
-    //Loop over the spacepoints and remove ones the relative direction is not within one sigma.
-    geo::Vector_t Direction_Mean{0, 0, 0};
-    int N = 0;
-    for (auto const sp : intitaltrack_sp) {
-      auto const Direction = sp->position() - StartPosition;
-      if ((std::abs((Direction - Mean).X()) < 1 * RMSX) &&
-          (std::abs((Direction - Mean).Y()) < 1 * RMSY) &&
-          (std::abs((Direction - Mean).Z()) < 1 * RMSZ)) {
-        if (Direction.R() == 0) { continue; }
+        meanDir += pos;
         ++N;
-        Direction_Mean += Direction;
       }
     }
 
     if (N > 0) {
-      //Take the mean value
-      Direction_Mean = Direction_Mean.Unit();
-      ShowerEleHolder.SetElement(Direction_Mean, fShowerDirectionOutputLabel);
+      meanDir = meanDir.Unit();
+      //NOTE need to include a direction otherwise this will not override any previous shower direciton tha did include an error :(
+      geo::Vector_t meanDirErr = {-999, -999, -999}; //Not implementing an error
+      ShowerEleHolder.SetElement(meanDir, meanDirErr, fShowerDirectionOutputLabel);
     }
     else {
       if (fVerbose)
-        mf::LogError("ShowerTrackHitDirection")
-          << "None of the points are within 1 sigma" << std::endl;
+        mf::LogError("ShowerTrackHitDirection") << "No points found to calculate a direction" << std::endl;
       return 1;
     }
+
     return 0;
   }
 }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
@@ -115,9 +115,9 @@ namespace ShowerRecoTools {
         intitaltrack_sp.push_back(sp);
 
         //Get the direction relative to the start positon
-        auto const pos = (sp->position() - StartPosition).Unit();
-        if (pos.R() == 0) { continue; }
-        meanDir += pos;
+        auto const dir = (sp->position() - StartPosition).Unit();
+        if (dir.R() == 0) { continue; }
+        meanDir += dir;
         ++N;
       }
     }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackHitDirection_tool.cc
@@ -119,11 +119,11 @@ namespace ShowerRecoTools {
         auto const pos = sp->position() - StartPosition;
         if (pos.R() == 0) { continue; }
 
-        sumX = pos.X();
+        sumX += pos.X();
         sumX2 += pos.X() * pos.X();
-        sumY = pos.Y();
+        sumY += pos.Y();
         sumY2 += pos.Y() * pos.Y();
-        sumZ = pos.Z();
+        sumZ += pos.Z();
         sumZ2 += pos.Z() * pos.Z();
       }
     }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
@@ -94,67 +94,32 @@ namespace ShowerRecoTools {
     std::vector<art::Ptr<recob::SpacePoint>> intitaltrack_sp;
     ShowerEleHolder.GetElement(fInitialTrackSpacePointsInputLabel, intitaltrack_sp);
 
-    //Calculate the mean direction and the the standard deviation
-    float sumX = 0, sumX2 = 0;
-    float sumY = 0, sumY2 = 0;
-    float sumZ = 0, sumZ2 = 0;
+    //Calculate the mean direction
+    geo::Vector_t meanDir = {0., 0., 0.};
 
     //Get the spacepoints associated to the track hit
+    int N = 0;
     for (auto const& sp : intitaltrack_sp) {
 
       //Get the direction relative to the start positon
-      auto const pos = sp->position() - StartPosition;
+      auto const pos = (sp->position() - StartPosition).Unit();
       if (pos.R() == 0) { continue; }
-
-      sumX += pos.X();
-      sumX2 += pos.X() * pos.X();
-      sumY += pos.Y();
-      sumY2 += pos.Y() * pos.Y();
-      sumZ += pos.Z();
-      sumZ2 += pos.Z() * pos.Z();
-    }
-
-    float NumSps = intitaltrack_sp.size();
-    auto const Mean = geo::Vector_t{sumX / NumSps, sumY / NumSps, sumZ / NumSps}.Unit();
-
-    float RMSX = 999;
-    float RMSY = 999;
-    float RMSZ = 999;
-    if (sumX2 / NumSps - ((sumX / NumSps) * ((sumX / NumSps))) > 0) {
-      RMSX = std::sqrt(sumX2 / NumSps - ((sumX / NumSps) * ((sumX / NumSps))));
-    }
-    if (sumY2 / NumSps - ((sumY / NumSps) * ((sumY / NumSps))) > 0) {
-      RMSY = std::sqrt(sumY2 / NumSps - ((sumY / NumSps) * ((sumY / NumSps))));
-    }
-    if (sumZ2 / NumSps - ((sumZ / NumSps) * ((sumZ / NumSps))) > 0) {
-      RMSZ = std::sqrt(sumZ2 / NumSps - ((sumZ / NumSps) * ((sumZ / NumSps))));
-    }
-
-    //Loop over the spacepoints and remove ones the relative direction is not within one sigma.
-    geo::Vector_t Direction_Mean = {0, 0, 0};
-    int N = 0;
-    for (auto const sp : intitaltrack_sp) {
-      auto const Direction = sp->position() - StartPosition;
-      if ((std::abs((Direction - Mean).X()) < 1 * RMSX) &&
-          (std::abs((Direction - Mean).Y()) < 1 * RMSY) &&
-          (std::abs((Direction - Mean).Z()) < 1 * RMSZ)) {
-        if (Direction.R() == 0) { continue; }
-        ++N;
-        Direction_Mean += Direction;
-      }
+      meanDir += pos;
+      ++N;
     }
 
     if (N > 0) {
-      //Take the mean value
-      Direction_Mean = Direction_Mean.Unit();
-      ShowerEleHolder.SetElement(Direction_Mean, fShowerDirectionOutputLabel);
+      meanDir = meanDir.Unit();
+      //NOTE need to include a direction otherwise this will not override any previous shower direciton tha did include an error :(
+      geo::Vector_t meanDirErr = {-999, -999, -999}; //Not implementing an error
+      ShowerEleHolder.SetElement(meanDir, meanDirErr, fShowerDirectionOutputLabel);
     }
     else {
       if (fVerbose)
-        mf::LogError("ShowerTrackSpacePointDirection")
-          << "None of the points are within 1 sigma" << std::endl;
+        mf::LogError("ShowerTrackSpacePointDirection") << "No points found to calculate a direction" << std::endl;
       return 1;
     }
+
     return 0;
   }
 }

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
@@ -106,11 +106,11 @@ namespace ShowerRecoTools {
       auto const pos = sp->position() - StartPosition;
       if (pos.R() == 0) { continue; }
 
-      sumX = pos.X();
+      sumX += pos.X();
       sumX2 += pos.X() * pos.X();
-      sumY = pos.Y();
+      sumY += pos.Y();
       sumY2 += pos.Y() * pos.Y();
-      sumZ = pos.Z();
+      sumZ += pos.Z();
       sumZ2 += pos.Z() * pos.Z();
     }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
@@ -102,9 +102,9 @@ namespace ShowerRecoTools {
     for (auto const& sp : intitaltrack_sp) {
 
       //Get the direction relative to the start positon
-      auto const pos = (sp->position() - StartPosition).Unit();
-      if (pos.R() == 0) { continue; }
-      meanDir += pos;
+      auto const dir = (sp->position() - StartPosition).Unit();
+      if (dir.R() == 0) { continue; }
+      meanDir += dir;
       ++N;
     }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/ShowerTrackSpacePointDirection_tool.cc
@@ -116,7 +116,8 @@ namespace ShowerRecoTools {
     }
     else {
       if (fVerbose)
-        mf::LogError("ShowerTrackSpacePointDirection") << "No points found to calculate a direction" << std::endl;
+        mf::LogError("ShowerTrackSpacePointDirection")
+          << "No points found to calculate a direction" << std::endl;
       return 1;
     }
 

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -161,6 +161,9 @@ showertrackdirection:{
     UsePositionInfo:  true #Don't use the directionAt point rather than definition above.
     #i.e. ((Position of traj point + 1) - (Position of traj point)
     DebugEVD:         false
+    InitialTrackInputLabel: "InitialTrack"
+    ShowerStartPositionInputLabel: "ShowerStartPosition"
+    ShowerDirectionOutputLabel: "ShowerDirection"
 }
 
 showertracktrajpointdirection: {

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -20,6 +20,7 @@ showerpcadirection:{
     UseStartPosition: true #The direction of the PCA is in the direction of
     #(Shower Center - Start Position)
     ChargeWeighted:   false #Apply a charge weighting in the PCA.
+    WritePCAxis:      true #Write the PCA to the event as a PCAxis product
     ShowerStartPositionInputLabel: "ShowerStartPosition"
     ShowerDirectionOutputLabel: "ShowerDirection"
     ShowerCentreOutputLabel: "ShowerCentre"
@@ -366,6 +367,7 @@ showerrefinedpcadirection:{
     tool_type: ShowerRefinedPCADirection
     BaseTools: @local::showerbasetools
     # PFParticleLabel: "pandora"
+    WritePCAxis: true
     ChargeWeighted: true
     QuadraticLongitudinalWeight: false
     QuadraticTransverseWeight: true

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -369,11 +369,11 @@ showerrefinedpcadirection:{
     # PFParticleLabel: "pandora"
     WritePCAxis: true
     ChargeWeighted: true
-    QuadraticLongitudinalWeight: false
+    QuadraticLongitudinalWeight: true
     QuadraticTransverseWeight: true
     MinPCAPoints: 10
     MaxIterations: 50
-    ConvergenceAngle: 0.01
+    ConvergenceAngle: 0.005
     TransverseScale: 3.
     LongitudinalScale: 7.
     DistanceFloor: 1.

--- a/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
+++ b/larpandora/LArPandoraEventBuilding/LArPandoraShower/Tools/pandorashowertools.fcl
@@ -362,6 +362,26 @@ showerlengthpercentile:{
     ShowerOpeningAngleOutputLabel: "ShowerOpeningAngle"
 }
 
+showerrefinedpcadirection:{
+    tool_type: ShowerRefinedPCADirection
+    BaseTools: @local::showerbasetools
+    # PFParticleLabel: "pandora"
+    ChargeWeighted: true
+    QuadraticLongitudinalWeight: false
+    QuadraticTransverseWeight: true
+    MinPCAPoints: 10
+    MaxIterations: 50
+    ConvergenceAngle: 0.01
+    TransverseScale: 3.
+    LongitudinalScale: 7.
+    DistanceFloor: 1.
+    ShowerStartPositionInputLabel: "ShowerStartPosition"
+    ShowerDirectionInputLabel: "ShowerDirection"
+    ShowerDirectionOutputLabel: "ShowerDirection"
+    ShowerCentreOutputLabel: "ShowerCentre"
+    ShowerPCAOutputLabel: "ShowerPCA"
+}
+
 showerpcaeigenvaluelength:{
     tool_type: ShowerPCAEigenvalueLength
     BaseTools: @local::showerbasetools


### PR DESCRIPTION
## Fixes
- `ShowerTrackDirection`: exposed the shower element labels to the fcl config to remove hardcoding
- `ShowerTrackHitDirection`: the original dir reco logic was broken, it mixed unit vectors and unnormalised vectors and its calculation of the standard deviation to try to remove outliers was not working. I couldnt really understand the intent of this tool and its implementation meant it was guaranteed to fail and never produce a direction. I assume this means no one has ever used it. I changed the logic to do dir reco by summing the unit vectors in the initial track, I think this is inline with what the class name suggets it does and the original intent of the code.
- `ShowerTrackSpacePointDirection`: Same problem and fix as for `ShowerTrackHitDirection`, these two are almost the same tool.

## New Tool `ShowerRefinedPCADirection`
- A new PCA that uses weighted PCA to iteratively refine a seed PCA so that it focuses more on spacepoints near the vertex and central core of the shower.
- Performs much better than all other tools for leading electron (see image)
- Scanned a handful of configurables and put the best set as the fcl defaults

## WritePCAxis change
`ShowerRefinedPCADireciton` runs after `ShowerPCADirection` to get a seed PCA. If both tools try to write a `recob::PCAxis` there is an error. I added a `WritePCAxis` configurable to each tool that controls whether the tool will write its PCA and assns out to the art-root file. Everything works fine if only one of these tools has `WritePCAxis: true`, I assume you would want this tool to be the refined PCA. Previously, `ShowerPCADiretion` was the only tool that did produced a PCA so this was not an issue.

<img width="1176" height="801" alt="Screenshot from 2026-07-04 10-13-19" src="https://github.com/user-attachments/assets/5d702ccb-98e3-44d3-a32c-c6c929c78f6e" />
