### PR TITLE
feature/v10_04_00

### DIFF
--- a/larpandora/LArPandoraInterface/LArPandora.cxx
+++ b/larpandora/LArPandoraInterface/LArPandora.cxx
@@ -56,7 +56,7 @@ namespace lar_pandora {
     , m_generatorModuleLabel(pset.get<std::string>("GeneratorModuleLabel", ""))
     , m_geantModuleLabel(pset.get<std::string>("GeantModuleLabel", "largeant"))
     , m_simChannelModuleLabel(pset.get<std::string>("SimChannelModuleLabel", m_geantModuleLabel))
-    , m_eDepSimModuleLabel(pset.get<std::string>("EDepSimModuleLabel", ""))
+    , m_eDepSimModuleLabel(pset.get<std::string>("EDepSimModuleLabel", "IonAndScint"))
     , m_hitfinderModuleLabel(pset.get<std::string>("HitFinderModuleLabel"))
     , m_backtrackerModuleLabel(pset.get<std::string>("BackTrackerModuleLabel", ""))
     , m_allOutcomesInstanceLabel(pset.get<std::string>("AllOutcomesInstanceLabel", "allOutcomes"))


### PR DESCRIPTION
This PR for larpandora v10_04_00 sets IonAndScint as the default EDepSimModule label in Pandora. The EDepSims are used to calculate the visible energy member variable of the Pandora MCParticle. No product changes are expected.